### PR TITLE
fix(dotnet): prevent infinite recursion in discriminator converter WriteJson

### DIFF
--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -161,8 +161,10 @@ export const dotnetEmitter: Emitter = {
 
     // Generate converters for discriminated base models (model-level
     // discriminators detected by enrichModelsFromSpec, e.g. EventSchema).
-    // Uses Populate to avoid infinite recursion with the [JsonConverter]
-    // attribute applied to the base class.
+    // ReadJson uses Populate (not Deserialize) to avoid infinite recursion
+    // with the [JsonConverter] attribute applied to the base class.
+    // CanWrite is false so serialization uses the default path and never
+    // re-enters WriteJson.
     for (const [baseName, disc] of modelDiscriminators) {
       const baseClass = modelClassName(baseName);
       const converterName = `${baseClass}DiscriminatorConverter`;
@@ -204,11 +206,15 @@ export const dotnetEmitter: Emitter = {
       lines.push('            return target;');
       lines.push('        }');
       lines.push('');
+      lines.push('        public override bool CanWrite => false;');
+      lines.push('');
       lines.push(
         '        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)',
       );
       lines.push('        {');
-      lines.push('            serializer.Serialize(writer, value);');
+      lines.push(
+        '            throw new NotImplementedException("Serialization is handled by the default serializer.");',
+      );
       lines.push('        }');
       lines.push('    }');
       lines.push('}');


### PR DESCRIPTION
## Summary
- Fix infinite recursion in generated `DiscriminatorConverter.WriteJson` by setting `CanWrite => false`
- The generated `WriteJson` called `serializer.Serialize(writer, value)`, which re-enters the same converter via the `[JsonConverter]` attribute on the base class, causing a `StackOverflowException`
- With `CanWrite` disabled, Newtonsoft.Json uses its default serialization path for writing and only invokes the converter for deserialization (`ReadJson`), where the discriminator logic lives

## Test plan
- [x] All 386 existing tests pass
- [x] Typecheck clean
- [ ] Regenerate dotnet SDK and verify `EventSchemaDiscriminatorConverter.cs` output includes `CanWrite => false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)