### PR TITLE
feat(php): emit optional userAgent constructor param on WorkOS client

### DIFF
--- a/src/php/client.ts
+++ b/src/php/client.ts
@@ -140,11 +140,12 @@ function generateMainClient(
   lines.push('        int $timeout = 60,');
   lines.push('        int $maxRetries = 3,');
   lines.push('        ?\\GuzzleHttp\\HandlerStack $handler = null,');
+  lines.push('        ?string $userAgent = null,');
   lines.push('    ) {');
   lines.push("        $apiKey ??= getenv('WORKOS_API_KEY') ?: self::$apiKey ?? '';");
   lines.push("        $clientId ??= getenv('WORKOS_CLIENT_ID') ?: self::$clientId;");
   lines.push(
-    '        $this->httpClient = new HttpClient($apiKey, $clientId, $baseUrl, $timeout, $maxRetries, $handler);',
+    '        $this->httpClient = new HttpClient($apiKey, $clientId, $baseUrl, $timeout, $maxRetries, $handler, $userAgent);',
   );
   lines.push('    }');
 

--- a/test/php/client.test.ts
+++ b/test/php/client.test.ts
@@ -74,8 +74,9 @@ describe('generateClient', () => {
     expect(result[0].content).toContain("string $baseUrl = 'https://api.example.com'");
     expect(result[0].content).toContain('int $timeout = 60');
     expect(result[0].content).toContain('int $maxRetries = 3');
+    expect(result[0].content).toContain('?string $userAgent = null');
     expect(result[0].content).toContain(
-      'new HttpClient($apiKey, $clientId, $baseUrl, $timeout, $maxRetries, $handler)',
+      'new HttpClient($apiKey, $clientId, $baseUrl, $timeout, $maxRetries, $handler, $userAgent)',
     );
     expect(result[0].content).not.toContain('self::$apiKey = $apiKey;');
     expect(result[0].content).not.toContain('self::$clientId = $clientId;');


### PR DESCRIPTION
## Summary

Emit a new `?string $userAgent = null` parameter at the end of the generated `WorkOS::__construct` signature in `lib/WorkOS.php`, and forward it to the hand-maintained `HttpClient`. `HttpClient` already sets a default `User-Agent` header (`WorkOS PHP/<version>`) and now honors this per-client override.

## Why

This pairs with [workos/workos-php#352](https://github.com/workos/workos-php/pull/352), which hand-edited the same two lines in the emitted `lib/WorkOS.php`. Landing the change here means the next emitter run won't clobber it. `workos-php-laravel` needs this hook to restore the `WorkOS PHP Laravel/<version>` identifier it lost in the v5 upgrade (when the static `WorkOS::setIdentifier` helper was removed).

## Changes

- `src/php/client.ts` — emit `?string $userAgent = null,` as the final constructor param; pass `$userAgent` as the final positional arg to `new HttpClient(...)`.
- `test/php/client.test.ts` — assert the new param is present and the `HttpClient` forwarding includes `$userAgent`.

## Test plan

- [x] `npx vitest run test/php/` — all 58 tests pass (5 in `client.test.ts` updated).
- [ ] Regenerate `workos-php` and confirm `lib/WorkOS.php` matches the hand-edit from #352 (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)