### PR TITLE
fix(dotnet,kotlin): restore fields on discriminated base models

### DIFF
--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -11,7 +11,7 @@ import type {
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { generateModels, primeModelAliases } from './models.js';
+import { generateModels, primeModelAliases, type DiscriminatorContext } from './models.js';
 import { enrichModelsFromSpec, getSyntheticEnums } from '../shared/model-utils.js';
 import { generateEnums, primeEnumAliases } from './enums.js';
 import { generateResources } from './resources.js';
@@ -21,6 +21,7 @@ import { buildOperationsMap } from './manifest.js';
 import { generateWrapperOptionsClasses } from './wrappers.js';
 import { groupByMount } from '../shared/resolved-ops.js';
 import { discriminatedUnions } from './type-map.js';
+import { modelClassName } from './naming.js';
 
 /**
  * Fix the namespace for C#. The CLI passes `--namespace workos` which gives
@@ -77,9 +78,36 @@ export const dotnetEmitter: Emitter = {
     if (synEnumsForModels.length > 0) {
       primeEnumAliases([...c.spec.enums, ...synEnumsForModels]);
     }
-    const files = generateModels(enriched, c);
+
+    // Restore fields on discriminated base models. enrichModelsFromSpec clears
+    // fields for dispatcher-capable languages; C# uses inheritance instead:
+    // the base class keeps its common fields and variant classes extend it.
+    const originalByName = new Map(models.map((m) => [m.name, m]));
+    const discriminatorBases = new Set<string>();
+    const variantToBase = new Map<string, string>();
+    const modelDiscriminators = new Map<string, { property: string; mapping: Record<string, string> }>();
+
+    const dotnetModels = enriched.map((m) => {
+      const disc = (m as any).discriminator;
+      if (disc && m.fields.length === 0) {
+        const original = originalByName.get(m.name);
+        if (original && original.fields.length > 0) {
+          discriminatorBases.add(m.name);
+          modelDiscriminators.set(m.name, disc);
+          for (const variantName of Object.values(disc.mapping) as string[]) {
+            variantToBase.set(variantName, m.name);
+          }
+          return { ...m, fields: original.fields };
+        }
+      }
+      return m;
+    });
+
+    const discCtx: DiscriminatorContext = { discriminatorBases, variantToBase };
+    const files = generateModels(dotnetModels, c, discCtx);
 
     // Generate discriminator converters for oneOf unions with discriminator
+    // (union-type references, e.g. a field typed as oneOf with discriminator)
     if (discriminatedUnions.size > 0) {
       for (const [baseName, disc] of discriminatedUnions) {
         const converterName = `${baseName}DiscriminatorConverter`;
@@ -87,8 +115,6 @@ export const dotnetEmitter: Emitter = {
         lines.push(`namespace ${c.namespacePascal}`);
         lines.push('{');
         lines.push('    using System;');
-        lines.push('    using System.Text.Json;');
-        lines.push('    using System.Text.Json.Serialization;');
         lines.push('    using Newtonsoft.Json;');
         lines.push('    using Newtonsoft.Json.Linq;');
         lines.push('');
@@ -109,7 +135,7 @@ export const dotnetEmitter: Emitter = {
         lines.push('            switch (discriminatorValue)');
         lines.push('            {');
         for (const [value, modelName] of Object.entries(disc.mapping)) {
-          const csName = modelName.replace(/([a-z])([A-Z])/g, '$1$2');
+          const csName = modelClassName(modelName);
           lines.push(`                case "${value}": return jObject.ToObject<${csName}>(serializer);`);
         }
         lines.push('                default: return jObject.ToObject<object>(serializer);');
@@ -131,6 +157,67 @@ export const dotnetEmitter: Emitter = {
           overwriteExisting: true,
         });
       }
+    }
+
+    // Generate converters for discriminated base models (model-level
+    // discriminators detected by enrichModelsFromSpec, e.g. EventSchema).
+    // Uses Populate to avoid infinite recursion with the [JsonConverter]
+    // attribute applied to the base class.
+    for (const [baseName, disc] of modelDiscriminators) {
+      const baseClass = modelClassName(baseName);
+      const converterName = `${baseClass}DiscriminatorConverter`;
+      const lines: string[] = [];
+      lines.push(`namespace ${c.namespacePascal}`);
+      lines.push('{');
+      lines.push('    using System;');
+      lines.push('    using Newtonsoft.Json;');
+      lines.push('    using Newtonsoft.Json.Linq;');
+      lines.push('');
+      lines.push(`    /// <summary>`);
+      lines.push(`    /// JSON converter that deserializes <see cref="${baseClass}"/> into the`);
+      lines.push(`    /// correct variant subclass based on the "${disc.property}" property.`);
+      lines.push(`    /// </summary>`);
+      lines.push(`    public class ${converterName} : Newtonsoft.Json.JsonConverter`);
+      lines.push('    {');
+      lines.push(
+        `        public override bool CanConvert(Type objectType) => typeof(${baseClass}).IsAssignableFrom(objectType);`,
+      );
+      lines.push('');
+      lines.push(
+        '        public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)',
+      );
+      lines.push('        {');
+      lines.push('            var jObject = JObject.Load(reader);');
+      lines.push(`            var discriminatorValue = jObject["${disc.property}"]?.ToString();`);
+      lines.push('');
+      lines.push('            object target;');
+      lines.push('            switch (discriminatorValue)');
+      lines.push('            {');
+      for (const [value, variantModelName] of Object.entries(disc.mapping)) {
+        const csName = modelClassName(variantModelName);
+        lines.push(`                case "${value}": target = new ${csName}(); break;`);
+      }
+      lines.push(`                default: target = new ${baseClass}(); break;`);
+      lines.push('            }');
+      lines.push('');
+      lines.push('            serializer.Populate(jObject.CreateReader(), target);');
+      lines.push('            return target;');
+      lines.push('        }');
+      lines.push('');
+      lines.push(
+        '        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)',
+      );
+      lines.push('        {');
+      lines.push('            serializer.Serialize(writer, value);');
+      lines.push('        }');
+      lines.push('    }');
+      lines.push('}');
+
+      files.push({
+        path: `Client/Utilities/${converterName}.cs`,
+        content: lines.join('\n'),
+        overwriteExisting: true,
+      });
     }
 
     return prefixSourcePaths(ensureTrailingNewlines(files));

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -22,11 +22,23 @@ import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.j
 export { isListWrapperModel, isListMetadataModel };
 
 /**
+ * Context for discriminated union inheritance in generated models.
+ * When present, base models get a [JsonConverter] attribute and variant
+ * models extend the base class, inheriting common fields.
+ */
+export interface DiscriminatorContext {
+  /** Model names that are discriminated union bases. */
+  discriminatorBases: Set<string>;
+  /** Maps variant model name → base model name. */
+  variantToBase: Map<string, string>;
+}
+
+/**
  * Generate C# model classes from IR Models.
  * Each model becomes a separate .cs file under Services/{mount}/Entities/.
  * For initial generation, all models go into a flat Entities/ directory.
  */
-export function generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
+export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: DiscriminatorContext): GeneratedFile[] {
   if (models.length === 0) return [];
 
   // Build a lookup from enum name → single wire value for 1-value enums so
@@ -43,6 +55,21 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
   // Compute and publish model aliases so mapTypeRef rewrites references.
   primeModelAliases(models);
+
+  // Build a lookup of base model field C# names → C# types for inheritance.
+  // Variant models skip inherited fields and use `new` for type-divergent ones.
+  const baseFieldLookup = new Map<string, Map<string, string>>();
+  if (discCtx) {
+    for (const model of models) {
+      if (discCtx.discriminatorBases.has(model.name)) {
+        const fieldMap = new Map<string, string>();
+        for (const field of model.fields) {
+          fieldMap.set(fieldName(field.name), mapTypeRef(field.type));
+        }
+        baseFieldLookup.set(model.name, fieldMap);
+      }
+    }
+  }
 
   for (const model of models) {
     if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
@@ -81,7 +108,23 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       lines.push(`    /// <summary>Represents ${articleFor(human)} ${human}.</summary>`);
     }
 
-    lines.push(`    public class ${csClassName}`);
+    // Discriminated union base: add JsonConverter so the deserializer dispatches
+    // to the correct variant subclass.
+    const isDiscBase = discCtx?.discriminatorBases.has(model.name) ?? false;
+    if (isDiscBase) {
+      lines.push(`    [Newtonsoft.Json.JsonConverter(typeof(${csClassName}DiscriminatorConverter))]`);
+    }
+
+    // Variant: extend the base class to inherit common fields.
+    const baseName = discCtx?.variantToBase.get(model.name);
+    const baseClassName = baseName ? modelClassName(baseName) : null;
+    const baseFields = baseName ? baseFieldLookup.get(baseName) : undefined;
+
+    if (baseClassName) {
+      lines.push(`    public class ${csClassName} : ${baseClassName}`);
+    } else {
+      lines.push(`    public class ${csClassName}`);
+    }
     lines.push('    {');
 
     // Track Dictionary<string, object> fields so we can emit a typed
@@ -94,6 +137,21 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       const csFieldName = fieldName(field.name);
       if (seenFieldNames.has(csFieldName)) continue;
       seenFieldNames.add(csFieldName);
+
+      // Inheritance: if this variant extends a base class, check each field
+      // against the base. Same C# type → skip (inherited). Different C# type
+      // → emit with `new` keyword so the variant has its own typed property.
+      let useNewModifier = false;
+      if (baseFields) {
+        const baseType = baseFields.get(csFieldName);
+        if (baseType !== undefined) {
+          const variantType = mapTypeRef(field.type);
+          if (baseType === variantType) {
+            continue; // Inherited from base — skip
+          }
+          useNewModifier = true;
+        }
+      }
 
       const isOptional = !field.required;
       const baseType = mapTypeRef(field.type);
@@ -141,7 +199,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
       const isRequiredEnum = field.required && isEnumRef(field.type) && constInit === null;
       lines.push(...emitJsonPropertyAttributes(field.name, { isRequiredEnum }));
-      lines.push(`        public ${csType} ${csFieldName} { get; ${setterModifier}set; }${initializer}`);
+      const newMod = useNewModifier ? 'new ' : '';
+      lines.push(`        public ${newMod}${csType} ${csFieldName} { get; ${setterModifier}set; }${initializer}`);
 
       // Track additional-properties / metadata dictionaries for typed accessors.
       // Skip deprecated fields so the generated accessor doesn't reference

--- a/src/kotlin/index.ts
+++ b/src/kotlin/index.ts
@@ -34,7 +34,22 @@ export const kotlinEmitter: Emitter = {
 
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
     const enriched = enrichModelsFromSpec(models);
-    return ensureTrailingNewlines(generateModels(enriched, ctx));
+    // Kotlin uses sealed interfaces (WorkOSEvent) for event dispatch rather
+    // than class inheritance, so discriminated base models like EventSchema
+    // need their fields restored to be emitted as proper data classes.
+    // enrichModelsFromSpec clears fields for dispatcher-capable languages;
+    // restore the originals here so Kotlin emits a full data class.
+    const originalByName = new Map(models.map((m) => [m.name, m]));
+    const kotlinModels = enriched.map((m) => {
+      if ((m as any).discriminator && m.fields.length === 0) {
+        const original = originalByName.get(m.name);
+        if (original && original.fields.length > 0) {
+          return { ...m, fields: original.fields };
+        }
+      }
+      return m;
+    });
+    return ensureTrailingNewlines(generateModels(kotlinModels, ctx));
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {


### PR DESCRIPTION
## Summary
- **Fixes the empty `EventSchema` class** in the generated dotnet and Kotlin SDKs. `enrichModelsFromSpec` clears fields on discriminated union bases for dispatcher-capable languages, but neither emitter was restoring them — producing empty classes that broke consumers.

### Dotnet
- Restores original fields on discriminated base models, emits variant classes with `: BaseClass` inheritance, skips same-typed inherited fields, and uses `new` for type-divergent fields (`Data`, `Context`)
- Adds `[JsonConverter]` attribute on base classes pointing to a `Populate`-based Newtonsoft converter (avoids infinite recursion); unknown discriminator values fall back to the base class

### Kotlin
- Restores original fields so `EventSchema` emits as a full `data class` implementing `WorkOSEvent` — Kotlin's sealed interface + Jackson `@JsonSubTypes` already handles polymorphic dispatch, so no inheritance changes needed

## Test plan
- [x] `npm test` — all 386 tests pass
- [x] `tsc --noEmit` — no type errors
- [x] Generated dotnet SDK output verified: `EventSchema` has all properties + typed accessors, variants extend it with `new` for divergent fields, converter dispatches correctly with 92 variant cases
- [x] Generated Kotlin SDK output verified: `EventSchema` is a proper `data class` with all fields, implementing `WorkOSEvent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)