### PR TITLE
fix(go): resolve test fixture paths through dedup rewrite map

### DIFF
--- a/src/go/fixtures.ts
+++ b/src/go/fixtures.ts
@@ -24,12 +24,11 @@ export const ID_PREFIXES: Record<string, string> = {
 /**
  * Generate JSON fixture files for test data.
  */
-export function generateFixtures(spec: {
-  models: Model[];
-  enums: Enum[];
-  services: any[];
-}): { path: string; content: string }[] {
-  if (spec.models.length === 0) return [];
+export function generateFixtures(spec: { models: Model[]; enums: Enum[]; services: any[] }): {
+  files: { path: string; content: string }[];
+  pathRewrites: Map<string, string>;
+} {
+  if (spec.models.length === 0) return { files: [], pathRewrites: new Map() };
 
   const modelMap = new Map(spec.models.map((m) => [m.name, m]));
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
@@ -96,7 +95,7 @@ export function generateFixtures(spec: {
   // Remove duplicate files (they'll reference the canonical)
   const deduped = files.filter((f) => !pathRewrites.has(f.path));
 
-  return deduped;
+  return { files: deduped, pathRewrites };
 }
 
 function unwrapListModel(model: Model, modelMap: Map<string, Model>): Model | null {

--- a/src/go/tests.ts
+++ b/src/go/tests.ts
@@ -72,7 +72,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   });
 
   // Generate fixture JSON files
-  const fixtures = generateFixtures(spec);
+  const { files: fixtures, pathRewrites: fixtureRewrites } = generateFixtures(spec);
   for (const fixture of fixtures) {
     files.push({
       path: fixture.path,
@@ -97,7 +97,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   for (const { name: mountName, operations } of testEntries) {
     if (operations.length === 0) continue;
     const mergedService: Service = { name: mountName, operations };
-    const testFile = generateServiceTest(mergedService, spec, ctx, accessPaths);
+    const testFile = generateServiceTest(mergedService, spec, ctx, accessPaths, fixtureRewrites);
     if (testFile) files.push(testFile);
   }
 
@@ -109,6 +109,7 @@ function generateServiceTest(
   spec: ApiSpec,
   ctx: EmitterContext,
   _accessPaths: Map<string, string>,
+  fixtureRewrites: Map<string, string>,
 ): GeneratedFile | null {
   if (service.operations.length === 0) return null;
 
@@ -213,6 +214,10 @@ function generateServiceTest(
             }
           }
           fixturePath = `testdata/list_${fileName(resolved.name)}.json`;
+          // If this fixture was deduplicated, use the canonical path
+          if (fixtureRewrites.has(fixturePath)) {
+            fixturePath = fixtureRewrites.get(fixturePath)!;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- When 3+ fixtures have identical content, `generateFixtures` deduplicates them to a single canonical file. But `generateServiceTest` computed fixture paths independently, so tests could reference files that were removed during dedup (e.g. `list_user_organization_membership_base_list_data.json` in `groups_test.go`).
- Now `generateFixtures` returns the `pathRewrites` map alongside the deduplicated files, and test generation applies it before emitting fixture references.

## Test plan

- [x] All 386 existing tests pass
- [ ] Regenerate Go SDK and verify no tests reference demanifested fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)