### PR TITLE
fix(ruby): eagerly load configuration.rb to fix WorkOS.configure

### DIFF
--- a/src/ruby/client.ts
+++ b/src/ruby/client.ts
@@ -162,9 +162,11 @@ function generateMainEntryFile(spec: ApiSpec, ctx: EmitterContext): GeneratedFil
   }
   lines.push(`loader.ignore("#{__dir__}/workos/errors.rb")`);
   lines.push(`loader.ignore("#{__dir__}/workos/inflections.rb")`);
+  lines.push(`loader.ignore("#{__dir__}/workos/configuration.rb")`);
   lines.push('loader.setup');
   lines.push('');
   lines.push(`require 'workos/errors'`);
+  lines.push(`require 'workos/configuration'`);
 
   return {
     path: 'lib/workos.rb',


### PR DESCRIPTION
## Summary
- Adds `configuration.rb` to the list of hand-maintained files that are ignored by Zeitwerk and explicitly required in the generated `lib/workos.rb`
- Follows the same pattern already used for `errors.rb` and `inflections.rb`
- Zeitwerk only triggers autoloading on constant access, not method calls — so `WorkOS.configure` (defined in `configuration.rb`) was unavailable until something happened to reference `WorkOS::Configuration` first

Fixes workos/workos-ruby#462

## Test plan
- [ ] Regenerate the Ruby SDK and verify `lib/workos.rb` includes `loader.ignore` and `require` lines for `configuration.rb`
- [ ] Confirm `WorkOS.configure` works immediately after `require 'workos'` without needing `require 'workos/configuration'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)