### PR TITLE
fix: cross-domain aliases and minor emitter fixes

### DIFF
--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -188,6 +188,8 @@ export const dotnetEmitter: Emitter = {
       lines.push(`    /// </summary>`);
       lines.push(`    public class ${converterName} : Newtonsoft.Json.JsonConverter`);
       lines.push('    {');
+      lines.push('        public override bool CanWrite => false;');
+      lines.push('');
       lines.push(
         `        public override bool CanConvert(Type objectType) => typeof(${baseClass}).IsAssignableFrom(objectType);`,
       );
@@ -212,8 +214,6 @@ export const dotnetEmitter: Emitter = {
       lines.push('            serializer.Populate(jObject.CreateReader(), target);');
       lines.push('            return target;');
       lines.push('        }');
-      lines.push('');
-      lines.push('        public override bool CanWrite => false;');
       lines.push('');
       lines.push(
         '        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)',

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -166,10 +166,27 @@ function makeOptional(goType: string): string {
 }
 
 function structuralHash(model: Model): string {
-  return model.fields
+  const fieldHash = model.fields
     .map((f) => `${f.name}:${JSON.stringify(f.type)}:${f.required}`)
     .sort()
     .join('|');
+  // Include entity domain for CRUD-prefixed models to prevent cross-domain
+  // aliasing (e.g. UpdateGroup vs UpdateAuthorizationPermission have identical
+  // fields but belong to different API domains and should stay separate types).
+  const domain = crudEntityDomain(model.name);
+  return domain ? `${domain}::${fieldHash}` : fieldHash;
+}
+
+const CRUD_PREFIXES = ['Create', 'Update', 'Delete', 'Get', 'List'];
+
+/** Strip CRUD verb prefix to get the entity name, or null if no prefix matches. */
+function crudEntityDomain(name: string): string | null {
+  for (const prefix of CRUD_PREFIXES) {
+    if (name.startsWith(prefix) && name.length > prefix.length) {
+      return name.slice(prefix.length);
+    }
+  }
+  return null;
 }
 
 /** Known acronyms to preserve as single tokens during humanization. */

--- a/src/go/tests.ts
+++ b/src/go/tests.ts
@@ -307,7 +307,10 @@ function generateServiceTest(
       // Success test
       const respModel = plan.responseModelName;
       const isArrayResponse = !isPaginated && op.response?.kind === 'array';
-      const fixturePath = `testdata/${fileName(respModel)}.json`;
+      let fixturePath = `testdata/${fileName(respModel)}.json`;
+      if (fixtureRewrites.has(fixturePath)) {
+        fixturePath = fixtureRewrites.get(fixturePath)!;
+      }
       const expectedPath = buildExpectedPath(op);
 
       const httpMethodUpper = op.httpMethod.toUpperCase();
@@ -411,7 +414,10 @@ function generateServiceTest(
       const wrapperParamsStruct = paramsStructName(resolvedName, wrapperMethod);
       const responseType = wrapper.responseModelName;
       const testName = `Test${accessorName}_${wrapperMethod}`;
-      const fixturePath = responseType ? `testdata/${fileName(responseType)}.json` : null;
+      let fixturePath = responseType ? `testdata/${fileName(responseType)}.json` : null;
+      if (fixturePath && fixtureRewrites.has(fixturePath)) {
+        fixturePath = fixtureRewrites.get(fixturePath)!;
+      }
 
       const wrapperCallArgs: string[] = ['context.Background()'];
       for (const p of sortPathParamsByTemplateOrder(op)) {


### PR DESCRIPTION
## Summary
- Prevent cross-domain model aliasing in Go emitter by incorporating the entity domain into `structuralHash` for CRUD-prefixed models (e.g. `UpdateGroup` vs `UpdateAuthorizationPermission` no longer collapse into one type)
- Respect `fixtureRewrites` map when resolving test fixture paths in Go service and wrapper tests
- Move `CanWrite => false` to top of converter class body in dotnet emitter for correct member ordering

## Test plan
- [ ] Regenerate Go SDK and verify CRUD-prefixed models with identical fields but different domains remain distinct types
- [ ] Regenerate dotnet SDK and verify converter classes compile correctly
- [ ] Run `script/ci` in target SDKs