### PR TITLE
fix: add implicit discriminator detection with unknown fallback variant

### DIFF
--- a/src/python/enums.ts
+++ b/src/python/enums.ts
@@ -37,6 +37,8 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
     // If this enum is an alias for a canonical enum, generate a type alias file
     const canonicalName = aliasOf.get(enumDef.name);
     if (canonicalName) {
+      // Skip when alias and canonical produce the same file name (self-import)
+      if (fileName(enumDef.name) === fileName(canonicalName)) continue;
       const canonicalService = enumToService.get(canonicalName);
       const canonicalDir = resolveDir(canonicalService);
       const canonicalCls = className(canonicalName);

--- a/src/python/index.ts
+++ b/src/python/index.ts
@@ -10,6 +10,7 @@ import type {
 } from '@workos/oagen';
 
 import { generateModels } from './models.js';
+import { detectDiscriminators } from '../shared/model-utils.js';
 import { generateEnums } from './enums.js';
 import { generateResources } from './resources.js';
 import { generateClient } from './client.js';
@@ -25,11 +26,23 @@ function ensureTrailingNewlines(files: GeneratedFile[]): GeneratedFile[] {
   return files;
 }
 
+/**
+ * Annotate models with implicit discriminator info (without full oneOf
+ * field flattening which can break existing model structures/fixtures).
+ */
+function withDiscriminators(ctx: EmitterContext): EmitterContext {
+  const annotated = detectDiscriminators(ctx.spec.models);
+  if (annotated === ctx.spec.models) return ctx;
+  const spec: ApiSpec = { ...ctx.spec, models: annotated };
+  return { ...ctx, spec };
+}
+
 export const pythonEmitter: Emitter = {
   language: 'python',
 
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
-    return ensureTrailingNewlines(generateModels(models, ctx));
+    const annotated = detectDiscriminators(models);
+    return ensureTrailingNewlines(generateModels(annotated, ctx));
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
@@ -37,11 +50,11 @@ export const pythonEmitter: Emitter = {
   },
 
   generateResources(services: Service[], ctx: EmitterContext): GeneratedFile[] {
-    return ensureTrailingNewlines(generateResources(services, ctx));
+    return ensureTrailingNewlines(generateResources(services, withDiscriminators(ctx)));
   },
 
   generateClient(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
-    return ensureTrailingNewlines(generateClient(spec, ctx));
+    return ensureTrailingNewlines(generateClient(spec, withDiscriminators(ctx)));
   },
 
   generateErrors(): GeneratedFile[] {
@@ -57,7 +70,15 @@ export const pythonEmitter: Emitter = {
   },
 
   generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
-    return ensureTrailingNewlines(generateTests(spec, ctx));
+    // Use original spec for model filtering (requestOnlyModelNames etc.) but
+    // annotate discriminator models so dispatch tests are generated.
+    const annotated = detectDiscriminators(spec.models);
+    // Only replace discriminator-annotated models, keep the rest unchanged
+    // so request-only filtering and field-based logic work correctly.
+    const annotatedByName = new Map(annotated.filter((m: any) => m.discriminator).map((m) => [m.name, m]));
+    const testModels = spec.models.map((m) => annotatedByName.get(m.name) ?? m);
+    const testSpec: ApiSpec = { ...spec, models: testModels };
+    return ensureTrailingNewlines(generateTests(testSpec, { ...ctx, spec: testSpec }));
   },
 
   generateManifest(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -48,6 +48,10 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     }
   }
 
+  // Track emitted file paths to prevent duplicates when synthetic models from
+  // oneOf enrichment collide with existing IR models in snake_case.
+  const emittedFilePaths = new Set<string>();
+
   for (const model of models) {
     // Skip list wrapper models (e.g., OrganizationList) — SyncPage handles envelopes
     if (isListWrapperModel(model)) continue;
@@ -57,6 +61,11 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     const service = modelToService.get(model.name);
     const dirName = resolveDir(service);
     const modelClassName = className(model.name);
+
+    // Skip models whose file path was already emitted (name collision after snake_case)
+    const modelFilePath = `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`;
+    if (emittedFilePaths.has(modelFilePath)) continue;
+    emittedFilePaths.add(modelFilePath);
 
     // If this model is a discriminated union dispatcher, generate a factory class
     // instead of a regular dataclass (e.g. EventSchema where each variant has
@@ -70,6 +79,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       const dispLines: string[] = [];
       dispLines.push('from __future__ import annotations');
       dispLines.push('');
+      dispLines.push('from dataclasses import dataclass');
       dispLines.push('from typing import Any, ClassVar, Dict, Union, cast');
       dispLines.push(`from ${ctx.namespace}._types import _raise_deserialize_error`);
       dispLines.push('');
@@ -88,14 +98,35 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
         }
       }
 
+      // Unknown variant for forward-compatible unknown discriminator values
+      const unknownClassName = `${modelClassName}Unknown`;
+      dispLines.push('');
+      dispLines.push('');
+      dispLines.push('@dataclass(slots=True)');
+      dispLines.push(`class ${unknownClassName}:`);
+      dispLines.push(`    """Unknown variant of ${modelClassName} not yet recognized by this SDK version."""`);
+      dispLines.push('');
+      dispLines.push('    raw_data: Dict[str, Any]');
+      dispLines.push('    """The raw payload, preserved so callers can still inspect the data."""');
+      dispLines.push('');
+      dispLines.push('    @classmethod');
+      dispLines.push(`    def from_dict(cls, data: Dict[str, Any]) -> "${unknownClassName}":`);
+      dispLines.push('        """Wrap raw data in an unknown variant."""');
+      dispLines.push('        return cls(raw_data=data)');
+      dispLines.push('');
+      dispLines.push('    def to_dict(self) -> Dict[str, Any]:');
+      dispLines.push('        """Return the original raw data."""');
+      dispLines.push('        return dict(self.raw_data)');
+
       dispLines.push('');
       dispLines.push('');
 
-      // Union type alias
+      // Union type alias — includes unknown variant for forward compatibility
       dispLines.push(`${variantTypeName} = Union[`);
       for (const variantModelName of sortedVariants) {
         dispLines.push(`    ${className(variantModelName)},`);
       }
+      dispLines.push(`    ${unknownClassName},`);
       dispLines.push(']');
 
       dispLines.push('');
@@ -110,7 +141,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
         dispLines.push(`    """Discriminated union dispatcher (discriminated by '${disc.property}')."""`);
       }
       dispLines.push('');
-      dispLines.push(`    _DISPATCH: ClassVar[Dict[str, Any]] = {`);
+      dispLines.push(`    _DISPATCH: ClassVar[Dict[str, type]] = {`);
       for (const [value, variantModelName] of Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b))) {
         dispLines.push(`        "${value}": ${className(variantModelName)},`);
       }
@@ -123,14 +154,15 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       dispLines.push(
         `            _raise_deserialize_error("${modelClassName}", ValueError("Missing required field '${disc.property}'"))`,
       );
-      dispLines.push(`        event_type = data["${disc.property}"]`);
-      dispLines.push('        if event_type is not None:');
-      dispLines.push('            dispatch_cls = cls._DISPATCH.get(str(event_type))');
-      dispLines.push('            if dispatch_cls is not None:');
-      dispLines.push(`                return cast("${variantTypeName}", dispatch_cls.from_dict(data))`);
+      dispLines.push(`        disc_value = data["${disc.property}"]`);
+      dispLines.push('        if disc_value is None:');
       dispLines.push(
-        `        _raise_deserialize_error("${modelClassName}", ValueError(f"Unknown ${disc.property}: {event_type!r}"))`,
+        `            _raise_deserialize_error("${modelClassName}", ValueError("${disc.property} must not be None"))`,
       );
+      dispLines.push('        dispatch_cls = cls._DISPATCH.get(disc_value)');
+      dispLines.push('        if dispatch_cls is not None:');
+      dispLines.push(`            return cast("${variantTypeName}", dispatch_cls.from_dict(data))`);
+      dispLines.push(`        return ${unknownClassName}.from_dict(data)`);
 
       files.push({
         path: `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`,
@@ -141,15 +173,24 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
       if (!emittedModelSymbolsByDir.has(dirName)) emittedModelSymbolsByDir.set(dirName, []);
       emittedModelSymbolsByDir.get(dirName)!.push(model.name);
-      // Also register the variant type alias in the barrel, pointing to the same file
+      // Also register the variant type alias and unknown variant in the barrel,
+      // pointing to the same file as the dispatcher.
       emittedModelSymbolsByDir.get(dirName)!.push(variantTypeName);
       symbolToFile.set(variantTypeName, fileName(model.name));
+      emittedModelSymbolsByDir.get(dirName)!.push(unknownClassName);
+      symbolToFile.set(unknownClassName, fileName(model.name));
       continue;
     }
 
     // If this model is an alias for a canonical model, generate a type alias file
     const canonicalName = aliasOf.get(model.name);
     if (canonicalName) {
+      // Skip when alias and canonical produce the same file name (self-import).
+      // This happens when synthetic models from oneOf enrichment collide with
+      // existing IR models in snake_case (e.g., Foo_bar vs FooBar).
+      if (fileName(model.name) === fileName(canonicalName)) {
+        continue;
+      }
       const canonicalService = modelToService.get(canonicalName);
       const canonicalDir = resolveDir(canonicalService);
       const canonicalClassName = className(canonicalName);
@@ -566,6 +607,9 @@ function compareAliasPriority(left: string, right: string, usage: ReturnType<typ
 }
 
 function canAliasModels(canonical: string, alias: string, usage: ReturnType<typeof collectModelUsage>): boolean {
+  // Don't alias when both models produce the same file name — the TypeAlias
+  // file would import from itself (e.g., FooBar aliased to Foo_bar).
+  if (fileName(canonical) === fileName(alias)) return false;
   // Don't alias across request/response boundaries — a request-only model
   // and a response-only model may look identical today but evolve independently.
   if (

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -665,7 +665,9 @@ function emitMethodBody(
       lines.push(`            ${awaitPrefix}self._client.request_page(`);
       lines.push(`                method="${httpMethod}",`);
       lines.push(`                path=${pathStr},`);
-      lines.push(`                model=${itemTypeClass},  # type: ignore[arg-type]`);
+      lines.push(
+        `                model=${itemTypeClass},  # type: ignore[arg-type]  # dispatcher; pagination only calls from_dict`,
+      );
       lines.push('                params=params,');
       lines.push('                request_options=request_options,');
       lines.push('            )');

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -139,6 +139,24 @@ function generateServiceTest(
     if (plan.responseModelName) modelImports.add(plan.responseModelName);
     if (op.pagination?.itemType.kind === 'model') {
       modelImports.add(op.pagination.itemType.name);
+      // Unwrap list wrapper to find the inner item model (may be a discriminated union)
+      let paginationItemName = op.pagination.itemType.name;
+      const wrapperModel = spec.models.find((m) => m.name === paginationItemName);
+      if (wrapperModel && isListWrapperModel(wrapperModel)) {
+        const dataField = wrapperModel.fields.find((f) => f.name === 'data');
+        if (dataField && dataField.type.kind === 'array' && dataField.type.items.kind === 'model') {
+          paginationItemName = dataField.type.items.name;
+        }
+      }
+      // For discriminated union pagination items, also import the first variant for isinstance checks
+      const paginationModel = spec.models.find((m) => m.name === paginationItemName);
+      if (paginationModel && (paginationModel as any).discriminator) {
+        const disc = (paginationModel as any).discriminator as { property: string; mapping: Record<string, string> };
+        const sortedEntries = Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b));
+        if (sortedEntries.length > 0) {
+          modelImports.add(sortedEntries[0][1]);
+        }
+      }
     }
     // Collect model-typed and enum-typed body fields (used as method arguments)
     if (plan.hasBody && op.requestBody?.kind === 'model') {
@@ -267,6 +285,8 @@ function generateServiceTest(
         }
       }
       // Skip fixture-based testing for models with no fields (discriminated unions)
+      // Save the unwrapped name before nulling — needed for discriminator check below
+      const unwrappedItemName = itemName;
       if (itemName) {
         const itemModel = spec.models.find((m) => m.name === itemName);
         if (itemModel && itemModel.fields.length === 0) itemName = null;
@@ -290,9 +310,29 @@ function generateServiceTest(
         lines.push('        assert isinstance(page, SyncPage)');
         lines.push('        assert page.data == []');
       } else {
-        lines.push('        httpx_mock.add_response(json={"data": [], "list_metadata": {}})');
-        lines.push(`        page = workos.${propName}.${method}(${paginatedArgs})`);
-        lines.push('        assert isinstance(page, SyncPage)');
+        // Check if the unwrapped item is a discriminated union — test dispatch through pagination
+        const discModel = unwrappedItemName ? spec.models.find((m) => m.name === unwrappedItemName) : null;
+        const disc =
+          discModel && (discModel as any).discriminator
+            ? ((discModel as any).discriminator as { property: string; mapping: Record<string, string> })
+            : null;
+        const discEntries = disc ? Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b)) : [];
+        if (disc && discEntries.length > 0) {
+          const [, firstVariantName] = discEntries[0];
+          const variantFixture = `${fileName(firstVariantName)}.json`;
+          const variantClass = className(firstVariantName);
+          lines.push('        httpx_mock.add_response(');
+          lines.push(`            json={"data": [load_fixture("${variantFixture}")], "list_metadata": {}},`);
+          lines.push('        )');
+          lines.push(`        page = workos.${propName}.${method}(${paginatedArgs})`);
+          lines.push('        assert isinstance(page, SyncPage)');
+          lines.push('        assert len(page.data) == 1');
+          lines.push(`        assert isinstance(page.data[0], ${variantClass})`);
+        } else {
+          lines.push('        httpx_mock.add_response(json={"data": [], "list_metadata": {}})');
+          lines.push(`        page = workos.${propName}.${method}(${paginatedArgs})`);
+          lines.push('        assert isinstance(page, SyncPage)');
+        }
       }
     } else if (isDelete) {
       lines.push(`    def test_${method}(self, workos, httpx_mock):`);
@@ -543,6 +583,8 @@ function generateServiceTest(
         }
       }
       // Skip fixture-based testing for models with no fields (discriminated unions)
+      // Save the unwrapped name before nulling — needed for discriminator check below
+      const unwrappedItemName = itemName;
       if (itemName) {
         const itemModel = spec.models.find((m) => m.name === itemName);
         if (itemModel && itemModel.fields.length === 0) itemName = null;
@@ -562,9 +604,29 @@ function generateServiceTest(
         lines.push('        assert isinstance(page, AsyncPage)');
         lines.push('        assert page.data == []');
       } else {
-        lines.push('        httpx_mock.add_response(json={"data": [], "list_metadata": {}})');
-        lines.push(`        page = await async_workos.${propName}.${method}(${asyncArgs})`);
-        lines.push('        assert isinstance(page, AsyncPage)');
+        // Check if the unwrapped item is a discriminated union — test dispatch through pagination
+        const discModel = unwrappedItemName ? spec.models.find((m) => m.name === unwrappedItemName) : null;
+        const disc =
+          discModel && (discModel as any).discriminator
+            ? ((discModel as any).discriminator as { property: string; mapping: Record<string, string> })
+            : null;
+        const discEntries = disc ? Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b)) : [];
+        if (disc && discEntries.length > 0) {
+          const [, firstVariantName] = discEntries[0];
+          const variantFixture = `${fileName(firstVariantName)}.json`;
+          const variantClass = className(firstVariantName);
+          lines.push('        httpx_mock.add_response(');
+          lines.push(`            json={"data": [load_fixture("${variantFixture}")], "list_metadata": {}},`);
+          lines.push('        )');
+          lines.push(`        page = await async_workos.${propName}.${method}(${asyncArgs})`);
+          lines.push('        assert isinstance(page, AsyncPage)');
+          lines.push('        assert len(page.data) == 1');
+          lines.push(`        assert isinstance(page.data[0], ${variantClass})`);
+        } else {
+          lines.push('        httpx_mock.add_response(json={"data": [], "list_metadata": {}})');
+          lines.push(`        page = await async_workos.${propName}.${method}(${asyncArgs})`);
+          lines.push('        assert isinstance(page, AsyncPage)');
+        }
       }
     } else if (isDelete) {
       const deletePath = buildExpectedPath(op);
@@ -1311,6 +1373,14 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
     if (!importsByDir.has(dirName)) importsByDir.set(dirName, []);
     importsByDir.get(dirName)!.push(className(model.name));
   }
+  // Add discriminator Unknown variant classes to imports for dispatch tests
+  for (const model of models) {
+    if (!(model as any).discriminator) continue;
+    const service = modelToService.get(model.name);
+    const dirName = resolveDir(service);
+    if (!importsByDir.has(dirName)) importsByDir.set(dirName, []);
+    importsByDir.get(dirName)!.push(`${className(model.name)}Unknown`);
+  }
 
   for (const [dirName, names] of [...importsByDir].sort()) {
     lines.push(`from ${ctx.namespace}.${dirToModule(dirName)}.models import ${names.sort().join(', ')}`);
@@ -1398,6 +1468,55 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
       lines.push(`        data = ${toPythonLiteral(unknownEnumPayload)}`);
       lines.push(`        instance = ${modelClass}.from_dict(data)`);
       lines.push('        assert instance.to_dict() == data');
+    }
+  }
+
+  // Discriminator dispatch tests — targeted coverage for from_dict routing
+  const discriminatorModels = models.filter((m) => (m as any).discriminator);
+  if (discriminatorModels.length > 0) {
+    lines.push('');
+    lines.push('');
+    lines.push('class TestDiscriminatorDispatch:');
+
+    for (const model of discriminatorModels) {
+      const disc = (model as any).discriminator as { property: string; mapping: Record<string, string> };
+      const modelClass = className(model.name);
+      const unknownClass = `${modelClass}Unknown`;
+
+      // Pick the first variant (alphabetically by discriminator value) for tests
+      const sortedEntries = Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b));
+      if (sortedEntries.length === 0) continue;
+      const [, firstVariantName] = sortedEntries[0];
+      const firstVariantClass = className(firstVariantName);
+      const firstVariantFixture = `${fileName(firstVariantName)}.json`;
+
+      lines.push('');
+      lines.push(`    def test_${fileName(model.name)}_dispatches_known_variant(self):`);
+      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
+      lines.push(`        result = ${modelClass}.from_dict(data)`);
+      lines.push(`        assert isinstance(result, ${firstVariantClass})`);
+
+      lines.push('');
+      lines.push(`    def test_${fileName(model.name)}_returns_unknown_for_unrecognized_type(self):`);
+      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
+      lines.push(`        data = {**data, "${disc.property}": "future.unrecognized.type"}`);
+      lines.push(`        result = ${modelClass}.from_dict(data)`);
+      lines.push(`        assert isinstance(result, ${unknownClass})`);
+      lines.push('        assert result.raw_data == data');
+
+      lines.push('');
+      lines.push(`    def test_${fileName(model.name)}_raises_on_missing_discriminator(self):`);
+      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
+      lines.push(`        data = {k: v for k, v in data.items() if k != "${disc.property}"}`);
+      lines.push('        with pytest.raises(Exception):');
+      lines.push(`            ${modelClass}.from_dict(data)`);
+
+      lines.push('');
+      lines.push(`    def test_${fileName(model.name)}_raises_on_none_discriminator(self):`);
+      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
+      lines.push(`        data = {**data, "${disc.property}": None}`);
+      lines.push('        with pytest.raises(Exception):');
+      lines.push(`            ${modelClass}.from_dict(data)`);
     }
   }
 

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -1,4 +1,5 @@
 import type { Model, Field, TypeRef, Enum } from '@workos/oagen';
+import { toSnakeCase } from '@workos/oagen';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 // @ts-ignore -- js-yaml has no type declarations in this project
@@ -159,7 +160,7 @@ function rawSchemaToTypeRef(
   if (schema.enum && collector && parentModelName && fName) {
     // Generate a synthetic enum
     const syntheticName = `${parentModelName}_${fName}`;
-    if (!collector.usedNames.has(syntheticName)) {
+    if (!collector.usedNames.has(syntheticName) && !collector.usedNames.has(toSnakeCase(syntheticName))) {
       collector.usedNames.add(syntheticName);
       collector.enums.push({
         name: syntheticName,
@@ -197,7 +198,7 @@ function rawSchemaToTypeRef(
   if (baseType === 'object' && schema.properties && collector && parentModelName && fName) {
     // Inline object -- generate a synthetic model
     const syntheticName = `${parentModelName}_${fName}`;
-    if (!collector.usedNames.has(syntheticName)) {
+    if (!collector.usedNames.has(syntheticName) && !collector.usedNames.has(toSnakeCase(syntheticName))) {
       collector.usedNames.add(syntheticName);
       const fields: Field[] = [];
       const requiredSet = new Set<string>(schema.required ?? []);
@@ -388,6 +389,102 @@ export function getSyntheticEnums(): Enum[] {
   return _lastSyntheticEnums;
 }
 
+// ---------------------------------------------------------------------------
+// Implicit discriminator detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a property name that has a `const` value in ALL oneOf variants.
+ * Returns null if no shared const property is found.
+ */
+function findSharedConstProperty(oneOfSchemas: Record<string, any>[]): string | null {
+  if (oneOfSchemas.length === 0) return null;
+
+  const first = oneOfSchemas[0];
+  if (!first.properties) return null;
+
+  // Candidate properties from the first variant that have const values
+  const candidates = Object.keys(first.properties).filter((name) => first.properties[name].const !== undefined);
+
+  // Return the first candidate that has const values in ALL variants
+  for (const candidate of candidates) {
+    const allHaveConst = oneOfSchemas.every((variant) => variant.properties?.[candidate]?.const !== undefined);
+    if (allHaveConst) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * Build a discriminator mapping from const values to IR model names.
+ * For each oneOf variant's const value on `discProperty`, find the IR model
+ * whose field with the same name is a Literal type with that value.
+ */
+function buildDiscriminatorMapping(
+  discProperty: string,
+  oneOfSchemas: Record<string, any>[],
+  models: Model[],
+  parentModelName: string,
+): Record<string, string> {
+  const mapping: Record<string, string> = {};
+
+  for (const variant of oneOfSchemas) {
+    const constValue = variant.properties?.[discProperty]?.const;
+    if (constValue === undefined) continue;
+
+    const variantModel = models.find(
+      (m) =>
+        m.name !== parentModelName &&
+        m.fields.some(
+          (f) => f.name === discProperty && f.type.kind === 'literal' && (f.type as any).value === constValue,
+        ),
+    );
+    if (variantModel) {
+      mapping[String(constValue)] = variantModel.name;
+    }
+  }
+
+  return mapping;
+}
+
+/**
+ * Detect implicit discriminators on models without full oneOf flattening.
+ * Returns a new array with discriminator annotations; models without
+ * discriminators are returned as-is. Use this when you need discriminator
+ * info but don't want the side-effects of full enrichment (synthetic
+ * models/enums, field flattening).
+ */
+export function detectDiscriminators(models: Model[]): Model[] {
+  const spec = loadRawSpec();
+  if (!spec) return models;
+
+  let changed = false;
+  const result = models.map((model) => {
+    if ((model as any).discriminator) return model;
+
+    const rawSchema = lookupRawSchema(model.name);
+    if (!rawSchema) return model;
+
+    const oneOfContainer = rawSchema.allOf?.find((s: any) => s.oneOf);
+    if (!oneOfContainer?.oneOf || oneOfContainer.oneOf.length === 0) return model;
+
+    const discProperty = findSharedConstProperty(oneOfContainer.oneOf);
+    if (!discProperty) return model;
+
+    const mapping = buildDiscriminatorMapping(discProperty, oneOfContainer.oneOf, models, model.name);
+    if (Object.keys(mapping).length === 0) return model;
+
+    changed = true;
+    return {
+      ...model,
+      fields: [],
+      discriminator: { property: discProperty, mapping },
+    };
+  });
+
+  return changed ? result : models;
+}
+
 /**
  * Enrich IR models by flattening oneOf/allOf+oneOf variant fields from the raw spec.
  *
@@ -411,8 +508,13 @@ export function enrichModelsFromSpec(models: Model[]): Model[] {
   }
 
   const collector = createCollector();
-  // Avoid name collisions with existing models
-  for (const m of models) collector.usedNames.add(m.name);
+  // Avoid name collisions with existing models (check both PascalCase and
+  // snake_case to prevent synthetic models from shadowing existing ones when
+  // they share a file name, e.g. FooBar vs Foo_bar -> foo_bar).
+  for (const m of models) {
+    collector.usedNames.add(m.name);
+    collector.usedNames.add(toSnakeCase(m.name));
+  }
 
   const enriched = models.map((model) => {
     const rawSchema = lookupRawSchema(model.name);
@@ -421,12 +523,31 @@ export function enrichModelsFromSpec(models: Model[]): Model[] {
     const hasOneOf = rawSchema.oneOf || rawSchema.allOf?.some((s: any) => s.oneOf);
     if (!hasOneOf) return model;
 
-    // Skip schemas with discriminator -- those are intentional unions
+    // Skip schemas with explicit discriminator -- those are intentional unions
     const hasDiscriminator =
       rawSchema.discriminator ||
       rawSchema.oneOf?.some((v: any) => v.discriminator) ||
       rawSchema.allOf?.some((s: any) => s.discriminator || s.oneOf?.some((v: any) => v.discriminator));
     if (hasDiscriminator) return model;
+
+    // Detect implicit discriminators: allOf+oneOf where all variants share a
+    // property with const values (e.g., EventSchema with event: const: "user.created").
+    // When found, attach a discriminator mapping and clear fields so the emitter
+    // generates a dispatcher class instead of a flat dataclass.
+    const oneOfContainer = rawSchema.allOf?.find((s: any) => s.oneOf);
+    if (oneOfContainer?.oneOf && oneOfContainer.oneOf.length > 0) {
+      const discProperty = findSharedConstProperty(oneOfContainer.oneOf);
+      if (discProperty) {
+        const mapping = buildDiscriminatorMapping(discProperty, oneOfContainer.oneOf, models, model.name);
+        if (Object.keys(mapping).length > 0) {
+          return {
+            ...model,
+            fields: [],
+            discriminator: { property: discProperty, mapping },
+          };
+        }
+      }
+    }
 
     // Collect all variant fields from the raw schema, generating synthetic
     // models/enums for inline definitions along the way.
@@ -467,6 +588,9 @@ export function enrichModelsFromSpec(models: Model[]): Model[] {
     values: e.values.map((v) => ({ value: v.value, description: v.description })),
   })) as Enum[];
 
-  // Append synthetic models to the output
-  return [...enriched2, ...collector.models];
+  // Append synthetic models, skipping those whose snake_case name collides
+  // with an existing model (prevents broken TypeAlias self-imports).
+  const existingSnakeNames = new Set(enriched2.map((m) => toSnakeCase(m.name)));
+  const filteredSynthetic = collector.models.filter((m) => !existingSnakeNames.has(toSnakeCase(m.name)));
+  return [...enriched2, ...filteredSynthetic];
 }

--- a/test/python/models.test.ts
+++ b/test/python/models.test.ts
@@ -610,6 +610,105 @@ describe('generateModels', () => {
     expect(modelFile.content).toContain('""".. deprecated:: This field is deprecated."""');
   });
 
+  it('generates discriminator dispatcher with unknown fallback variant', () => {
+    const service: Service = {
+      name: 'Events',
+      operations: [
+        {
+          name: 'listEvents',
+          httpMethod: 'get',
+          path: '/events',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'EventSchema' },
+          errors: [],
+          injectIdempotencyKey: false,
+          pagination: {
+            strategy: 'cursor',
+            param: 'after',
+            dataPath: 'data',
+            itemType: { kind: 'model', name: 'EventSchema' },
+          },
+        },
+      ],
+    };
+
+    const discriminatorModel: any = {
+      name: 'EventSchema',
+      fields: [],
+      discriminator: {
+        property: 'event',
+        mapping: {
+          'user.created': 'UserCreated',
+          'dsync.user.created': 'DsyncUserCreated',
+        },
+      },
+    };
+
+    const models: Model[] = [
+      discriminatorModel,
+      {
+        name: 'UserCreated',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'event', type: { kind: 'literal', value: 'user.created' }, required: true },
+          { name: 'data', type: { kind: 'primitive', type: 'unknown' }, required: true },
+        ],
+      },
+      {
+        name: 'DsyncUserCreated',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'event', type: { kind: 'literal', value: 'dsync.user.created' }, required: true },
+          { name: 'data', type: { kind: 'primitive', type: 'unknown' }, required: true },
+        ],
+      },
+    ];
+
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], models },
+    };
+
+    const files = generateModels(models, ctxWithServices);
+    const dispatcherFile = files.find((f) => f.path.includes('event_schema.py'))!;
+    expect(dispatcherFile).toBeDefined();
+
+    // Has Unknown variant dataclass
+    expect(dispatcherFile.content).toContain('@dataclass(slots=True)');
+    expect(dispatcherFile.content).toContain('class EventSchemaUnknown:');
+    expect(dispatcherFile.content).toContain('raw_data: Dict[str, Any]');
+    expect(dispatcherFile.content).toContain('def from_dict(cls, data: Dict[str, Any]) -> "EventSchemaUnknown"');
+    expect(dispatcherFile.content).toContain('def to_dict(self) -> Dict[str, Any]:');
+
+    // Union includes Unknown variant
+    expect(dispatcherFile.content).toContain('EventSchemaVariant = Union[');
+    expect(dispatcherFile.content).toContain('    EventSchemaUnknown,');
+
+    // Dispatcher class
+    expect(dispatcherFile.content).toContain('class EventSchema:');
+    expect(dispatcherFile.content).toContain('_DISPATCH: ClassVar[Dict[str, type]]');
+
+    // from_dict falls back to Unknown instead of raising
+    expect(dispatcherFile.content).toContain('return EventSchemaUnknown.from_dict(data)');
+    expect(dispatcherFile.content).not.toContain('Unknown event');
+
+    // No str() coercion on discriminator value
+    expect(dispatcherFile.content).toContain('cls._DISPATCH.get(disc_value)');
+    expect(dispatcherFile.content).not.toContain('str(');
+
+    // Still raises on missing key and None value
+    expect(dispatcherFile.content).toContain("Missing required field 'event'");
+    expect(dispatcherFile.content).toContain('event must not be None');
+
+    // Barrel exports include Unknown variant
+    const barrel = files.find((f) => f.path.endsWith('__init__.py') && f.path.includes('models/'));
+    expect(barrel).toBeDefined();
+    expect(barrel!.content).toContain('EventSchemaUnknown');
+    expect(barrel!.content).toContain('EventSchemaVariant');
+  });
+
   it('deduplicates models with recursively identical sub-model references', () => {
     const service: Service = {
       name: 'Events',

--- a/test/python/tests.test.ts
+++ b/test/python/tests.test.ts
@@ -109,6 +109,93 @@ describe('generateTests', () => {
     expect(data).toHaveProperty('name');
   });
 
+  it('generates discriminator dispatch tests for dispatcher models', () => {
+    const discriminatorModel: any = {
+      name: 'EventSchema',
+      fields: [],
+      discriminator: {
+        property: 'event',
+        mapping: {
+          'user.created': 'UserCreated',
+          'dsync.user.created': 'DsyncUserCreated',
+        },
+      },
+    };
+
+    const discModels: Model[] = [
+      discriminatorModel,
+      {
+        name: 'UserCreated',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'event', type: { kind: 'literal', value: 'user.created' }, required: true },
+          { name: 'data', type: { kind: 'primitive', type: 'unknown' }, required: true },
+        ],
+      },
+      {
+        name: 'DsyncUserCreated',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'event', type: { kind: 'literal', value: 'dsync.user.created' }, required: true },
+          { name: 'data', type: { kind: 'primitive', type: 'unknown' }, required: true },
+        ],
+      },
+    ];
+
+    const discServices: Service[] = [
+      {
+        name: 'Events',
+        operations: [
+          {
+            name: 'listEvents',
+            httpMethod: 'get',
+            path: '/events',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'EventSchema' },
+            errors: [],
+            injectIdempotencyKey: false,
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'EventSchema' },
+            },
+          },
+        ],
+      },
+    ];
+
+    const discSpec: ApiSpec = {
+      ...spec,
+      models: discModels,
+      services: discServices,
+      enums: [],
+    };
+
+    const files = generateTests(discSpec, { ...ctx, spec: discSpec });
+    const roundTripTest = files.find((f) => f.path === 'tests/test_models_round_trip.py');
+    expect(roundTripTest).toBeDefined();
+
+    const content = roundTripTest!.content;
+    expect(content).toContain('class TestDiscriminatorDispatch:');
+    expect(content).toContain('def test_event_schema_dispatches_known_variant(self)');
+    expect(content).toContain('def test_event_schema_returns_unknown_for_unrecognized_type(self)');
+    expect(content).toContain('isinstance(result, EventSchemaUnknown)');
+    expect(content).toContain('def test_event_schema_raises_on_missing_discriminator(self)');
+    expect(content).toContain('def test_event_schema_raises_on_none_discriminator(self)');
+    expect(content).toContain('pytest.raises(Exception)');
+
+    // Service test should exercise discriminated union dispatch through pagination
+    const serviceTest = files.find((f) => f.path === 'tests/test_events.py');
+    expect(serviceTest).toBeDefined();
+    const svcContent = serviceTest!.content;
+    expect(svcContent).toContain('load_fixture("dsync_user_created.json")');
+    expect(svcContent).toContain('isinstance(page.data[0], DsyncUserCreated)');
+    expect(svcContent).toContain('assert len(page.data) == 1');
+  });
+
   it('generates model edge-case and query/pagination regression tests', () => {
     const edgeModels: Model[] = [
       {


### PR DESCRIPTION
## Summary
- Detect implicit discriminators from `allOf`+`oneOf` schemas where all variants share a `const` property, enabling dispatcher class generation without requiring an explicit OpenAPI `discriminator` keyword
- Dispatcher `from_dict` now falls back to an `Unknown` dataclass (preserving `raw_data`) instead of raising, so new server-side discriminator values don't crash older SDK versions
- Prevent snake_case file-name collisions between synthetic oneOf models and existing IR models (e.g. `FooBar` vs `Foo_bar`) which caused self-importing TypeAlias files
- Generate discriminator dispatch tests: known variant routing, unknown fallback, missing/None discriminator errors, and pagination through discriminated unions

## Test plan
- [ ] `npm test` passes in oagen-emitters (unit tests for model generation and test generation)
- [ ] Regenerate workos-python against real spec and verify `script/ci` passes
- [ ] Verify generated dispatcher classes contain `Unknown` variant and correct `from_dict` fallback
- [ ] Verify generated `test_models_round_trip.py` includes `TestDiscriminatorDispatch` class