### PR TITLE
fix(ruby): emit typed variant classes for parameter groups

### DIFF
--- a/src/ruby/index.ts
+++ b/src/ruby/index.ts
@@ -15,6 +15,7 @@ import { generateClient } from './client.js';
 import { generateTests } from './tests.js';
 import { buildOperationsMap } from './manifest.js';
 import { generateRbiFiles } from './rbi.js';
+import { generateParameterGroupClasses, generateParameterGroupRbi } from './parameter-groups.js';
 
 /** Ensure every generated file's content ends with a trailing newline. */
 function ensureTrailingNewlines(files: GeneratedFile[]): GeneratedFile[] {
@@ -30,7 +31,9 @@ export const rubyEmitter: Emitter = {
   language: 'ruby',
 
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
-    return ensureTrailingNewlines(generateModels(models, ctx));
+    const modelFiles = generateModels(models, ctx);
+    const groupFiles = generateParameterGroupClasses(ctx.spec.services, ctx);
+    return ensureTrailingNewlines([...modelFiles, ...groupFiles]);
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
@@ -54,7 +57,9 @@ export const rubyEmitter: Emitter = {
   },
 
   generateTypeSignatures(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
-    return ensureTrailingNewlines(generateRbiFiles(spec, ctx));
+    const rbiFiles = generateRbiFiles(spec, ctx);
+    const groupRbiFiles = generateParameterGroupRbi(spec.services, ctx);
+    return ensureTrailingNewlines([...rbiFiles, ...groupRbiFiles]);
   },
 
   generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {

--- a/src/ruby/index.ts
+++ b/src/ruby/index.ts
@@ -15,7 +15,6 @@ import { generateClient } from './client.js';
 import { generateTests } from './tests.js';
 import { buildOperationsMap } from './manifest.js';
 import { generateRbiFiles } from './rbi.js';
-import { generateParameterGroupClasses, generateParameterGroupRbi } from './parameter-groups.js';
 
 /** Ensure every generated file's content ends with a trailing newline. */
 function ensureTrailingNewlines(files: GeneratedFile[]): GeneratedFile[] {
@@ -32,8 +31,7 @@ export const rubyEmitter: Emitter = {
 
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
     const modelFiles = generateModels(models, ctx);
-    const groupFiles = generateParameterGroupClasses(ctx.spec.services, ctx);
-    return ensureTrailingNewlines([...modelFiles, ...groupFiles]);
+    return ensureTrailingNewlines(modelFiles);
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
@@ -58,8 +56,7 @@ export const rubyEmitter: Emitter = {
 
   generateTypeSignatures(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
     const rbiFiles = generateRbiFiles(spec, ctx);
-    const groupRbiFiles = generateParameterGroupRbi(spec.services, ctx);
-    return ensureTrailingNewlines([...rbiFiles, ...groupRbiFiles]);
+    return ensureTrailingNewlines(rbiFiles);
   },
 
   generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {

--- a/src/ruby/naming.ts
+++ b/src/ruby/naming.ts
@@ -117,6 +117,20 @@ export function moduleName(name: string): string {
   return toSnakeCase(name);
 }
 
+/**
+ * PascalCase class name for a parameter-group variant. Mirrors the Python
+ * convention: group "password" + variant "plaintext" → `PasswordPlaintext`.
+ * Used as the Ruby constant under the WorkOS module.
+ */
+export function groupVariantClassName(groupName: string, variantName: string): string {
+  return className(`${groupName}_${variantName}`);
+}
+
+/** snake_case Zeitwerk-compatible filename for a parameter-group variant. */
+export function groupVariantFileName(groupName: string, variantName: string): string {
+  return fileName(`${groupName}_${variantName}`);
+}
+
 /** snake_case property name for service accessors on the client. */
 export function servicePropertyName(name: string): string {
   return toSnakeCase(name);

--- a/src/ruby/naming.ts
+++ b/src/ruby/naming.ts
@@ -131,6 +131,15 @@ export function groupVariantFileName(groupName: string, variantName: string): st
   return fileName(`${groupName}_${variantName}`);
 }
 
+/**
+ * Fully-qualified Ruby constant for a parameter-group variant scoped under
+ * its owning resource module — e.g. "WorkOS::UserManagement::PasswordPlaintext".
+ * Mirrors Python's `workos.user_management.PasswordPlaintext` namespacing.
+ */
+export function scopedGroupVariantClassName(mountTarget: string, groupName: string, variantName: string): string {
+  return `WorkOS::${className(mountTarget)}::${groupVariantClassName(groupName, variantName)}`;
+}
+
 /** snake_case property name for service accessors on the client. */
 export function servicePropertyName(name: string): string {
   return toSnakeCase(name);

--- a/src/ruby/parameter-groups.ts
+++ b/src/ruby/parameter-groups.ts
@@ -142,8 +142,12 @@ export function collectVariantsForMountTarget(
  * fidelity-recovery case the body fallback was added for. Strip any outer
  * nullable from the body type, since body nullability reflects the parent
  * group's optionality, not the leaf's required-ness within the variant.
+ *
+ * Exported so the test emitter can recover the same type the variant class
+ * declares — IR primitives for fields like `role_slugs` would otherwise stub
+ * as `"stub"` strings instead of the `["stub"]` arrays the class accepts.
  */
-function pickVariantParamType(irType: TypeRef, bodyType: TypeRef | undefined): TypeRef {
+export function pickVariantParamType(irType: TypeRef, bodyType: TypeRef | undefined): TypeRef {
   if (!bodyType) return irType;
   const unwrappedBody = bodyType.kind === 'nullable' ? bodyType.inner : bodyType;
   const bodyIsStructured =

--- a/src/ruby/parameter-groups.ts
+++ b/src/ruby/parameter-groups.ts
@@ -1,7 +1,7 @@
-import type { Service, EmitterContext, GeneratedFile, Operation, TypeRef, Model } from '@workos/oagen';
-import { className, fieldName, groupVariantClassName, groupVariantFileName } from './naming.js';
-import { mapTypeRef as mapYardType, mapTypeRefForYard } from './type-map.js';
-import { collectBodyFieldTypes } from '../shared/resolved-ops.js';
+import type { EmitterContext, TypeRef, Model } from '@workos/oagen';
+import { className, fieldName, groupVariantClassName } from './naming.js';
+import { mapTypeRefForYard } from './type-map.js';
+import { collectBodyFieldTypes, groupByMount } from '../shared/resolved-ops.js';
 
 /**
  * Sorbet type string for a TypeRef. Mirrors `mapSorbetType` in rbi.ts but
@@ -48,18 +48,49 @@ function mapSorbetType(ref: TypeRef): string {
   return 'T.untyped';
 }
 
-interface CollectedVariant {
+export interface CollectedVariant {
   className: string;
-  fileName: string;
   groupName: string;
   variantName: string;
+  /** PascalCase mount target this variant is scoped under (e.g. "UserManagement"). */
+  mountTarget: string;
   parameters: { name: string; type: TypeRef }[];
 }
 
 /**
- * Walk every operation, collect each unique parameter-group variant once.
- * The same group name can appear in multiple operations (e.g. `resource_target`
- * in `check`/`assign_role`/`remove_role`); we dedupe by class name.
+ * Build a stable groupName -> mountTarget map. Each parameter group is owned
+ * by exactly one resource module — Ruby variant classes are inlined into
+ * `WorkOS::<MountTarget>::<Variant>` (matching Python's per-resource layout),
+ * so a dispatcher in another resource that references the same group still
+ * resolves to a single canonical class.
+ *
+ * Mount targets are visited in alphabetical order so first-wins is
+ * deterministic across runs. In the current spec no group is shared across
+ * mount targets; if one ever is, the alphabetically-first owner gets the
+ * class and other dispatchers reference it by full path.
+ */
+export function buildGroupOwnerMap(ctx: EmitterContext): Map<string, string> {
+  const owner = new Map<string, string>();
+  const groups = groupByMount(ctx);
+  const sortedTargets = [...groups.keys()].sort();
+  for (const target of sortedTargets) {
+    const g = groups.get(target);
+    if (!g) continue;
+    for (const op of g.operations) {
+      for (const grp of op.parameterGroups ?? []) {
+        if (!owner.has(grp.name)) owner.set(grp.name, target);
+      }
+    }
+  }
+  return owner;
+}
+
+/**
+ * Collect all variant classes a given mount target owns. Variants are
+ * inlined into the resource file (and its RBI counterpart) — Zeitwerk's
+ * collapse convention means subdirectories under `lib/workos/<service>/`
+ * don't add a namespace level, so files there can't define
+ * `WorkOS::<Service>::<Variant>`. Inline definitions sidestep that.
  *
  * Variant parameter types are taken from the IR's leaf type. When the IR's
  * leaf is a bare primitive but the request body model has a richer type
@@ -68,21 +99,30 @@ interface CollectedVariant {
  * optional, the body field for the group becomes nullable, but within a
  * variant the leaf is always required (selecting the variant means passing it).
  */
-function collectVariants(operations: Operation[], models: Model[]): CollectedVariant[] {
+export function collectVariantsForMountTarget(
+  ctx: EmitterContext,
+  models: Model[],
+  mountTarget: string,
+): CollectedVariant[] {
+  const owner = buildGroupOwnerMap(ctx);
   const seen = new Set<string>();
   const out: CollectedVariant[] = [];
-  for (const op of operations) {
+  const groups = groupByMount(ctx);
+  const g = groups.get(mountTarget);
+  if (!g) return out;
+  for (const op of g.operations) {
     const bodyFieldTypes = collectBodyFieldTypes(op, models);
     for (const group of op.parameterGroups ?? []) {
+      if (owner.get(group.name) !== mountTarget) continue;
       for (const variant of group.variants) {
         const cls = groupVariantClassName(group.name, variant.name);
         if (seen.has(cls)) continue;
         seen.add(cls);
         out.push({
           className: cls,
-          fileName: groupVariantFileName(group.name, variant.name),
           groupName: group.name,
           variantName: variant.name,
+          mountTarget,
           parameters: variant.parameters.map((p) => ({
             name: p.name,
             type: pickVariantParamType(p.type, bodyFieldTypes.get(p.name)),
@@ -120,106 +160,58 @@ function readableName(name: string): string {
 }
 
 /**
- * Generate a `Data.define` class file for each unique parameter-group variant
- * referenced by any service's operations. Files are emitted alongside models
- * under `lib/workos/<variant>.rb` so Zeitwerk autoloads them.
+ * Render the inline `Data.define` block for a single variant, indented for
+ * inclusion inside a `class <Service>` body. Returns an array of lines with
+ * 4-space indent (the resource file's class members are 4-space indented).
  */
-export function generateParameterGroupClasses(services: Service[], _ctx: EmitterContext): GeneratedFile[] {
-  const operations = services.flatMap((s) => s.operations);
-  const models = (_ctx.spec.models as Model[]) ?? [];
-  const variants = collectVariants(operations, models);
-
-  const files: GeneratedFile[] = [];
-  for (const v of variants) {
-    const lines: string[] = [];
-    lines.push('module WorkOS');
-    lines.push(`  # Identifies the ${readableName(v.groupName)} (${readableName(v.variantName)} variant).`);
-    lines.push('  #');
-    for (const p of v.parameters) {
-      const yardType = mapTypeRefForYard(p.type);
-      lines.push(`  # @!attribute [r] ${fieldName(p.name)}`);
-      lines.push(`  #   @return [${yardType}]`);
-    }
-    if (v.parameters.length === 0) {
-      lines.push(`  ${v.className} = Data.define`);
-    } else {
-      const fields = v.parameters.map((p) => `:${fieldName(p.name)}`).join(', ');
-      lines.push(`  ${v.className} = Data.define(${fields})`);
-    }
-    lines.push('end');
-    files.push({
-      path: `lib/workos/${v.fileName}.rb`,
-      content: lines.join('\n'),
-      integrateTarget: true,
-      overwriteExisting: true,
-    });
+export function emitInlineVariantClass(v: CollectedVariant): string[] {
+  const lines: string[] = [];
+  lines.push(`    # Identifies the ${readableName(v.groupName)} (${readableName(v.variantName)} variant).`);
+  lines.push('    #');
+  for (const p of v.parameters) {
+    const yardType = mapTypeRefForYard(p.type);
+    lines.push(`    # @!attribute [r] ${fieldName(p.name)}`);
+    lines.push(`    #   @return [${yardType}]`);
   }
-  return files;
+  if (v.parameters.length === 0) {
+    lines.push(`    ${v.className} = Data.define`);
+  } else {
+    const fields = v.parameters.map((p) => `:${fieldName(p.name)}`).join(', ');
+    lines.push(`    ${v.className} = Data.define(${fields})`);
+  }
+  return lines;
 }
 
 /**
- * Generate a Sorbet `.rbi` file for each variant class. Mirrors the shape
- * used by `rbi/workos/types/api_response.rbi`.
+ * Render the inline RBI `class` block for a single variant, indented for
+ * inclusion inside a `class <Service>` body in a service .rbi file. Returns
+ * lines with 4-space indent.
  */
-export function generateParameterGroupRbi(services: Service[], ctx: EmitterContext): GeneratedFile[] {
-  const operations = services.flatMap((s) => s.operations);
-  const models = (ctx.spec.models as Model[]) ?? [];
-  const variants = collectVariants(operations, models);
-
-  const files: GeneratedFile[] = [];
-  for (const v of variants) {
-    const lines: string[] = [];
-    lines.push('# typed: strong');
+export function emitInlineVariantRbi(v: CollectedVariant): string[] {
+  const lines: string[] = [];
+  const fqcn = `WorkOS::${v.mountTarget}::${v.className}`;
+  lines.push(`    class ${v.className}`);
+  for (const p of v.parameters) {
+    lines.push(`      sig { returns(${mapSorbetType(p.type)}) }`);
+    lines.push(`      def ${fieldName(p.name)}; end`);
     lines.push('');
-    lines.push('module WorkOS');
-    lines.push(`  class ${v.className}`);
-    for (const p of v.parameters) {
-      lines.push(`    sig { returns(${mapSorbetType(p.type)}) }`);
-      lines.push(`    def ${fieldName(p.name)}; end`);
-      lines.push('');
-    }
-    if (v.parameters.length === 0) {
-      lines.push(`    sig { returns(WorkOS::${v.className}) }`);
-      lines.push(`    def self.new; end`);
-    } else {
-      lines.push('    sig do');
-      lines.push('      params(');
-      for (let i = 0; i < v.parameters.length; i++) {
-        const p = v.parameters[i];
-        const sep = i === v.parameters.length - 1 ? '' : ',';
-        lines.push(`        ${fieldName(p.name)}: ${mapSorbetType(p.type)}${sep}`);
-      }
-      lines.push(`      ).returns(WorkOS::${v.className})`);
-      lines.push('    end');
-      const kwargs = v.parameters.map((p) => `${fieldName(p.name)}:`).join(', ');
-      lines.push(`    def self.new(${kwargs}); end`);
-    }
-    lines.push('  end');
-    lines.push('end');
-    files.push({
-      path: `rbi/workos/${v.fileName}.rbi`,
-      content: lines.join('\n'),
-      integrateTarget: true,
-      overwriteExisting: true,
-    });
   }
-  return files;
-}
-
-/**
- * Build the YARD type-tag union string for a parameter group's kwarg.
- * E.g., `[WorkOS::PasswordPlaintext, WorkOS::PasswordHashed]`.
- */
-export function groupYardUnion(group: { name: string; variants: { name: string }[] }): string {
-  void mapYardType;
-  return group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`).join(', ');
-}
-
-/**
- * Build the Sorbet `T.any(...)` type for a parameter group's kwarg.
- */
-export function groupSorbetUnion(group: { name: string; variants: { name: string }[] }): string {
-  const variants = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`);
-  if (variants.length === 1) return variants[0];
-  return `T.any(${variants.join(', ')})`;
+  if (v.parameters.length === 0) {
+    lines.push(`      sig { returns(${fqcn}) }`);
+    lines.push(`      def self.new; end`);
+  } else {
+    lines.push('      sig do');
+    lines.push('        params(');
+    for (let i = 0; i < v.parameters.length; i++) {
+      const p = v.parameters[i];
+      const sep = i === v.parameters.length - 1 ? '' : ',';
+      lines.push(`          ${fieldName(p.name)}: ${mapSorbetType(p.type)}${sep}`);
+    }
+    lines.push(`        ).returns(${fqcn})`);
+    lines.push('      end');
+    const kwargs = v.parameters.map((p) => `${fieldName(p.name)}:`).join(', ');
+    lines.push(`      def self.new(${kwargs}); end`);
+  }
+  lines.push('    end');
+  return lines;
 }

--- a/src/ruby/parameter-groups.ts
+++ b/src/ruby/parameter-groups.ts
@@ -61,9 +61,12 @@ interface CollectedVariant {
  * The same group name can appear in multiple operations (e.g. `resource_target`
  * in `check`/`assign_role`/`remove_role`); we dedupe by class name.
  *
- * Variant parameter types are restored from the operation's request-body
- * model when available, since the IR's variant-level type info can fall back
- * to plain primitives and lose enum/array fidelity.
+ * Variant parameter types are taken from the IR's leaf type. When the IR's
+ * leaf is a bare primitive but the request body model has a richer type
+ * (array/enum/model/map), we fall back to the body type to recover fidelity
+ * the IR drops. Body nullability is stripped — when a parameter group is
+ * optional, the body field for the group becomes nullable, but within a
+ * variant the leaf is always required (selecting the variant means passing it).
  */
 function collectVariants(operations: Operation[], models: Model[]): CollectedVariant[] {
   const seen = new Set<string>();
@@ -82,13 +85,34 @@ function collectVariants(operations: Operation[], models: Model[]): CollectedVar
           variantName: variant.name,
           parameters: variant.parameters.map((p) => ({
             name: p.name,
-            type: bodyFieldTypes.get(p.name) ?? p.type,
+            type: pickVariantParamType(p.type, bodyFieldTypes.get(p.name)),
           })),
         });
       }
     }
   }
   return out;
+}
+
+/**
+ * Pick the type for a variant leaf parameter.
+ *
+ * Prefer the IR's leaf type. Use the body model's type only when the IR is a
+ * bare primitive but the body has a structured type — that's the original
+ * fidelity-recovery case the body fallback was added for. Strip any outer
+ * nullable from the body type, since body nullability reflects the parent
+ * group's optionality, not the leaf's required-ness within the variant.
+ */
+function pickVariantParamType(irType: TypeRef, bodyType: TypeRef | undefined): TypeRef {
+  if (!bodyType) return irType;
+  const unwrappedBody = bodyType.kind === 'nullable' ? bodyType.inner : bodyType;
+  const bodyIsStructured =
+    unwrappedBody.kind === 'array' ||
+    unwrappedBody.kind === 'enum' ||
+    unwrappedBody.kind === 'model' ||
+    unwrappedBody.kind === 'map';
+  if (irType.kind === 'primitive' && bodyIsStructured) return unwrappedBody;
+  return irType;
 }
 
 function readableName(name: string): string {

--- a/src/ruby/parameter-groups.ts
+++ b/src/ruby/parameter-groups.ts
@@ -1,0 +1,201 @@
+import type { Service, EmitterContext, GeneratedFile, Operation, TypeRef, Model } from '@workos/oagen';
+import { className, fieldName, groupVariantClassName, groupVariantFileName } from './naming.js';
+import { mapTypeRef as mapYardType, mapTypeRefForYard } from './type-map.js';
+import { collectBodyFieldTypes } from '../shared/resolved-ops.js';
+
+/**
+ * Sorbet type string for a TypeRef. Mirrors `mapSorbetType` in rbi.ts but
+ * lives here so the parameter-groups module is self-contained.
+ */
+function mapSorbetType(ref: TypeRef): string {
+  switch (ref.kind) {
+    case 'primitive':
+      switch (ref.type) {
+        case 'string':
+          return 'String';
+        case 'integer':
+          return 'Integer';
+        case 'number':
+          return 'Float';
+        case 'boolean':
+          return 'T::Boolean';
+        case 'unknown':
+          return 'T.untyped';
+      }
+      break;
+    case 'array':
+      return `T::Array[${mapSorbetType(ref.items)}]`;
+    case 'model':
+      return `WorkOS::${className(ref.name)}`;
+    case 'enum':
+      return 'String';
+    case 'nullable':
+      return `T.nilable(${mapSorbetType(ref.inner)})`;
+    case 'literal':
+      if (typeof ref.value === 'string') return 'String';
+      if (ref.value === null) return 'NilClass';
+      if (typeof ref.value === 'number') return Number.isInteger(ref.value) ? 'Integer' : 'Float';
+      return 'T::Boolean';
+    case 'union': {
+      const variants = ref.variants.map((v) => mapSorbetType(v));
+      const unique = [...new Set(variants)];
+      if (unique.length === 1) return unique[0];
+      return `T.any(${unique.join(', ')})`;
+    }
+    case 'map':
+      return `T::Hash[String, ${mapSorbetType(ref.valueType)}]`;
+  }
+  return 'T.untyped';
+}
+
+interface CollectedVariant {
+  className: string;
+  fileName: string;
+  groupName: string;
+  variantName: string;
+  parameters: { name: string; type: TypeRef }[];
+}
+
+/**
+ * Walk every operation, collect each unique parameter-group variant once.
+ * The same group name can appear in multiple operations (e.g. `resource_target`
+ * in `check`/`assign_role`/`remove_role`); we dedupe by class name.
+ *
+ * Variant parameter types are restored from the operation's request-body
+ * model when available, since the IR's variant-level type info can fall back
+ * to plain primitives and lose enum/array fidelity.
+ */
+function collectVariants(operations: Operation[], models: Model[]): CollectedVariant[] {
+  const seen = new Set<string>();
+  const out: CollectedVariant[] = [];
+  for (const op of operations) {
+    const bodyFieldTypes = collectBodyFieldTypes(op, models);
+    for (const group of op.parameterGroups ?? []) {
+      for (const variant of group.variants) {
+        const cls = groupVariantClassName(group.name, variant.name);
+        if (seen.has(cls)) continue;
+        seen.add(cls);
+        out.push({
+          className: cls,
+          fileName: groupVariantFileName(group.name, variant.name),
+          groupName: group.name,
+          variantName: variant.name,
+          parameters: variant.parameters.map((p) => ({
+            name: p.name,
+            type: bodyFieldTypes.get(p.name) ?? p.type,
+          })),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function readableName(name: string): string {
+  return name.replace(/_/g, ' ');
+}
+
+/**
+ * Generate a `Data.define` class file for each unique parameter-group variant
+ * referenced by any service's operations. Files are emitted alongside models
+ * under `lib/workos/<variant>.rb` so Zeitwerk autoloads them.
+ */
+export function generateParameterGroupClasses(services: Service[], _ctx: EmitterContext): GeneratedFile[] {
+  const operations = services.flatMap((s) => s.operations);
+  const models = (_ctx.spec.models as Model[]) ?? [];
+  const variants = collectVariants(operations, models);
+
+  const files: GeneratedFile[] = [];
+  for (const v of variants) {
+    const lines: string[] = [];
+    lines.push('module WorkOS');
+    lines.push(`  # Identifies the ${readableName(v.groupName)} (${readableName(v.variantName)} variant).`);
+    lines.push('  #');
+    for (const p of v.parameters) {
+      const yardType = mapTypeRefForYard(p.type);
+      lines.push(`  # @!attribute [r] ${fieldName(p.name)}`);
+      lines.push(`  #   @return [${yardType}]`);
+    }
+    if (v.parameters.length === 0) {
+      lines.push(`  ${v.className} = Data.define`);
+    } else {
+      const fields = v.parameters.map((p) => `:${fieldName(p.name)}`).join(', ');
+      lines.push(`  ${v.className} = Data.define(${fields})`);
+    }
+    lines.push('end');
+    files.push({
+      path: `lib/workos/${v.fileName}.rb`,
+      content: lines.join('\n'),
+      integrateTarget: true,
+      overwriteExisting: true,
+    });
+  }
+  return files;
+}
+
+/**
+ * Generate a Sorbet `.rbi` file for each variant class. Mirrors the shape
+ * used by `rbi/workos/types/api_response.rbi`.
+ */
+export function generateParameterGroupRbi(services: Service[], ctx: EmitterContext): GeneratedFile[] {
+  const operations = services.flatMap((s) => s.operations);
+  const models = (ctx.spec.models as Model[]) ?? [];
+  const variants = collectVariants(operations, models);
+
+  const files: GeneratedFile[] = [];
+  for (const v of variants) {
+    const lines: string[] = [];
+    lines.push('# typed: strong');
+    lines.push('');
+    lines.push('module WorkOS');
+    lines.push(`  class ${v.className}`);
+    for (const p of v.parameters) {
+      lines.push(`    sig { returns(${mapSorbetType(p.type)}) }`);
+      lines.push(`    def ${fieldName(p.name)}; end`);
+      lines.push('');
+    }
+    if (v.parameters.length === 0) {
+      lines.push(`    sig { returns(WorkOS::${v.className}) }`);
+      lines.push(`    def self.new; end`);
+    } else {
+      lines.push('    sig do');
+      lines.push('      params(');
+      for (let i = 0; i < v.parameters.length; i++) {
+        const p = v.parameters[i];
+        const sep = i === v.parameters.length - 1 ? '' : ',';
+        lines.push(`        ${fieldName(p.name)}: ${mapSorbetType(p.type)}${sep}`);
+      }
+      lines.push(`      ).returns(WorkOS::${v.className})`);
+      lines.push('    end');
+      const kwargs = v.parameters.map((p) => `${fieldName(p.name)}:`).join(', ');
+      lines.push(`    def self.new(${kwargs}); end`);
+    }
+    lines.push('  end');
+    lines.push('end');
+    files.push({
+      path: `rbi/workos/${v.fileName}.rbi`,
+      content: lines.join('\n'),
+      integrateTarget: true,
+      overwriteExisting: true,
+    });
+  }
+  return files;
+}
+
+/**
+ * Build the YARD type-tag union string for a parameter group's kwarg.
+ * E.g., `[WorkOS::PasswordPlaintext, WorkOS::PasswordHashed]`.
+ */
+export function groupYardUnion(group: { name: string; variants: { name: string }[] }): string {
+  void mapYardType;
+  return group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`).join(', ');
+}
+
+/**
+ * Build the Sorbet `T.any(...)` type for a parameter group's kwarg.
+ */
+export function groupSorbetUnion(group: { name: string; variants: { name: string }[] }): string {
+  const variants = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`);
+  if (variants.length === 1) return variants[0];
+  return `T.any(${variants.join(', ')})`;
+}

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -1,6 +1,6 @@
 import type { ApiSpec, EmitterContext, GeneratedFile, TypeRef, Model } from '@workos/oagen';
 import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
-import { className, fieldName, fileName, safeParamName, resolveMethodName } from './naming.js';
+import { className, fieldName, fileName, groupVariantClassName, safeParamName, resolveMethodName } from './naming.js';
 import {
   buildResolvedLookup,
   groupByMount,
@@ -153,9 +153,22 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
       const hiddenParams = buildHiddenParams(resolved);
       const groupedParamNames = collectGroupedParamNames(op);
       const queryParams = (op.queryParams ?? []).filter((q) => !groupedParamNames.has(q.name));
-      const bodyFields = getRequestBodyFieldsFlat(op, hiddenParams, modelByName);
+      // Drop body fields that collide with a parameter-group name; the group
+      // dispatcher kwarg handles them. See ruby/resources.ts for the matching
+      // filter on the runtime side.
+      const bodyFields = getRequestBodyFieldsFlat(op, hiddenParams, modelByName).filter(
+        (f) => !groupedParamNames.has(f.name),
+      );
+      const parameterGroups = op.parameterGroups ?? [];
+      const groupSorbetType = (group: (typeof parameterGroups)[number]): string => {
+        const variants = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`);
+        if (variants.length === 1) return variants[0];
+        return `T.any(${variants.join(', ')})`;
+      };
 
-      // Build parameter list for sig
+      // Build parameter list for sig. Order mirrors the runtime emitter:
+      // path → required body → required query → required groups → optional
+      // body → optional query → optional groups → request_options.
       const sigParams: string[] = [];
       const seen = new Set<string>();
 
@@ -181,6 +194,13 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
         seen.add(n);
         sigParams.push(`${n}: ${mapSorbetType(q.type)}`);
       }
+      for (const group of parameterGroups) {
+        if (group.optional) continue;
+        const n = fieldName(group.name);
+        if (seen.has(n)) continue;
+        seen.add(n);
+        sigParams.push(`${n}: ${groupSorbetType(group)}`);
+      }
       for (const f of bodyFields) {
         if (hiddenParams.has(f.name)) continue;
         if (f.required) continue;
@@ -196,6 +216,13 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
         if (seen.has(n)) continue;
         seen.add(n);
         sigParams.push(`${n}: T.nilable(${unwrapNilable(mapSorbetType(q.type))})`);
+      }
+      for (const group of parameterGroups) {
+        if (!group.optional) continue;
+        const n = fieldName(group.name);
+        if (seen.has(n)) continue;
+        seen.add(n);
+        sigParams.push(`${n}: T.nilable(${groupSorbetType(group)})`);
       }
       sigParams.push('request_options: T::Hash[Symbol, T.untyped]');
 

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -1,6 +1,13 @@
 import type { ApiSpec, EmitterContext, GeneratedFile, TypeRef, Model } from '@workos/oagen';
 import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
-import { className, fieldName, fileName, groupVariantClassName, safeParamName, resolveMethodName } from './naming.js';
+import {
+  className,
+  fieldName,
+  fileName,
+  safeParamName,
+  scopedGroupVariantClassName,
+  resolveMethodName,
+} from './naming.js';
 import {
   buildResolvedLookup,
   groupByMount,
@@ -9,6 +16,7 @@ import {
   collectGroupedParamNames,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
+import { buildGroupOwnerMap, collectVariantsForMountTarget, emitInlineVariantRbi } from './parameter-groups.js';
 
 /**
  * Map an IR TypeRef to a Sorbet type string for RBI files.
@@ -120,6 +128,7 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
   for (const m of spec.models as Model[]) {
     if (isListWrapperModel(m)) listWrapperModels.set(m.name, m);
   }
+  const groupOwners = buildGroupOwnerMap(ctx);
 
   for (const [mountTarget, group] of groups) {
     const cls = className(mountTarget);
@@ -128,6 +137,15 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
     lines.push('');
     lines.push('module WorkOS');
     lines.push(`  class ${cls}`);
+
+    // Inline parameter-group variant RBI blocks owned by this mount target.
+    // Mirrors the runtime `class ... PasswordPlaintext = Data.define(...) end`
+    // layout in lib/workos/<service>.rb.
+    const variants = collectVariantsForMountTarget(ctx, spec.models as Model[], mountTarget);
+    for (const v of variants) {
+      for (const line of emitInlineVariantRbi(v)) lines.push(line);
+      lines.push('');
+    }
 
     lines.push('    sig { params(client: WorkOS::BaseClient).void }');
     lines.push('    def initialize(client); end');
@@ -161,7 +179,11 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
       );
       const parameterGroups = op.parameterGroups ?? [];
       const groupSorbetType = (group: (typeof parameterGroups)[number]): string => {
-        const variants = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`);
+        const owner = groupOwners.get(group.name);
+        if (!owner) {
+          throw new Error(`No owner mount target found for parameter group '${group.name}'`);
+        }
+        const variants = group.variants.map((v) => scopedGroupVariantClassName(owner, group.name, v.name));
         if (variants.length === 1) return variants[0];
         return `T.any(${variants.join(', ')})`;
       };

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -4,10 +4,10 @@ import {
   className,
   fieldName,
   fileName,
-  groupVariantClassName,
   methodName,
   safeParamName,
   resolveMethodName,
+  scopedGroupVariantClassName,
 } from './naming.js';
 import { mapTypeRefForYard } from './type-map.js';
 import {
@@ -21,6 +21,7 @@ import {
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel } from '../shared/model-utils.js';
 import { generateWrapperMethods, collectWrapperResponseModels } from './wrappers.js';
+import { buildGroupOwnerMap, collectVariantsForMountTarget, emitInlineVariantClass } from './parameter-groups.js';
 
 /**
  * Generate Ruby resource (service) classes from IR services.
@@ -42,6 +43,11 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   for (const m of ctx.spec.models as Model[]) {
     if (isListWrapperModel(m)) listWrapperModels.set(m.name, m);
   }
+
+  // Resolve groupName -> owner mountTarget once per generation pass; every
+  // dispatcher and YARD `@param` reference resolves variant classes through
+  // this map so cross-resource references stay consistent.
+  const groupOwners = buildGroupOwnerMap(ctx);
 
   for (const [mountTarget, group] of groups) {
     const cls = className(mountTarget);
@@ -96,6 +102,7 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
         modelByName,
         listWrapperModels,
         requires,
+        groupOwners,
       });
       methodBodies.push(body);
 
@@ -129,6 +136,18 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
     }
     lines.push('module WorkOS');
     lines.push(`  class ${cls}`);
+
+    // Inline parameter-group variant classes owned by this mount target.
+    // Zeitwerk's `loader.collapse` flattens `lib/workos/<service>/` so files
+    // there can't define `WorkOS::<Service>::*` constants — variants must
+    // live inside the service's own file. Matches Python's per-resource
+    // dataclass layout.
+    const variants = collectVariantsForMountTarget(ctx, ctx.spec.models as Model[], mountTarget);
+    for (const v of variants) {
+      for (const line of emitInlineVariantClass(v)) lines.push(line);
+      lines.push('');
+    }
+
     lines.push('    def initialize(client)');
     lines.push('      @client = client');
     lines.push('    end');
@@ -162,6 +181,7 @@ function emitMethod(args: {
   modelByName: Map<string, Model>;
   listWrapperModels: Map<string, Model>;
   requires: Set<string>;
+  groupOwners: Map<string, string>;
 }): string {
   const {
     op,
@@ -174,8 +194,18 @@ function emitMethod(args: {
     modelByName,
     listWrapperModels,
     requires,
+    groupOwners,
   } = args;
   void enumNames;
+
+  /** Fully-qualified Ruby constant for a variant (e.g. WorkOS::UserManagement::PasswordPlaintext). */
+  const variantClassRef = (group: { name: string }, variantName: string): string => {
+    const owner = groupOwners.get(group.name);
+    if (!owner) {
+      throw new Error(`No owner mount target found for parameter group '${group.name}'`);
+    }
+    return scopedGroupVariantClassName(owner, group.name, variantName);
+  };
 
   const plan = planOperation(op);
   const lines: string[] = [];
@@ -280,7 +310,16 @@ function emitMethod(args: {
   sigParts.push('request_options: {}');
 
   // YARD docs.
-  const doc = buildYardDoc(op, pathParams, queryParams, bodyFields, hiddenParams, bodyFieldRenames, listWrapperModels);
+  const doc = buildYardDoc(
+    op,
+    pathParams,
+    queryParams,
+    bodyFields,
+    hiddenParams,
+    bodyFieldRenames,
+    listWrapperModels,
+    variantClassRef,
+  );
   for (const line of doc) lines.push(`    ${line}`);
 
   // Signature.
@@ -347,14 +386,14 @@ function emitMethod(args: {
           lines.push(`      case ${prop}`);
         }
         for (const variant of group.variants) {
-          const variantClass = `WorkOS::${groupVariantClassName(group.name, variant.name)}`;
+          const variantClass = variantClassRef(group, variant.name);
           lines.push(`      when ${variantClass}`);
           for (const p of variant.parameters) {
             lines.push(`        params[${rubyStringLit(p.name)}] = ${prop}.${fieldName(p.name)}`);
           }
         }
         lines.push(`      else`);
-        lines.push(`        raise ArgumentError, ${dispatchErrorLiteral(group, prop)}`);
+        lines.push(`        raise ArgumentError, ${dispatchErrorLiteral(group, prop, variantClassRef)}`);
         lines.push('      end');
         if (group.optional) {
           lines.push('      end');
@@ -411,14 +450,14 @@ function emitMethod(args: {
           lines.push(`      case ${prop}`);
         }
         for (const variant of group.variants) {
-          const variantClass = `WorkOS::${groupVariantClassName(group.name, variant.name)}`;
+          const variantClass = variantClassRef(group, variant.name);
           lines.push(`      when ${variantClass}`);
           for (const p of variant.parameters) {
             lines.push(`        body[${rubyStringLit(p.name)}] = ${prop}.${fieldName(p.name)}`);
           }
         }
         lines.push(`      else`);
-        lines.push(`        raise ArgumentError, ${dispatchErrorLiteral(group, prop)}`);
+        lines.push(`        raise ArgumentError, ${dispatchErrorLiteral(group, prop, variantClassRef)}`);
         lines.push('      end');
         if (group.optional) {
           lines.push('      end');
@@ -754,8 +793,9 @@ function buildYardDoc(
   queryParams: Parameter[],
   bodyFields: { name: string; required: boolean; type: TypeRef; description?: string; deprecated?: boolean }[],
   hiddenParams: Set<string>,
-  bodyFieldRenames?: Map<string, string>,
-  listWrapperModels?: Map<string, Model>,
+  bodyFieldRenames: Map<string, string> | undefined,
+  listWrapperModels: Map<string, Model> | undefined,
+  variantClassRef: (group: { name: string }, variantName: string) => string,
 ): string[] {
   const lines: string[] = [];
   const summary = op.description ?? `${op.httpMethod.toUpperCase()} ${op.path}`;
@@ -805,7 +845,7 @@ function buildYardDoc(
     const n = fieldName(group.name);
     if (emittedParamNames.has(n)) continue;
     emittedParamNames.add(n);
-    const variantTypes = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`).join(', ');
+    const variantTypes = group.variants.map((v) => variantClassRef(group, v.name)).join(', ');
     const suffix = group.optional ? ', nil' : '';
     lines.push(`# @param ${n} [${variantTypes}${suffix}] Identifies the ${group.name.replace(/_/g, ' ')}.`);
   }
@@ -848,7 +888,11 @@ function rubyStringLit(s: string): string {
  * arm of a parameter-group dispatcher. Lists the expected variant classes and
  * interpolates the actual class of the value the caller passed.
  */
-function dispatchErrorLiteral(group: { name: string; variants: { name: string }[] }, prop: string): string {
-  const expected = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`).join(', ');
+function dispatchErrorLiteral(
+  group: { name: string; variants: { name: string }[] },
+  prop: string,
+  variantClassRef: (group: { name: string }, variantName: string) => string,
+): string {
+  const expected = group.variants.map((v) => variantClassRef(group, v.name)).join(', ');
   return `"expected ${prop} to be one of: ${expected}, got #{${prop}.class}"`;
 }

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -1,6 +1,14 @@
 import type { Service, EmitterContext, GeneratedFile, Operation, TypeRef, Parameter, Model } from '@workos/oagen';
 import { planOperation } from '@workos/oagen';
-import { className, fieldName, fileName, methodName, safeParamName, resolveMethodName } from './naming.js';
+import {
+  className,
+  fieldName,
+  fileName,
+  groupVariantClassName,
+  methodName,
+  safeParamName,
+  resolveMethodName,
+} from './naming.js';
 import { mapTypeRefForYard } from './type-map.js';
 import {
   buildResolvedLookup,
@@ -177,8 +185,11 @@ function emitMethod(args: {
   const groupedParamNames = collectGroupedParamNames(op);
   const queryParams = (op.queryParams ?? []).filter((q) => !groupedParamNames.has(q.name));
 
-  // Request body params: if body is a model, expand its fields.
-  const bodyFields = getRequestBodyFields(op, hiddenParams, modelByName);
+  // Request body params: if body is a model, expand its fields. Drop any field
+  // whose name is also a parameter-group name — those are dispatched by the
+  // group kwarg below, so emitting them as flat kwargs would shadow the group
+  // and cause `String#[Symbol]` TypeErrors when the dispatcher reads `:type`.
+  const bodyFields = getRequestBodyFields(op, hiddenParams, modelByName).filter((f) => !groupedParamNames.has(f.name));
 
   // Detect path/body name collisions and build a rename map for body fields.
   // When a body field's snake_case name matches a path param, prefix with "body_"
@@ -318,19 +329,22 @@ function emitMethod(args: {
     lines.push('      }.compact');
 
     if (groupsGoToQuery) {
-      // Parameter group dispatch: merge grouped params into the query hash
+      // Parameter group dispatch: callers pass a typed variant class instance
+      // (e.g. `WorkOS::ParentResourceById`); we pattern-match on its class
+      // and forward its readers into the query hash.
       for (const group of op.parameterGroups ?? []) {
         const prop = fieldName(group.name);
         if (group.optional) {
           lines.push(`      if ${prop}`);
-          lines.push(`        case ${prop}[:type]`);
+          lines.push(`        case ${prop}`);
         } else {
-          lines.push(`      case ${prop}[:type]`);
+          lines.push(`      case ${prop}`);
         }
         for (const variant of group.variants) {
-          lines.push(`      when ${rubyStringLit(variant.name)}`);
+          const variantClass = `WorkOS::${groupVariantClassName(group.name, variant.name)}`;
+          lines.push(`      when ${variantClass}`);
           for (const p of variant.parameters) {
-            lines.push(`        params[${rubyStringLit(p.name)}] = ${prop}[:${fieldName(p.name)}]`);
+            lines.push(`        params[${rubyStringLit(p.name)}] = ${prop}.${fieldName(p.name)}`);
           }
         }
         lines.push('      end');
@@ -369,19 +383,21 @@ function emitMethod(args: {
     // Parameter group dispatch into body for POST/PUT/PATCH so sensitive
     // fields (passwords, role slugs) never leak into the URL query string.
     // DELETE groups are already handled via query above (groupsGoToQuery).
+    // Callers pass a typed variant class instance and we pattern-match on it.
     if (hasGroups && hasBodyMethod) {
       for (const group of op.parameterGroups ?? []) {
         const prop = fieldName(group.name);
         if (group.optional) {
           lines.push(`      if ${prop}`);
-          lines.push(`        case ${prop}[:type]`);
+          lines.push(`        case ${prop}`);
         } else {
-          lines.push(`      case ${prop}[:type]`);
+          lines.push(`      case ${prop}`);
         }
         for (const variant of group.variants) {
-          lines.push(`      when ${rubyStringLit(variant.name)}`);
+          const variantClass = `WorkOS::${groupVariantClassName(group.name, variant.name)}`;
+          lines.push(`      when ${variantClass}`);
           for (const p of variant.parameters) {
-            lines.push(`        body[${rubyStringLit(p.name)}] = ${prop}[:${fieldName(p.name)}]`);
+            lines.push(`        body[${rubyStringLit(p.name)}] = ${prop}.${fieldName(p.name)}`);
           }
         }
         lines.push('      end');
@@ -763,6 +779,16 @@ function buildYardDoc(
     const suffix = q.required || alreadyNilable ? '' : ', nil';
     const deprecatedPrefix = q.deprecated ? '(deprecated) ' : '';
     lines.push(`# @param ${n} [${type}${suffix}] ${deprecatedPrefix}${oneLine(q.description)}`.trim());
+  }
+  // Parameter group kwargs: the type bracket lists the variant classes the
+  // caller may pass; no extra prose needed since YARD already renders them.
+  for (const group of op.parameterGroups ?? []) {
+    const n = fieldName(group.name);
+    if (emittedParamNames.has(n)) continue;
+    emittedParamNames.add(n);
+    const variantTypes = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`).join(', ');
+    const suffix = group.optional ? ', nil' : '';
+    lines.push(`# @param ${n} [${variantTypes}${suffix}] Identifies the ${group.name.replace(/_/g, ' ')}.`);
   }
   lines.push(`# @param request_options [Hash] (see WorkOS::Types::RequestOptions)`);
 

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -347,6 +347,8 @@ function emitMethod(args: {
             lines.push(`        params[${rubyStringLit(p.name)}] = ${prop}.${fieldName(p.name)}`);
           }
         }
+        lines.push(`      else`);
+        lines.push(`        raise ArgumentError, ${dispatchErrorLiteral(group, prop)}`);
         lines.push('      end');
         if (group.optional) {
           lines.push('      end');
@@ -404,6 +406,8 @@ function emitMethod(args: {
             lines.push(`        body[${rubyStringLit(p.name)}] = ${prop}.${fieldName(p.name)}`);
           }
         }
+        lines.push(`      else`);
+        lines.push(`        raise ArgumentError, ${dispatchErrorLiteral(group, prop)}`);
         lines.push('      end');
         if (group.optional) {
           lines.push('      end');
@@ -826,4 +830,14 @@ void methodName;
 /** Render a Ruby single-quoted string literal, escaping embedded quotes and backslashes. */
 function rubyStringLit(s: string): string {
   return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+/**
+ * Build a Ruby double-quoted string expression for the `else raise ArgumentError`
+ * arm of a parameter-group dispatcher. Lists the expected variant classes and
+ * interpolates the actual class of the value the caller passed.
+ */
+function dispatchErrorLiteral(group: { name: string; variants: { name: string }[] }, prop: string): string {
+  const expected = group.variants.map((v) => `WorkOS::${groupVariantClassName(group.name, v.name)}`).join(', ');
+  return `"expected ${prop} to be one of: ${expected}, got #{${prop}.class}"`;
 }

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -320,13 +320,19 @@ function emitMethod(args: {
   const groupsGoToQuery = hasGroups && !hasBodyMethod;
   const hasQuery = qEntries.length > 0 || groupsGoToQuery;
   if (hasQuery) {
+    // Skip `.compact` when no entry can be nil — required kwargs are always
+    // passed (Ruby raises ArgumentError otherwise), so the literal has no nil
+    // values to drop. Group dispatch happens after the literal is built and
+    // doesn't contribute potentially-nil entries either.
+    const queryHasNilable = qEntries.some((q) => !q.required);
+    const queryCompact = queryHasNilable ? '.compact' : '';
     lines.push('      params = {');
     for (let i = 0; i < qEntries.length; i++) {
       const q = qEntries[i];
       const sep = i === qEntries.length - 1 && !groupsGoToQuery ? '' : ',';
       lines.push(`        ${rubyStringLit(q.name)} => ${safeParamName(q.name)}${sep}`);
     }
-    lines.push('      }.compact');
+    lines.push(`      }${queryCompact}`);
 
     if (groupsGoToQuery) {
       // Parameter group dispatch: callers pass a typed variant class instance
@@ -375,16 +381,21 @@ function emitMethod(args: {
       const optKey = fc === 'client_secret' ? 'api_key' : fc;
       bodyEntries.push(`${rubyStringLit(fc)} => (request_options[:${optKey}] || @client.${clientProp})`);
     }
+    // Track whether any literal entry can be nil — defaults/inferFromClient
+    // resolve to non-nil values, so only optional body kwargs are nilable.
+    let bodyHasNilable = false;
     for (const f of bodyFields) {
       if (hiddenParams.has(f.name)) continue;
       bodyEntries.push(`${rubyStringLit(f.name)} => ${bodyKwargName(f.name)}`);
+      if (!f.required) bodyHasNilable = true;
     }
+    const bodyCompact = bodyHasNilable ? '.compact' : '';
     lines.push('      body = {');
     for (let i = 0; i < bodyEntries.length; i++) {
       const sep = i === bodyEntries.length - 1 ? '' : ',';
       lines.push(`        ${bodyEntries[i]}${sep}`);
     }
-    lines.push('      }.compact');
+    lines.push(`      }${bodyCompact}`);
 
     // Parameter group dispatch into body for POST/PUT/PATCH so sensitive
     // fields (passwords, role slugs) never leak into the URL query string.

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -355,8 +355,12 @@ function emitMethod(args: {
     }
   }
 
-  // Request body
-  const hasBody = bodyFields.length > 0 && !['get', 'head'].includes(method_http);
+  // Request body. Emit when there are non-group body fields OR a parameter
+  // group dispatches into the body — the latter case matters when an
+  // operation's body is exclusively managed by a group (e.g.
+  // update_organization_membership's `role`), where filtering the group's
+  // leaves leaves bodyFields empty but the request still needs a payload.
+  const hasBody = (bodyFields.length > 0 && !['get', 'head'].includes(method_http)) || (hasGroups && hasBodyMethod);
 
   if (hasBody) {
     const bodyEntries: string[] = [];

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -101,6 +101,38 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
       }
       lines.push('  end');
 
+      // Per-variant tests: for every parameter group with more than one
+      // variant, emit one extra test per non-first variant so the second/third
+      // arm of the dispatcher gets exercised. Without this, a wrong wire-name
+      // mapping in (e.g.) ResourceTargetByExternalId would slip through.
+      for (const group of op.parameterGroups ?? []) {
+        for (let vi = 1; vi < group.variants.length; vi++) {
+          const variant = group.variants[vi];
+          const overrides = new Map<string, number>([[group.name, vi]]);
+          const variantCallArgs = buildCallArgsStub(op, modelByName, hiddenParams, overrides);
+          const variantBodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams, overrides);
+          const suffix = `with_${fieldName(group.name)}_${fieldName(variant.name)}`;
+          lines.push('');
+          lines.push(`  def test_${method}_${suffix}_returns_expected_result`);
+          lines.push(`    stub_request(${httpMethodSym}, ${stubRegex})`);
+          if (variantBodyMatcher) lines.push(`      .with(body: ${variantBodyMatcher})`);
+          if (isList) {
+            lines.push(`      .to_return(body: '{"data": [], "list_metadata": {}}', status: 200)`);
+            lines.push(`    result = @client.${prop}.${method}(${variantCallArgs})`);
+            lines.push('    assert_kind_of WorkOS::Types::ListStruct, result');
+          } else if (op.response.kind === 'primitive') {
+            lines.push(`      .to_return(body: "{}", status: 200)`);
+            lines.push(`    result = @client.${prop}.${method}(${variantCallArgs})`);
+            lines.push('    assert_nil result');
+          } else {
+            lines.push(`      .to_return(body: "{}", status: 200)`);
+            lines.push(`    result = @client.${prop}.${method}(${variantCallArgs})`);
+            lines.push('    refute_nil result');
+          }
+          lines.push('  end');
+        }
+      }
+
       // Wrapper tests (union split variants).
       if (resolved?.wrappers && resolved.wrappers.length > 0) {
         for (const wrapper of resolved.wrappers) {
@@ -286,8 +318,17 @@ function roundTripStub(ref: TypeRef, enumNames: Set<string>): string {
   }
 }
 
-/** Build minimal placeholder arguments for calling the SDK method from a test. */
-function buildCallArgsStub(op: Operation, modelByName: Map<string, Model>, hiddenParams: Set<string>): string {
+/** Build minimal placeholder arguments for calling the SDK method from a test.
+ *  `variantOverrides` selects a non-zero variant index per group; absent groups
+ *  default to variant 0. Used to emit per-variant test cases that exercise the
+ *  second/third arm of each parameter-group dispatcher.
+ */
+function buildCallArgsStub(
+  op: Operation,
+  modelByName: Map<string, Model>,
+  hiddenParams: Set<string>,
+  variantOverrides: Map<string, number> = new Map(),
+): string {
   const parts: string[] = [];
   const seen = new Set<string>();
 
@@ -339,10 +380,11 @@ function buildCallArgsStub(op: Operation, modelByName: Map<string, Model>, hidde
     const name = fieldName(group.name);
     if (seen.has(name)) continue;
     seen.add(name);
-    const firstVariant = group.variants[0];
-    if (firstVariant) {
-      const variantClass = `WorkOS::${groupVariantClassName(group.name, firstVariant.name)}`;
-      const fieldStubs = firstVariant.parameters.map((p) => `${fieldName(p.name)}: ${stubValueFor(p.type)}`).join(', ');
+    const idx = variantOverrides.get(group.name) ?? 0;
+    const variant = group.variants[idx];
+    if (variant) {
+      const variantClass = `WorkOS::${groupVariantClassName(group.name, variant.name)}`;
+      const fieldStubs = variant.parameters.map((p) => `${fieldName(p.name)}: ${stubValueFor(p.type)}`).join(', ');
       parts.push(`${name}: ${variantClass}.new(${fieldStubs})`);
     }
   }
@@ -361,7 +403,12 @@ function buildCallArgsStub(op: Operation, modelByName: Map<string, Model>, hidde
  * catches regressions where the dispatcher silently drops a passed group
  * (the original `update_organization_membership` regression).
  */
-function buildBodyMatcher(op: Operation, modelByName: Map<string, Model>, hiddenParams: Set<string>): string | null {
+function buildBodyMatcher(
+  op: Operation,
+  modelByName: Map<string, Model>,
+  hiddenParams: Set<string>,
+  variantOverrides: Map<string, number> = new Map(),
+): string | null {
   const httpMethod = op.httpMethod.toLowerCase();
   const hasBodyMethod = !['get', 'head', 'delete'].includes(httpMethod);
   const hasGroups = (op.parameterGroups?.length ?? 0) > 0;
@@ -389,11 +436,12 @@ function buildBodyMatcher(op: Operation, modelByName: Map<string, Model>, hidden
     }
   }
 
-  // First variant of each group: its leaves get pumped into the body.
+  // Selected variant of each group: its leaves get pumped into the body.
   for (const group of op.parameterGroups ?? []) {
-    const firstVariant = group.variants[0];
-    if (!firstVariant) continue;
-    for (const p of firstVariant.parameters) {
+    const idx = variantOverrides.get(group.name) ?? 0;
+    const variant = group.variants[idx];
+    if (!variant) continue;
+    for (const p of variant.parameters) {
       entries.push(`"${p.name}" => ${stubValueFor(p.type)}`);
     }
   }

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -8,10 +8,16 @@ import {
   servicePropertyName,
   resolveMethodName,
 } from './naming.js';
-import { buildResolvedLookup, groupByMount, lookupResolved, buildHiddenParams } from '../shared/resolved-ops.js';
+import {
+  buildResolvedLookup,
+  groupByMount,
+  lookupResolved,
+  buildHiddenParams,
+  collectBodyFieldTypes,
+} from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
-import { buildGroupOwnerMap } from './parameter-groups.js';
+import { buildGroupOwnerMap, pickVariantParamType } from './parameter-groups.js';
 
 /**
  * Generate Ruby Minitest test files for each service and per-method.
@@ -26,8 +32,9 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   const files: GeneratedFile[] = [];
 
   const groups = groupByMount(ctx);
+  const models = spec.models as Model[];
   const modelByName = new Map<string, Model>();
-  for (const m of spec.models as Model[]) modelByName.set(m.name, m);
+  for (const m of models) modelByName.set(m.name, m);
 
   const lookup = buildResolvedLookup(ctx);
   const groupOwners = buildGroupOwnerMap(ctx);
@@ -78,8 +85,8 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
 
       const resolved = lookupResolved(op, lookup);
       const hiddenParams = buildHiddenParams(resolved);
-      const callArgs = buildCallArgsStub(op, modelByName, hiddenParams, groupOwners);
-      const bodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams);
+      const callArgs = buildCallArgsStub(op, modelByName, hiddenParams, groupOwners, models);
+      const bodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams, models);
 
       // Collect method info for the parameterized 401 test (T20).
       authMethodManifest.push({ method, httpMethodSym, stubUrl, callArgs });
@@ -111,8 +118,8 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
         for (let vi = 1; vi < group.variants.length; vi++) {
           const variant = group.variants[vi];
           const overrides = new Map<string, number>([[group.name, vi]]);
-          const variantCallArgs = buildCallArgsStub(op, modelByName, hiddenParams, groupOwners, overrides);
-          const variantBodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams, overrides);
+          const variantCallArgs = buildCallArgsStub(op, modelByName, hiddenParams, groupOwners, models, overrides);
+          const variantBodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams, models, overrides);
           const suffix = `with_${fieldName(group.name)}_${fieldName(variant.name)}`;
           lines.push('');
           lines.push(`  def test_${method}_${suffix}_returns_expected_result`);
@@ -330,6 +337,7 @@ function buildCallArgsStub(
   modelByName: Map<string, Model>,
   hiddenParams: Set<string>,
   groupOwners: Map<string, string>,
+  models: Model[],
   variantOverrides: Map<string, number> = new Map(),
 ): string {
   const parts: string[] = [];
@@ -379,6 +387,14 @@ function buildCallArgsStub(
   // variant's class. Optional groups are exercised too so the dispatcher
   // code path is covered — passing nothing would skip the body block and
   // hide silent-drop bugs (see workos/oagen-emitters#66).
+  //
+  // Variant param types are recovered from the body model: the IR's leaf type
+  // is often a bare primitive (`role_slugs: string`) even when the body model
+  // declares a richer shape (`Array<String>`). Stubbing without recovery would
+  // pass `"stub"` to `RoleMultiple.new(role_slugs:)` while the class signature
+  // declares `T::Array[String]` — the test passes locally but ships an invalid
+  // wire body the API rejects.
+  const bodyFieldTypes = collectBodyFieldTypes(op, models);
   for (const group of op.parameterGroups ?? []) {
     const name = fieldName(group.name);
     if (seen.has(name)) continue;
@@ -391,7 +407,9 @@ function buildCallArgsStub(
         throw new Error(`No owner mount target found for parameter group '${group.name}'`);
       }
       const variantClass = scopedGroupVariantClassName(owner, group.name, variant.name);
-      const fieldStubs = variant.parameters.map((p) => `${fieldName(p.name)}: ${stubValueFor(p.type)}`).join(', ');
+      const fieldStubs = variant.parameters
+        .map((p) => `${fieldName(p.name)}: ${stubValueFor(pickVariantParamType(p.type, bodyFieldTypes.get(p.name)))}`)
+        .join(', ');
       parts.push(`${name}: ${variantClass}.new(${fieldStubs})`);
     }
   }
@@ -414,6 +432,7 @@ function buildBodyMatcher(
   op: Operation,
   modelByName: Map<string, Model>,
   hiddenParams: Set<string>,
+  models: Model[],
   variantOverrides: Map<string, number> = new Map(),
 ): string | null {
   const httpMethod = op.httpMethod.toLowerCase();
@@ -443,13 +462,18 @@ function buildBodyMatcher(
     }
   }
 
-  // Selected variant of each group: its leaves get pumped into the body.
+  // Selected variant of each group: its leaves get pumped into the body. The
+  // matcher value must use the recovered (body-model) type, not the IR leaf —
+  // see buildCallArgsStub for the same reasoning. Without this, the matcher
+  // shape diverges from what the SDK actually sends.
+  const bodyFieldTypes = collectBodyFieldTypes(op, models);
   for (const group of op.parameterGroups ?? []) {
     const idx = variantOverrides.get(group.name) ?? 0;
     const variant = group.variants[idx];
     if (!variant) continue;
     for (const p of variant.parameters) {
-      entries.push(`"${p.name}" => ${stubValueFor(p.type)}`);
+      const recovered = pickVariantParamType(p.type, bodyFieldTypes.get(p.name));
+      entries.push(`"${p.name}" => ${stubValueFor(recovered)}`);
     }
   }
 
@@ -533,7 +557,10 @@ function stubValueFor(ref: TypeRef): string {
           return `nil`;
       }
     case 'array':
-      return `[]`;
+      // Single-element array — exercises the wire shape under hash_including
+      // matchers. An empty `[]` would match `"role_slugs": []` on the wire,
+      // hiding regressions where the SDK serializes the wrong type.
+      return `[${stubValueFor(ref.items)}]`;
     case 'map':
       return `{}`;
     case 'enum':

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -3,14 +3,15 @@ import {
   className,
   fileName,
   fieldName,
-  groupVariantClassName,
   safeParamName,
+  scopedGroupVariantClassName,
   servicePropertyName,
   resolveMethodName,
 } from './naming.js';
 import { buildResolvedLookup, groupByMount, lookupResolved, buildHiddenParams } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
+import { buildGroupOwnerMap } from './parameter-groups.js';
 
 /**
  * Generate Ruby Minitest test files for each service and per-method.
@@ -29,6 +30,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   for (const m of spec.models as Model[]) modelByName.set(m.name, m);
 
   const lookup = buildResolvedLookup(ctx);
+  const groupOwners = buildGroupOwnerMap(ctx);
 
   for (const [mountTarget, group] of groups) {
     const cls = className(mountTarget);
@@ -76,7 +78,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
 
       const resolved = lookupResolved(op, lookup);
       const hiddenParams = buildHiddenParams(resolved);
-      const callArgs = buildCallArgsStub(op, modelByName, hiddenParams);
+      const callArgs = buildCallArgsStub(op, modelByName, hiddenParams, groupOwners);
       const bodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams);
 
       // Collect method info for the parameterized 401 test (T20).
@@ -109,7 +111,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
         for (let vi = 1; vi < group.variants.length; vi++) {
           const variant = group.variants[vi];
           const overrides = new Map<string, number>([[group.name, vi]]);
-          const variantCallArgs = buildCallArgsStub(op, modelByName, hiddenParams, overrides);
+          const variantCallArgs = buildCallArgsStub(op, modelByName, hiddenParams, groupOwners, overrides);
           const variantBodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams, overrides);
           const suffix = `with_${fieldName(group.name)}_${fieldName(variant.name)}`;
           lines.push('');
@@ -327,6 +329,7 @@ function buildCallArgsStub(
   op: Operation,
   modelByName: Map<string, Model>,
   hiddenParams: Set<string>,
+  groupOwners: Map<string, string>,
   variantOverrides: Map<string, number> = new Map(),
 ): string {
   const parts: string[] = [];
@@ -383,7 +386,11 @@ function buildCallArgsStub(
     const idx = variantOverrides.get(group.name) ?? 0;
     const variant = group.variants[idx];
     if (variant) {
-      const variantClass = `WorkOS::${groupVariantClassName(group.name, variant.name)}`;
+      const owner = groupOwners.get(group.name);
+      if (!owner) {
+        throw new Error(`No owner mount target found for parameter group '${group.name}'`);
+      }
+      const variantClass = scopedGroupVariantClassName(owner, group.name, variant.name);
       const fieldStubs = variant.parameters.map((p) => `${fieldName(p.name)}: ${stubValueFor(p.type)}`).join(', ');
       parts.push(`${name}: ${variantClass}.new(${fieldStubs})`);
     }

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -1,5 +1,13 @@
 import type { ApiSpec, EmitterContext, GeneratedFile, Model, Operation, ResolvedWrapper, TypeRef } from '@workos/oagen';
-import { className, fileName, fieldName, safeParamName, servicePropertyName, resolveMethodName } from './naming.js';
+import {
+  className,
+  fileName,
+  fieldName,
+  groupVariantClassName,
+  safeParamName,
+  servicePropertyName,
+  resolveMethodName,
+} from './naming.js';
 import { buildResolvedLookup, groupByMount, lookupResolved, buildHiddenParams } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
@@ -323,18 +331,17 @@ function buildCallArgsStub(op: Operation, modelByName: Map<string, Model>, hidde
     parts.push(`${name}: ${stubValueFor(q.type)}`);
   }
 
-  // Required parameter group kwargs.
+  // Required parameter group kwargs: instantiate the first variant's class.
   for (const group of op.parameterGroups ?? []) {
     if (group.optional) continue;
     const name = fieldName(group.name);
     if (seen.has(name)) continue;
     seen.add(name);
-    // Stub as a hash with the first variant's type discriminant.
     const firstVariant = group.variants[0];
     if (firstVariant) {
-      parts.push(`${name}: { type: "${firstVariant.name}" }`);
-    } else {
-      parts.push(`${name}: {}`);
+      const variantClass = `WorkOS::${groupVariantClassName(group.name, firstVariant.name)}`;
+      const fieldStubs = firstVariant.parameters.map((p) => `${fieldName(p.name)}: ${stubValueFor(p.type)}`).join(', ');
+      parts.push(`${name}: ${variantClass}.new(${fieldStubs})`);
     }
   }
 

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -77,24 +77,24 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
       const resolved = lookupResolved(op, lookup);
       const hiddenParams = buildHiddenParams(resolved);
       const callArgs = buildCallArgsStub(op, modelByName, hiddenParams);
+      const bodyMatcher = buildBodyMatcher(op, modelByName, hiddenParams);
 
       // Collect method info for the parameterized 401 test (T20).
       authMethodManifest.push({ method, httpMethodSym, stubUrl, callArgs });
 
       const stubRegex = stubUrlRegex(stubUrl);
       lines.push(`  def test_${method}_returns_expected_result`);
+      lines.push(`    stub_request(${httpMethodSym}, ${stubRegex})`);
+      if (bodyMatcher) lines.push(`      .with(body: ${bodyMatcher})`);
       if (isList) {
-        lines.push(`    stub_request(${httpMethodSym}, ${stubRegex})`);
         lines.push(`      .to_return(body: '{"data": [], "list_metadata": {}}', status: 200)`);
         lines.push(`    result = @client.${prop}.${method}(${callArgs})`);
         lines.push('    assert_kind_of WorkOS::Types::ListStruct, result');
       } else if (op.response.kind === 'primitive') {
-        lines.push(`    stub_request(${httpMethodSym}, ${stubRegex})`);
         lines.push(`      .to_return(body: "{}", status: 200)`);
         lines.push(`    result = @client.${prop}.${method}(${callArgs})`);
         lines.push('    assert_nil result');
       } else {
-        lines.push(`    stub_request(${httpMethodSym}, ${stubRegex})`);
         lines.push(`      .to_return(body: "{}", status: 200)`);
         lines.push(`    result = @client.${prop}.${method}(${callArgs})`);
         lines.push('    refute_nil result');
@@ -331,9 +331,11 @@ function buildCallArgsStub(op: Operation, modelByName: Map<string, Model>, hidde
     parts.push(`${name}: ${stubValueFor(q.type)}`);
   }
 
-  // Required parameter group kwargs: instantiate the first variant's class.
+  // Parameter group kwargs (required and optional): instantiate the first
+  // variant's class. Optional groups are exercised too so the dispatcher
+  // code path is covered — passing nothing would skip the body block and
+  // hide silent-drop bugs (see workos/oagen-emitters#66).
   for (const group of op.parameterGroups ?? []) {
-    if (group.optional) continue;
     const name = fieldName(group.name);
     if (seen.has(name)) continue;
     seen.add(name);
@@ -346,6 +348,58 @@ function buildCallArgsStub(op: Operation, modelByName: Map<string, Model>, hidde
   }
 
   return parts.join(', ');
+}
+
+/**
+ * Build a Ruby `hash_including(...)` matcher describing the wire body the
+ * SDK should send for an operation whose body is constructed (in part) by a
+ * parameter-group dispatcher. Returns `null` for operations without body
+ * groups — those are still stubbed without a body matcher.
+ *
+ * The matcher includes every required non-group body field plus the first
+ * variant's wire-name leaves for each group dispatched into the body. This
+ * catches regressions where the dispatcher silently drops a passed group
+ * (the original `update_organization_membership` regression).
+ */
+function buildBodyMatcher(op: Operation, modelByName: Map<string, Model>, hiddenParams: Set<string>): string | null {
+  const httpMethod = op.httpMethod.toLowerCase();
+  const hasBodyMethod = !['get', 'head', 'delete'].includes(httpMethod);
+  const hasGroups = (op.parameterGroups?.length ?? 0) > 0;
+  if (!hasBodyMethod || !hasGroups) return null;
+
+  const groupedParamNames = new Set<string>();
+  for (const group of op.parameterGroups ?? []) {
+    for (const variant of group.variants) {
+      for (const p of variant.parameters) groupedParamNames.add(p.name);
+    }
+  }
+
+  const entries: string[] = [];
+
+  // Required non-group body fields, keyed by wire name.
+  if (op.requestBody) {
+    const bodyModel = resolveBodyModel(op.requestBody, modelByName);
+    if (bodyModel) {
+      for (const f of bodyModel.fields) {
+        if (!f.required) continue;
+        if (hiddenParams.has(f.name)) continue;
+        if (groupedParamNames.has(f.name)) continue;
+        entries.push(`"${f.name}" => ${stubValueFor(f.type)}`);
+      }
+    }
+  }
+
+  // First variant of each group: its leaves get pumped into the body.
+  for (const group of op.parameterGroups ?? []) {
+    const firstVariant = group.variants[0];
+    if (!firstVariant) continue;
+    for (const p of firstVariant.parameters) {
+      entries.push(`"${p.name}" => ${stubValueFor(p.type)}`);
+    }
+  }
+
+  if (entries.length === 0) return null;
+  return `hash_including(${entries.join(', ')})`;
 }
 
 function resolveBodyModel(ref: TypeRef, modelByName: Map<string, Model>): Model | null {


### PR DESCRIPTION
## Summary

Fixes a `TypeError: no implicit conversion of Symbol into Integer` raised by the Ruby SDK whenever a caller passed `password:` to `UserManagement#create_user` or `#update_user` (reported by Mentimeter on workos-ruby 7.x). The Ruby emitter exposed `x-mutually-exclusive-(body|parameter)-groups` as a hash with a `:type` symbol discriminator. When a group's name happened to match one of its variant leaf params — the spec's `password` group has a `password` leaf in the `plaintext` variant — the emitter generated a flat `String` kwarg that shadowed the dispatcher's hash kwarg in the method signature, so `password[:type]` ran against a `String` and crashed before the request hit the wire.

Two fixes combined:

1. **Filter `bodyFields` through `collectGroupedParamNames`** everywhere body fields are iterated in `ruby/resources.ts` and `ruby/rbi.ts`. Python, Go, PHP, .NET, and Kotlin already do this. The leaks let callers bypass the spec's mutual-exclusivity contract for non-colliding groups too.

2. **Replace the hash-with-`:type` API surface with typed variant classes**, matching every other language emitter:
   - new `ruby/parameter-groups.ts` emits one `Data.define(...)` class per `(group, variant)` under `lib/workos/<variant>.rb`, plus a Sorbet `.rbi` shim.
   - `ruby/resources.ts` dispatcher: `case prop[:type] when "x"` → `case prop when WorkOS::VariantClass`; field reads switch from hash subscripts to Data accessors.
   - `ruby/rbi.ts` group kwarg type: `T::Hash[Symbol, T.untyped]` → `T.any(WorkOS::VariantA, WorkOS::VariantB)` (nilable for optional groups). Group kwargs were also entirely missing from `.rbi` sigs before — now emitted.
   - `ruby/tests.ts` stub: `{ type: "by_id" }` → `WorkOS::VariantClass.new(...)`.
   - YARD docs: variant union in the type bracket; one-line description.

This is a breaking change for SDK callers — the regenerated output and migration notes live in workos/workos-ruby#473.

## Test plan

- [x] `npm test` — 388 emitter tests pass
- [x] `npm run lint` and `npm run format -- --check`
- [x] Regenerated workos-ruby + ran `bundle exec rake test` — 858 runs / 4383 assertions / 0 failures
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)