### PR TITLE
fix: PHP grouped body params and Go discriminated union base fields

### DIFF
--- a/src/go/index.ts
+++ b/src/go/index.ts
@@ -33,7 +33,21 @@ export const goEmitter: Emitter = {
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
     // Enrich models by flattening oneOf/allOf+oneOf variant fields from the raw spec
     const enriched = enrichModelsFromSpec(models);
-    return ensureTrailingNewlines(generateModels(enriched, ctx));
+    // Go has no sum types, so discriminated union base models (e.g. EventSchema)
+    // need their base fields preserved. enrichModelsFromSpec clears fields for
+    // discriminated models so dispatcher-capable languages can generate sealed
+    // classes; restore the original fields here since Go just emits flat structs.
+    const originalByName = new Map(models.map((m) => [m.name, m]));
+    const goModels = enriched.map((m) => {
+      if ((m as any).discriminator && m.fields.length === 0) {
+        const original = originalByName.get(m.name);
+        if (original && original.fields.length > 0) {
+          return { ...m, fields: original.fields };
+        }
+      }
+      return m;
+    });
+    return ensureTrailingNewlines(generateModels(goModels, ctx));
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -261,12 +261,14 @@ function generateMethod(
   }
 
   // @param for body fields
+  const groupedParamNames = collectGroupedParamNames(op);
   if (plan.hasBody && op.requestBody?.kind === 'model') {
     const bodyModel = modelMap.get(op.requestBody.name);
     if (bodyModel) {
       const bodyParamMap = buildBodyParamMap(op, bodyModel);
       for (const field of bodyModel.fields) {
         if (hiddenParams.has(field.name)) continue;
+        if (groupedParamNames.has(field.name)) continue;
         const docType = mapTypeRefForPHPDoc(field.type);
         const phpName = bodyParamMap.get(field.name) ?? fieldName(field.name);
         if (seenDocParams.has(phpName)) continue;
@@ -280,7 +282,6 @@ function generateMethod(
   }
 
   // @param for parameter groups (union-typed)
-  const groupedParamNames = collectGroupedParamNames(op);
   for (const group of op.parameterGroups ?? []) {
     const phpName = fieldName(group.name);
     if (seenDocParams.has(phpName)) continue;
@@ -438,7 +439,9 @@ function generateMethod(
     if (plan.hasBody) {
       const bodyModel = op.requestBody?.kind === 'model' ? modelMap.get(op.requestBody.name) : null;
       const bodyParamMap = buildBodyParamMap(op, bodyModel ?? null);
-      const visibleFields = bodyModel?.fields.filter((f) => !hiddenParams.has(f.name)) ?? [];
+      const deleteGroupedParams = collectGroupedParamNames(op);
+      const visibleFields =
+        bodyModel?.fields.filter((f) => !hiddenParams.has(f.name) && !deleteGroupedParams.has(f.name)) ?? [];
       const hasOptionalFields = visibleFields.some((f) => !f.required);
       if (hasOptionalFields) {
         lines.push('        $body = array_filter([');
@@ -493,7 +496,9 @@ function generateMethod(
   } else if (plan.hasBody) {
     const bodyModel = op.requestBody?.kind === 'model' ? modelMap.get(op.requestBody.name) : null;
     const bodyParamMap = buildBodyParamMap(op, bodyModel ?? null);
-    const visibleFields = bodyModel?.fields.filter((f) => !hiddenParams.has(f.name)) ?? [];
+    const bodyGroupedParams = collectGroupedParamNames(op);
+    const visibleFields =
+      bodyModel?.fields.filter((f) => !hiddenParams.has(f.name) && !bodyGroupedParams.has(f.name)) ?? [];
     const hasOptionalFields = visibleFields.some((f) => !f.required);
     if (hasOptionalFields) {
       lines.push('        $body = array_filter([');
@@ -617,7 +622,6 @@ function buildMethodParams(
   const usedNames = new Set<string>();
   const hidden = hiddenParams ?? new Set();
   const groupedParams = collectGroupedParamNames(op);
-
   // Path params (always required)
   for (const p of op.pathParams) {
     const phpType = mapTypeRef(p.type, { qualified: true });
@@ -633,6 +637,7 @@ function buildMethodParams(
     if (bodyModel) {
       for (const field of bodyModel.fields) {
         if (hidden.has(field.name)) continue;
+        if (groupedParams.has(field.name)) continue;
         const phpType = mapTypeRef(field.type, { qualified: true });
         let phpName = fieldName(field.name);
         if (usedNames.has(phpName)) {


### PR DESCRIPTION
## Summary
- **fix(php):** Body fields belonging to mutually-exclusive parameter groups (e.g. `password`/`password_hash`/`password_hash_type`) were emitted as individual `?string` params instead of the union-typed group param (`null|PasswordPlaintext|PasswordHashed`). The `instanceof` dispatch in the method body became dead code, which PHPStan flagged. Skips grouped body fields from the method signature, PHPDoc, body array, and delete body array — matching the existing filter on query params.
- **fix(go):** `enrichModelsFromSpec` clears fields on discriminated union base models (e.g. `EventSchema`) for languages with sum types. Go has no sum types and just emits flat structs, so the cleared fields produced an empty struct. Restores original base fields in the Go emitter before passing to `generateModels`.

## Test plan
- [x] PHP: `script/ci` passes (php-cs-fixer, PHPStan, PHPUnit — 255 tests)
- [x] Go: `script/ci` passes (go fmt, go build, go vet, go test)
- [x] Ruby, Kotlin, Python all unaffected and pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)