### PR TITLE
fix(python): emit non-spec imports as plain imports instead of ignore block

### DIFF
--- a/src/python/client.ts
+++ b/src/python/client.ts
@@ -163,15 +163,17 @@ function generateWorkOSClient(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
       lines.push(importLine);
     }
   }
-  // Non-spec service imports — wrapped in ignore markers so the merger
-  // matches them positionally and doesn't displace them.
-  lines.push('');
-  lines.push('# @oagen-ignore-start — non-spec service imports (hand-maintained)');
+  // Non-spec service imports — emitted as plain imports (not wrapped in
+  // ignore markers). The overwriteWithPreservedRegions() machinery in oagen
+  // relocates top-level ignore blocks to EOF because they have no containing
+  // class, stripping the markers from the imports while spliceExtraImports()
+  // preserves the bare import lines. Emitting them directly avoids the
+  // displacement entirely; spliceExtraImports() will preserve any additional
+  // hand-added imports from the existing file on subsequent regenerations.
   for (const s of NON_SPEC_SERVICES) {
     const w = PYTHON_NON_SPEC_WIRING[s.id];
     if (w) lines.push(w.importLine);
   }
-  lines.push('# @oagen-ignore-end');
   lines.push('');
   lines.push('');
 


### PR DESCRIPTION
## Summary

- Stop wrapping non-spec service imports (passwordless, vault, actions, pkce) in `@oagen-ignore-start`/`@oagen-ignore-end` markers in the generated Python `_client.py`
- The `overwriteWithPreservedRegions()` function in oagen relocates top-level ignore blocks to EOF because they have no `containingClass`, which was stripping the markers from the imports and leaving a vestigial empty block at the end of the file (see workos/workos-python#639)
- The generator already knows the exact imports via `PYTHON_NON_SPEC_WIRING`, so the ignore block was redundant — `spliceExtraImports()` preserves any additional hand-added imports from the existing file on subsequent regenerations
- Class-level accessor ignore blocks are unaffected (they work correctly because they have a containing class)

## Test plan

- [x] All 386 existing tests pass
- [x] Lint and format checks pass
- [x] Type checking passes
- [ ] Regenerate Python SDK and verify non-spec imports appear at the top without markers and no empty block at EOF

🤖 Generated with [Claude Code](https://claude.com/claude-code)