### PR TITLE
fix(php,python): use fallback defaults for literal fields during deserialization

### DIFF
--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -150,6 +150,11 @@ function generateFromArrayAccessor(ref: TypeRef, wireName: string, required: boo
     }
     return `$data['${wireName}'] ?? null`;
   }
+  // Literal fields have a statically known value; use ?? with a default
+  // so deserialization is resilient when the API omits the key.
+  if (ref.kind === 'literal') {
+    return `$data['${wireName}'] ?? ${phpLiteralDefault(ref.value)}`;
+  }
   // Required field: access directly
   return generateFromArrayValue(ref, `$data['${wireName}']`);
 }
@@ -196,6 +201,14 @@ function generateFromArrayValue(ref: TypeRef, accessor: string): string {
     case 'literal':
       return accessor;
   }
+}
+
+/** Convert a LiteralType value to a PHP default expression for use with ??. */
+function phpLiteralDefault(value: string | number | boolean | null): string {
+  if (value === null) return 'null';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string') return `'${value}'`;
+  return String(value);
 }
 
 /**

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -356,7 +356,14 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       const pyFieldName = fieldName(field.name);
       const wireKey = field.name; // Wire keys are snake_case from the spec
       const isRequired = !isOptionalField(model.name, field, ctx);
-      const accessor = isRequired ? `data["${wireKey}"]` : `data.get("${wireKey}")`;
+      let accessor: string;
+      if (field.type.kind === 'literal') {
+        // Literal fields have a statically known value; use .get() with a default
+        // so deserialization is resilient when the API omits the key.
+        accessor = `data.get("${wireKey}", ${pythonLiteralDefault(field.type.value)})`;
+      } else {
+        accessor = isRequired ? `data["${wireKey}"]` : `data.get("${wireKey}")`;
+      }
       // For deserialization expressions, nullable types must always handle None
       // even when the field itself is required (the key must be present, but value can be null).
       const deserRequired = isRequired && field.type.kind !== 'nullable';
@@ -630,6 +637,14 @@ function isOptionalField(modelName: string, field: Model['fields'][number], ctx:
   // The spec's required status always takes precedence over the old SDK's API surface.
   if (!field.required || field.deprecated) return true;
   return false;
+}
+
+/** Convert a LiteralType value to a Python default expression for use in data.get(). */
+function pythonLiteralDefault(value: string | number | boolean | null): string {
+  if (value === null) return 'None';
+  if (typeof value === 'boolean') return value ? 'True' : 'False';
+  if (typeof value === 'string') return `"${value}"`;
+  return String(value);
 }
 
 function resolveModelFieldType(ref: any): string {


### PR DESCRIPTION
## Summary
- Literal (const) fields have a statically known value but the API may omit them from the response payload
- **PHP**: crashes with undefined index when the key is missing — now uses `??` with the literal default
- **Python**: raises `KeyError` when the key is missing — now uses `.get()` with the literal default

## Test plan
- [x] `npm test` — all 386 tests pass
- [x] `tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)