### PR TITLE
fix(dotnet): mark discriminator property as internal set on base class

### DIFF
--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -103,7 +103,14 @@ export const dotnetEmitter: Emitter = {
       return m;
     });
 
-    const discCtx: DiscriminatorContext = { discriminatorBases, variantToBase };
+    // Build a map of base model name → discriminator wire-property name so the
+    // model emitter can mark the discriminator field as internal-set.
+    const discriminatorProperties = new Map<string, string>();
+    for (const [baseName, disc] of modelDiscriminators) {
+      discriminatorProperties.set(baseName, disc.property);
+    }
+
+    const discCtx: DiscriminatorContext = { discriminatorBases, variantToBase, discriminatorProperties };
     const files = generateModels(dotnetModels, c, discCtx);
 
     // Generate discriminator converters for oneOf unions with discriminator

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -31,6 +31,8 @@ export interface DiscriminatorContext {
   discriminatorBases: Set<string>;
   /** Maps variant model name → base model name. */
   variantToBase: Map<string, string>;
+  /** Maps base model name → wire name of the discriminator property. */
+  discriminatorProperties?: Map<string, string>;
 }
 
 /**
@@ -161,6 +163,12 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
       let initializer = '';
       let setterModifier = '';
 
+      // On a discriminated union base, the discriminator property (e.g. "event")
+      // should be non-public-settable even though it lacks a single const value
+      // (each variant has a different value). Consumers must never mutate it.
+      const discProp = isDiscBase ? discCtx?.discriminatorProperties?.get(model.name) : undefined;
+      const isDiscriminatorField = discProp !== undefined && field.name === discProp;
+
       if (constInit !== null && !isOptional) {
         // Discriminator-style single-value enum/literal: emit with a const
         // initializer and a non-public setter so callers can't drift the
@@ -169,6 +177,14 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
         // so absent keys round-trip correctly.
         csType = baseType;
         initializer = ` = ${constInit};`;
+        setterModifier = 'internal ';
+      } else if (isDiscriminatorField) {
+        // Discriminator property on the base class: varies per variant but
+        // should still be non-public-settable so consumers can't change it.
+        csType = baseType;
+        if (!isAlreadyNullable && !isValueTypeRef(field.type)) {
+          initializer = ' = default!;';
+        }
         setterModifier = 'internal ';
       } else if (isOptional) {
         if (isAlreadyNullable) {
@@ -219,6 +235,14 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
       lines.push(`        /// <paramref name="key"/> coerced to <typeparamref name="T"/>, or the default`);
       lines.push(`        /// value when the key is missing or the value is not convertible.`);
       lines.push(`        /// </summary>`);
+      if (isDiscBase) {
+        lines.push(`        /// <remarks>`);
+        lines.push(`        /// Variant subclasses provide strongly-typed <c>${dict.csName}</c> properties that`);
+        lines.push(`        /// shadow this dictionary. This accessor is intended for forward-compatible handling`);
+        lines.push(`        /// of types not yet known to this SDK version. For recognized types, cast to the`);
+        lines.push(`        /// specific subclass and access its typed <c>${dict.csName}</c> property directly.`);
+        lines.push(`        /// </remarks>`);
+      }
       lines.push(`        /// <typeparam name="T">Expected value type.</typeparam>`);
       lines.push(`        /// <param name="key">The key to look up.</param>`);
       lines.push(`        public T? Get${dict.csName}Attribute<T>(string key)`);

--- a/test/dotnet/models.test.ts
+++ b/test/dotnet/models.test.ts
@@ -265,7 +265,7 @@ describe('dotnet/models', () => {
           { name: 'event', type: { kind: 'primitive', type: 'string' }, required: true },
           {
             name: 'data',
-            type: { kind: 'map', valueType: { kind: 'primitive', type: 'any' } },
+            type: { kind: 'map', valueType: { kind: 'primitive', type: 'unknown' } },
             required: true,
           },
         ],

--- a/test/dotnet/models.test.ts
+++ b/test/dotnet/models.test.ts
@@ -255,4 +255,81 @@ describe('dotnet/models', () => {
     expect(orgFile).toBeDefined();
     expect(orgFile.content).toContain('List<OrganizationDomain>');
   });
+
+  it('emits internal set on discriminator property of base class', () => {
+    const models: Model[] = [
+      {
+        name: 'EventSchema',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'event', type: { kind: 'primitive', type: 'string' }, required: true },
+          {
+            name: 'data',
+            type: { kind: 'map', valueType: { kind: 'primitive', type: 'any' } },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'UserCreated',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'event', type: { kind: 'literal', value: 'user.created' }, required: true },
+          { name: 'data', type: { kind: 'model', name: 'UserCreatedData' }, required: true },
+        ],
+      },
+      {
+        name: 'UserCreatedData',
+        fields: [{ name: 'user_id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const discCtx = {
+      discriminatorBases: new Set(['EventSchema']),
+      variantToBase: new Map([['UserCreated', 'EventSchema']]),
+      discriminatorProperties: new Map([['EventSchema', 'event']]),
+    };
+    const files = generateModels(models, { ...ctx, spec: { ...emptySpec, models } }, discCtx);
+
+    const baseFile = files.find((f) => f.path.includes('EventSchema.cs'))!;
+    expect(baseFile).toBeDefined();
+
+    // The discriminator property "event" should have internal set
+    expect(baseFile.content).toContain('Event { get; internal set; }');
+    // Non-discriminator required fields should NOT have internal set
+    expect(baseFile.content).toContain('Id { get; set; }');
+  });
+
+  it('adds remarks to dictionary accessors on discriminator base class', () => {
+    const models: Model[] = [
+      {
+        name: 'EventSchema',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'event', type: { kind: 'primitive', type: 'string' }, required: true },
+          {
+            name: 'data',
+            type: { kind: 'map', valueType: { kind: 'primitive', type: 'unknown' } },
+            required: true,
+          },
+        ],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const discCtx = {
+      discriminatorBases: new Set(['EventSchema']),
+      variantToBase: new Map<string, string>(),
+      discriminatorProperties: new Map([['EventSchema', 'event']]),
+    };
+    const files = generateModels(models, { ...ctx, spec: { ...emptySpec, models } }, discCtx);
+
+    const baseFile = files.find((f) => f.path.includes('EventSchema.cs'))!;
+    expect(baseFile).toBeDefined();
+
+    // Dictionary accessors on discriminator bases should have a remarks note
+    expect(baseFile.content).toContain('/// <remarks>');
+    expect(baseFile.content).toContain('forward-compatible');
+  });
 });


### PR DESCRIPTION
## Summary

- **Discriminator property gets `internal set`**: On discriminated union base classes (e.g. `EventSchema`), the discriminator property (e.g. `Event`) was emitted with a public setter because it lacks a single-value const initializer — the value varies per variant. This meant consumers could mutate the event type string on deserialized events. Now the discriminator field correctly gets `internal set`, matching the behavior of other const-initialized properties like `Object`.
- **Dictionary accessor docs**: Adds `<remarks>` XML documentation to `GetDataAttribute<T>()` and `GetContextAttribute<T>()` helpers on discriminated union base classes, explaining that these accessors only work for unrecognized variant types (the `default` fallback case in the converter). Recognized types should be cast to their specific subclass for typed property access.

### Other languages investigated

Checked all 7 language emitters for analogous issues:

| Language | Has discriminator handling? | Same bug? |
|----------|---------------------------|-----------|
| Node     | No special handling       | N/A       |
| Python   | Yes (dispatcher pattern)  | Conceptually similar — dataclass fields are mutable, but Python has no `internal`/`readonly` equivalent for properties |
| Ruby     | No special handling       | N/A       |
| Go       | Flat struct restoration   | N/A — Go structs have no per-field immutability |
| PHP      | No special handling       | No — PHP uses `readonly class` which makes all fields immutable |
| Kotlin   | Yes (sealed interface)    | Minor — `val` is already immutable, but Jackson could overwrite during deser |

Only the .NET emitter had a clear, fixable bug. Python and Kotlin have conceptual variants of the issue but are either unfixable (Python has no field-level immutability) or already mitigated (Kotlin's `val`).

## Test plan

- [x] New test: discriminator property on base class gets `internal set`
- [x] New test: dictionary accessors on discriminator bases include `<remarks>` note
- [x] All 388 existing tests pass
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)