### PR TITLE
fix: use per-operation mountOn in manifest service field

### DIFF
--- a/src/dotnet/manifest.ts
+++ b/src/dotnet/manifest.ts
@@ -1,7 +1,7 @@
 import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
 import { resolveMethodName } from './naming.js';
 import { buildServiceAccessPaths } from './client.js';
-import { getMountTarget } from '../shared/resolved-ops.js';
+import { buildResolvedLookup, lookupResolved, getMountTarget } from '../shared/resolved-ops.js';
 
 /**
  * Build operation-to-SDK-method mapping for the manifest.
@@ -9,19 +9,25 @@ import { getMountTarget } from '../shared/resolved-ops.js';
 export function buildOperationsMap(spec: ApiSpec, ctx: EmitterContext): OperationsMap {
   const manifest: OperationsMap = {};
   const accessPaths = buildServiceAccessPaths(spec.services, ctx);
+  const resolvedLookup = buildResolvedLookup(ctx);
 
   for (const service of spec.services) {
-    let propName = accessPaths.get(service.name);
-    if (!propName) {
+    let serviceProp = accessPaths.get(service.name);
+    if (!serviceProp) {
       const mountTarget = getMountTarget(service, ctx);
-      propName = accessPaths.get(mountTarget);
+      serviceProp = accessPaths.get(mountTarget);
     }
-    if (!propName) {
+    if (!serviceProp) {
       throw new Error(`Missing public client access path for service ${service.name}`);
     }
     for (const op of service.operations) {
       const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
       const method = resolveMethodName(op, service, ctx);
+
+      // Use per-operation mountOn when it differs from the service default
+      const resolved = lookupResolved(op, resolvedLookup);
+      const propName = (resolved && accessPaths.get(resolved.mountOn)) ?? serviceProp;
+
       manifest[httpKey] = { sdkMethod: method, service: propName };
     }
   }

--- a/src/go/manifest.ts
+++ b/src/go/manifest.ts
@@ -1,7 +1,7 @@
 import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
 import { resolveMethodName } from './naming.js';
 import { buildServiceAccessPaths } from './client.js';
-import { getMountTarget } from '../shared/resolved-ops.js';
+import { buildResolvedLookup, lookupResolved, getMountTarget } from '../shared/resolved-ops.js';
 
 /**
  * Build operation-to-SDK-method mapping for the manifest.
@@ -9,19 +9,25 @@ import { getMountTarget } from '../shared/resolved-ops.js';
 export function buildOperationsMap(spec: ApiSpec, ctx: EmitterContext): OperationsMap {
   const manifest: OperationsMap = {};
   const accessPaths = buildServiceAccessPaths(spec.services, ctx);
+  const resolvedLookup = buildResolvedLookup(ctx);
 
   for (const service of spec.services) {
-    let propName = accessPaths.get(service.name);
-    if (!propName) {
+    let serviceProp = accessPaths.get(service.name);
+    if (!serviceProp) {
       const mountTarget = getMountTarget(service, ctx);
-      propName = accessPaths.get(mountTarget);
+      serviceProp = accessPaths.get(mountTarget);
     }
-    if (!propName) {
+    if (!serviceProp) {
       throw new Error(`Missing public client access path for service ${service.name}`);
     }
     for (const op of service.operations) {
       const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
       const method = resolveMethodName(op, service, ctx);
+
+      // Use per-operation mountOn when it differs from the service default
+      const resolved = lookupResolved(op, resolvedLookup);
+      const propName = (resolved && accessPaths.get(resolved.mountOn)) ?? serviceProp;
+
       manifest[httpKey] = { sdkMethod: method, service: propName };
     }
   }

--- a/src/node/manifest.ts
+++ b/src/node/manifest.ts
@@ -1,15 +1,22 @@
 import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
 import { resolveMethodName, servicePropertyName } from './naming.js';
 import { resolveResourceClassName } from './resources.js';
+import { buildResolvedLookup, lookupResolved } from '../shared/resolved-ops.js';
 
 export function buildOperationsMap(spec: ApiSpec, ctx: EmitterContext): OperationsMap {
   const manifest: OperationsMap = {};
+  const resolvedLookup = buildResolvedLookup(ctx);
 
   for (const service of spec.services) {
-    const propName = servicePropertyName(resolveResourceClassName(service, ctx));
+    const serviceProp = servicePropertyName(resolveResourceClassName(service, ctx));
     for (const op of service.operations) {
       const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
       const method = resolveMethodName(op, service, ctx);
+
+      // Use per-operation mountOn when it differs from the service default
+      const resolved = lookupResolved(op, resolvedLookup);
+      const propName = resolved ? servicePropertyName(resolved.mountOn) : serviceProp;
+
       manifest[httpKey] = { sdkMethod: method, service: propName };
     }
   }

--- a/src/php/manifest.ts
+++ b/src/php/manifest.ts
@@ -1,7 +1,7 @@
 import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
 import { resolveMethodName } from './naming.js';
 import { buildServiceAccessPaths } from './client.js';
-import { getMountTarget } from '../shared/resolved-ops.js';
+import { buildResolvedLookup, lookupResolved, getMountTarget } from '../shared/resolved-ops.js';
 
 /**
  * Build operation-to-SDK-method mapping for the manifest.
@@ -9,19 +9,25 @@ import { getMountTarget } from '../shared/resolved-ops.js';
 export function buildOperationsMap(spec: ApiSpec, ctx: EmitterContext): OperationsMap {
   const manifest: OperationsMap = {};
   const accessPaths = buildServiceAccessPaths(spec.services, ctx);
+  const resolvedLookup = buildResolvedLookup(ctx);
 
   for (const service of spec.services) {
-    let propName = accessPaths.get(service.name);
-    if (!propName) {
+    let serviceProp = accessPaths.get(service.name);
+    if (!serviceProp) {
       const mountTarget = getMountTarget(service, ctx);
-      propName = accessPaths.get(mountTarget);
+      serviceProp = accessPaths.get(mountTarget);
     }
-    if (!propName) {
+    if (!serviceProp) {
       throw new Error(`Missing public client access path for service ${service.name}`);
     }
     for (const op of service.operations) {
       const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
       const method = resolveMethodName(op, service, ctx);
+
+      // Use per-operation mountOn when it differs from the service default
+      const resolved = lookupResolved(op, resolvedLookup);
+      const propName = (resolved && accessPaths.get(resolved.mountOn)) ?? serviceProp;
+
       manifest[httpKey] = { sdkMethod: method, service: propName };
     }
   }

--- a/src/python/manifest.ts
+++ b/src/python/manifest.ts
@@ -1,7 +1,7 @@
 import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
 import { resolveMethodName } from './naming.js';
 import { buildServiceAccessPaths } from './client.js';
-import { getMountTarget } from '../shared/resolved-ops.js';
+import { buildResolvedLookup, lookupResolved, getMountTarget } from '../shared/resolved-ops.js';
 
 /**
  * Build operation-to-SDK-method mapping for the manifest.
@@ -9,20 +9,26 @@ import { getMountTarget } from '../shared/resolved-ops.js';
 export function buildOperationsMap(spec: ApiSpec, ctx: EmitterContext): OperationsMap {
   const manifest: OperationsMap = {};
   const accessPaths = buildServiceAccessPaths(spec.services, ctx);
+  const resolvedLookup = buildResolvedLookup(ctx);
 
   for (const service of spec.services) {
     // For mounted services, look up the mount target's access path
-    let propName = accessPaths.get(service.name);
-    if (!propName) {
+    let serviceProp = accessPaths.get(service.name);
+    if (!serviceProp) {
       const mountTarget = getMountTarget(service, ctx);
-      propName = accessPaths.get(mountTarget);
+      serviceProp = accessPaths.get(mountTarget);
     }
-    if (!propName) {
+    if (!serviceProp) {
       throw new Error(`Missing public client access path for service ${service.name}`);
     }
     for (const op of service.operations) {
       const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
       const method = resolveMethodName(op, service, ctx);
+
+      // Use per-operation mountOn when it differs from the service default
+      const resolved = lookupResolved(op, resolvedLookup);
+      const propName = (resolved && accessPaths.get(resolved.mountOn)) ?? serviceProp;
+
       manifest[httpKey] = { sdkMethod: method, service: propName };
     }
   }


### PR DESCRIPTION
## Summary

- Operations with per-operation `mountOn` overrides (e.g., `mountOn: 'AuditLogs'` on the retention endpoints) had their manifest `service` field set to the original IR service (`organizations`) instead of the mount target (`auditLogs`)
- This caused `compat-extract` to classify the remounted methods as hand-written and filter them out, producing false "removed" entries in the SDK compatibility report
- Ruby and Kotlin already handled this correctly — applied the same `resolvedLookup` pattern to PHP, Go, dotnet, Python, and Node emitters

## Test plan

- [x] All 386 existing tests pass
- [x] Type-check passes
- [ ] Regenerate PHP SDK and verify `getOrganizationAuditLogsRetention` appears in the manifest under `auditLogs` (not `organizations`)
- [ ] Run `compat-extract` on PHP SDK and verify the retention methods appear in the snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)