### PR TITLE
feat: thread modelHints through assignModelsToServices call sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ const config: OagenConfig = {
   docUrl: "https://workos.com/docs",
   operationHints,
   mountRules,
+  modelHints,
 };
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.9.0"
+        "@workos/oagen": "^0.12.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
@@ -1664,14 +1664,14 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.29.1.tgz",
-      "integrity": "sha512-T9FeS2+lpXR9V/XHqiJ53uGjoF1Hs80nRA9ACEXpTLF9a4jzzSANO92/f9HKuQvl0bHgyaIbP5OsBgVU3EP1KQ==",
+      "version": "2.30.3",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.3.tgz",
+      "integrity": "sha512-roSwxkitl+JY3LajLEg6n9ujaFkCB4cqtjgrjXxedgk57Qde5t0Vn4HBYkOomw1bHOI7W+Ux2qfPQOpzK7BnLg==",
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.48.0",
-        "ajv": "npm:@redocly/ajv@8.18.0",
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/config": "^0.48.1",
+        "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -1683,6 +1683,23 @@
       "engines": {
         "node": ">=22.12.0 || >=20.19.0 <21.0.0",
         "npm": ">=10"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/ajv": {
+      "name": "@redocly/ajv",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2176,9 +2193,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.9.0.tgz",
-      "integrity": "sha512-U+NGQChtG5nVr2uddELvnXs3cWqFbBFwmtMiZCA0eoiNnwABGHVT/kn8hCcXWae+Dy0wDj/6nPAbcN/aGVFx8g==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.12.0.tgz",
+      "integrity": "sha512-bfXANikWQQ/vJmbM1O7t+56NGI625vnObyaB24Npkh/JKRNc9073WwL5Wq2vR6m+ORinqTJKB8kOYU6MIhApqQ==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",
@@ -2202,6 +2219,208 @@
       },
       "engines": {
         "node": ">=24.10.0"
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-elixir": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-elixir/-/tree-sitter-elixir-0.3.5.tgz",
+      "integrity": "sha512-xozQMvYK0aSolcQZAx2d84Xe/YMWFuRPYFlLVxO01bM2GITh5jyiIp0TqPCQa8754UzRAI7A83hZmfiYub5TZQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-elixir/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-go": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.23.4.tgz",
+      "integrity": "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-kotlin": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-kotlin/-/tree-sitter-kotlin-0.3.8.tgz",
+      "integrity": "sha512-A4obq6bjzmYrA+F0JLLoheFPcofFkctNaZSpnDd+GPn1SfVZLY4/GG4C0cYVBTOShuPBGGAOPLM1JWLZQV4m1g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-kotlin/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-php": {
+      "version": "0.23.12",
+      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.23.12.tgz",
+      "integrity": "sha512-VwkBVOahhC2NYXK/Fuqq30NxuL/6c2hmbxEF4jrB7AyR5rLc7nT27mzF3qoi+pqx9Gy2AbXnGezF7h4MeM6YRA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-python": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.21.0.tgz",
+      "integrity": "sha512-IUKx7JcTVbByUx1iHGFS/QsIjx7pqwTMHL9bl/NGyhyyydbfNrpruo2C7W6V4KZrbkkCOlX8QVrCoGOFW5qecg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-python/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-ruby": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-ruby/-/tree-sitter-ruby-0.21.0.tgz",
+      "integrity": "sha512-UrMpF9CZxKbZ5UFuPdXDuraaaYSMMlAiuzTpQXwNm7y0D48ibc9stWU5D6vDyJD0qf5/R+3yKTYHdHkqibmLSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-rust": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.21.0.tgz",
+      "integrity": "sha512-unVr73YLn3VC4Qa/GF0Nk+Wom6UtI526p5kz9Rn2iZSqwIFedyCZ3e0fKCEmUJLIPGrTb/cIEdu3ZUNGzfZx7A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-rust/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/@workos/oagen/node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv": {
@@ -3882,17 +4101,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
-      }
-    },
     "node_modules/tree-sitter-c-sharp": {
       "version": "0.23.5",
       "resolved": "https://registry.npmjs.org/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.23.5.tgz",
@@ -3905,197 +4113,6 @@
       },
       "peerDependencies": {
         "tree-sitter": "^0.25.0"
-      },
-      "peerDependenciesMeta": {
-        "tree-sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-elixir": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-elixir/-/tree-sitter-elixir-0.3.5.tgz",
-      "integrity": "sha512-xozQMvYK0aSolcQZAx2d84Xe/YMWFuRPYFlLVxO01bM2GITh5jyiIp0TqPCQa8754UzRAI7A83hZmfiYub5TZQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "node-gyp-build": "^4.8.0"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.0"
-      }
-    },
-    "node_modules/tree-sitter-elixir/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
-    },
-    "node_modules/tree-sitter-go": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.23.4.tgz",
-      "integrity": "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.2.1",
-        "node-gyp-build": "^4.8.2"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.1"
-      },
-      "peerDependenciesMeta": {
-        "tree-sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-javascript": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
-      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.2.2",
-        "node-gyp-build": "^4.8.2"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.1"
-      },
-      "peerDependenciesMeta": {
-        "tree-sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-kotlin": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/tree-sitter-kotlin/-/tree-sitter-kotlin-0.3.8.tgz",
-      "integrity": "sha512-A4obq6bjzmYrA+F0JLLoheFPcofFkctNaZSpnDd+GPn1SfVZLY4/GG4C0cYVBTOShuPBGGAOPLM1JWLZQV4m1g==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "node-gyp-build": "^4.8.0"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.0"
-      },
-      "peerDependenciesMeta": {
-        "tree_sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-kotlin/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
-    },
-    "node_modules/tree-sitter-php": {
-      "version": "0.23.12",
-      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.23.12.tgz",
-      "integrity": "sha512-VwkBVOahhC2NYXK/Fuqq30NxuL/6c2hmbxEF4jrB7AyR5rLc7nT27mzF3qoi+pqx9Gy2AbXnGezF7h4MeM6YRA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.2.2",
-        "node-gyp-build": "^4.8.2"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.1"
-      },
-      "peerDependenciesMeta": {
-        "tree-sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-python": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.21.0.tgz",
-      "integrity": "sha512-IUKx7JcTVbByUx1iHGFS/QsIjx7pqwTMHL9bl/NGyhyyydbfNrpruo2C7W6V4KZrbkkCOlX8QVrCoGOFW5qecg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "node-gyp-build": "^4.8.0"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.0"
-      },
-      "peerDependenciesMeta": {
-        "tree_sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-python/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
-    },
-    "node_modules/tree-sitter-ruby": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-ruby/-/tree-sitter-ruby-0.21.0.tgz",
-      "integrity": "sha512-UrMpF9CZxKbZ5UFuPdXDuraaaYSMMlAiuzTpQXwNm7y0D48ibc9stWU5D6vDyJD0qf5/R+3yKTYHdHkqibmLSQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.1"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.0"
-      },
-      "peerDependenciesMeta": {
-        "tree_sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-rust": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.21.0.tgz",
-      "integrity": "sha512-unVr73YLn3VC4Qa/GF0Nk+Wom6UtI526p5kz9Rn2iZSqwIFedyCZ3e0fKCEmUJLIPGrTb/cIEdu3ZUNGzfZx7A==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "node-gyp-build": "^4.8.0"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.1"
-      },
-      "peerDependenciesMeta": {
-        "tree_sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-rust/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
-    },
-    "node_modules/tree-sitter-typescript": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
-      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.2.2",
-        "node-gyp-build": "^4.8.2",
-        "tree-sitter-javascript": "^0.23.1"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.21.0"
       },
       "peerDependenciesMeta": {
         "tree-sitter": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.9.0"
+    "@workos/oagen": "^0.12.0"
   }
 }

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -854,7 +854,7 @@ function modelNeedsRoundTripTest(model: Model): boolean {
  */
 function generateSerializerTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
-  const modelToService = assignModelsToServices(spec.models, spec.services);
+  const modelToService = assignModelsToServices(spec.models, spec.services, ctx.modelHints);
   const serviceNameMap = new Map<string, string>();
   for (const service of spec.services) {
     serviceNameMap.set(service.name, resolveResourceClassName(service, ctx));

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -223,7 +223,7 @@ export function createServiceDirResolver(
   serviceNameMap: Map<string, string>;
   resolveDir: (irService: string | undefined) => string;
 } {
-  const modelToService = assignModelsToServices(models, services);
+  const modelToService = assignModelsToServices(models, services, ctx.modelHints);
   const serviceNameMap = buildServiceNameMap(services, ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? resolveServiceDir(serviceNameMap.get(irService) ?? irService) : 'common';

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -11,7 +11,7 @@ import { assignEnumsToServices, collectGeneratedEnumSymbolsByDir } from './enums
 export function generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
   if (models.length === 0) return [];
 
-  const modelToService = assignModelsToServices(models, ctx.spec.services);
+  const modelToService = assignModelsToServices(models, ctx.spec.services, ctx.modelHints);
   const enumToService = assignEnumsToServices(ctx.spec.enums, ctx.spec.services);
   const mountDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -1116,7 +1116,7 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
     const actualModelImports = [...modelImports];
 
     // Split imports into same-service and cross-service (using mount-based dirs)
-    const modelToServiceMap = assignModelsToServices(ctx.spec.models, ctx.spec.services);
+    const modelToServiceMap = assignModelsToServices(ctx.spec.models, ctx.spec.services, ctx.modelHints);
     // Discriminator variant type aliases (e.g. EventSchemaVariant) live in the same
     // service as their dispatcher model, so ensure they resolve to the same directory.
     for (const model of ctx.spec.models) {

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -227,7 +227,7 @@ function generateServiceTest(
   });
 
   // Group imports by their actual service directory (models may live in different services)
-  const modelToServiceMap = assignModelsToServices(spec.models, spec.services);
+  const modelToServiceMap = assignModelsToServices(spec.models, spec.services, ctx.modelHints);
   const mountDirMap = buildMountDirMap(ctx);
   const resolveModelDir = (modelName: string) => {
     const svc = modelToServiceMap.get(modelName);
@@ -1402,7 +1402,7 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
   );
   if (models.length === 0) return null;
 
-  const modelToService = assignModelsToServices(spec.models, spec.services);
+  const modelToService = assignModelsToServices(spec.models, spec.services, ctx.modelHints);
   const roundTripDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (roundTripDirMap.get(irService) ?? 'common') : 'common';

--- a/src/ruby/client.ts
+++ b/src/ruby/client.ts
@@ -182,7 +182,7 @@ function generateMainEntryFile(spec: ApiSpec, ctx: EmitterContext): GeneratedFil
  * keep the generated namespace flat while the filesystem is grouped.
  */
 function collectModelSubdirs(spec: ApiSpec, ctx: EmitterContext): string[] {
-  const modelToService = assignModelsToServices(spec.models as Model[], spec.services);
+  const modelToService = assignModelsToServices(spec.models as Model[], spec.services, ctx.modelHints);
   const mountDirMap = buildMountDirMap(ctx);
   const subdirs = new Set<string>();
   for (const model of spec.models as Model[]) {

--- a/src/ruby/models.ts
+++ b/src/ruby/models.ts
@@ -67,7 +67,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // Model → mount target directory. Each model is assigned to the first service
   // that references it (transitively). Orphans land in `shared/`. Zeitwerk is
   // told to collapse each subfolder (in client.ts) so the namespace stays flat.
-  const modelToService = assignModelsToServices(models, ctx.spec.services);
+  const modelToService = assignModelsToServices(models, ctx.spec.services, ctx.modelHints);
   const mountDirMap = buildMountDirMap(ctx);
   const dirFor = (modelName: string): string => {
     const service = modelToService.get(modelName);


### PR DESCRIPTION
## Summary

- Pass `ctx.modelHints` to every `assignModelsToServices` invocation across the python, node, and ruby emitters.
- Activates the new oagen `modelHints` config knob (workos/oagen#45) for emitters whose output paths are namespace-aware (most relevantly Python's per-service submodule layout).
- The fixtures fallback path that runs without `ctx` is unchanged — passing undefined preserves current behavior.

## Files changed (7 production call sites)

- `src/python/models.ts`
- `src/python/resources.ts`
- `src/python/tests.ts` (×2)
- `src/node/utils.ts` (`createServiceDirResolver`)
- `src/node/tests.ts`
- `src/ruby/client.ts`
- `src/ruby/models.ts`
- `README.md` — mention `modelHints` alongside the existing config knobs in the consumer example

## ⚠️ Blocked on oagen release

CI typecheck will fail until **workos/oagen#45** is merged, released, and `@workos/oagen` bumped here. Locally verified via `npm link` against an unreleased oagen build — once the new oagen ships, bump `^0.9.0` to whatever version exposes `modelHints` and CI will go green.

## Test plan

- [x] Local link → regen workos-python with `modelHints: { User: 'UserManagementUsers' }` and confirm `User` lands in `user_management/models/user.py`
- [x] `npx tsc --noEmit` clean (against linked oagen)
- [x] `npx vitest run` — 388/388 passing
- [x] Negative: typo'd hint key fails loud
- [ ] Re-verify after `@workos/oagen` dep bump