### PR TITLE
fix(python,kotlin,dotnet): skip literal defaults for optional fields; fix dotnet JsonConverter nullability

### DIFF
--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -127,7 +127,7 @@ export const dotnetEmitter: Emitter = {
         lines.push('        public override bool CanConvert(Type objectType) => objectType == typeof(object);');
         lines.push('');
         lines.push(
-          '        public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)',
+          '        public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)',
         );
         lines.push('        {');
         lines.push('            var jObject = JObject.Load(reader);');
@@ -143,7 +143,7 @@ export const dotnetEmitter: Emitter = {
         lines.push('        }');
         lines.push('');
         lines.push(
-          '        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)',
+          '        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)',
         );
         lines.push('        {');
         lines.push('            serializer.Serialize(writer, value);');
@@ -184,7 +184,7 @@ export const dotnetEmitter: Emitter = {
       );
       lines.push('');
       lines.push(
-        '        public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)',
+        '        public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)',
       );
       lines.push('        {');
       lines.push('            var jObject = JObject.Load(reader);');
@@ -205,7 +205,7 @@ export const dotnetEmitter: Emitter = {
       lines.push('        }');
       lines.push('');
       lines.push(
-        '        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)',
+        '        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)',
       );
       lines.push('        {');
       lines.push('            serializer.Serialize(writer, value);');

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -161,10 +161,12 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
       let initializer = '';
       let setterModifier = '';
 
-      if (constInit !== null) {
+      if (constInit !== null && !isOptional) {
         // Discriminator-style single-value enum/literal: emit with a const
         // initializer and a non-public setter so callers can't drift the
         // wire value. The converter still reads whatever the server sends.
+        // Only for required fields — optional literal fields must be nullable
+        // so absent keys round-trip correctly.
         csType = baseType;
         initializer = ` = ${constInit};`;
         setterModifier = 'internal ';

--- a/src/kotlin/models.ts
+++ b/src/kotlin/models.ts
@@ -304,11 +304,13 @@ function renderFields(fields: Field[], overrideFields: Set<string> = new Set()):
     let kotlinType: string;
     let defaultExpr: string | null = null;
 
-    // Const literal fields: always emit a hardcoded default matching the
-    // literal value so callers don't have to pass it.
+    // Const literal fields: emit a hardcoded default matching the literal
+    // value so callers don't have to pass it — but only when the field is
+    // required. Optional literal fields must default to null so that absent
+    // keys round-trip correctly.
     const literalDefault = literalDefaultExpr(field.type);
 
-    if (literalDefault !== null) {
+    if (literalDefault !== null && field.required) {
       kotlinType = baseType;
       defaultExpr = literalDefault;
     } else if (!field.required) {

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -357,8 +357,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       const wireKey = field.name; // Wire keys are snake_case from the spec
       const isRequired = !isOptionalField(model.name, field, ctx);
       let accessor: string;
-      if (field.type.kind === 'literal') {
-        // Literal fields have a statically known value; use .get() with a default
+      if (field.type.kind === 'literal' && isRequired) {
+        // Required literal fields have a statically known value; use .get() with a default
         // so deserialization is resilient when the API omits the key.
         accessor = `data.get("${wireKey}", ${pythonLiteralDefault(field.type.value)})`;
       } else {


### PR DESCRIPTION
## Summary
- **Skip literal defaults for optional fields** (Python, Kotlin, .NET): Optional literal fields were unconditionally given concrete defaults (e.g., `"GoogleSAML"`, `"m2m"`, `true`) during deserialization, causing absent keys to round-trip as present. The literal default is now gated on the field being required so optional literals correctly default to `null`/`None`.
- **Fix dotnet JsonConverter override nullability** (.NET): The Newtonsoft.Json base class declares `existingValue` and `value` as `object?`, so generated overrides now match to avoid CS8765 nullability errors when the SDK project has nullable reference types enabled.

## Test plan
- [ ] Regenerate Python, Kotlin, and .NET SDKs against real spec
- [ ] Verify optional literal fields default to null/None when absent
- [ ] Verify required literal fields still get their concrete defaults
- [ ] Verify .NET SDK compiles without CS8765 warnings under `<Nullable>enable</Nullable>`
- [ ] Run `script/ci` in each affected SDK