### PR TITLE
fix(python): use explicit re-export form in service __init__.py

### DIFF
--- a/src/python/client.ts
+++ b/src/python/client.ts
@@ -270,8 +270,13 @@ function generateServiceInits(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     const ops = mountGroups.get(mountTarget)?.operations ?? service.operations;
     const groupClassNames = collectParameterGroupClassNames(ops);
 
+    // Use `X as X` re-export form (PEP 484) so pyright recognizes these as
+    // public re-exports. Otherwise consumers importing
+    // `from workos.user_management import RoleSingle` get a private-import
+    // warning under strict mode. Models barrel uses the same convention.
     const resourceImports = [resolvedName, `Async${resolvedName}`, ...groupClassNames];
-    lines.push(`from ._resource import ${resourceImports.join(', ')}`);
+    const aliasedImports = resourceImports.map((n) => `${n} as ${n}`);
+    lines.push(`from ._resource import ${aliasedImports.join(', ')}`);
     lines.push('from .models import *');
 
     files.push({

--- a/test/python/client.test.ts
+++ b/test/python/client.test.ts
@@ -103,7 +103,9 @@ describe('generateClient', () => {
 
     const serviceInit = files.find((f) => f.path === 'src/workos/organizations/__init__.py');
     expect(serviceInit).toBeDefined();
-    expect(serviceInit!.content).toContain('from ._resource import Organizations, AsyncOrganizations');
+    expect(serviceInit!.content).toContain(
+      'from ._resource import Organizations as Organizations, AsyncOrganizations as AsyncOrganizations',
+    );
   });
 
   it('generates flat directory structure for services (no nested namespaces)', () => {
@@ -193,7 +195,7 @@ describe('generateClient', () => {
     expect(serviceInit!.content).toContain('RoleSingle');
     expect(serviceInit!.content).toContain('RoleMultiple');
     expect(serviceInit!.content).toContain(
-      'from ._resource import UserManagement, AsyncUserManagement, RoleSingle, RoleMultiple',
+      'from ._resource import UserManagement as UserManagement, AsyncUserManagement as AsyncUserManagement, RoleSingle as RoleSingle, RoleMultiple as RoleMultiple',
     );
   });
 


### PR DESCRIPTION
## Summary

- Switches Python service `__init__.py` re-exports from bare `from ._resource import X` to the PEP 484 explicit form `from ._resource import X as X`
- Fixes pyright's `reportPrivateImportUsage` warning under strict mode for consumers importing names like `RoleSingle`, `RoleMultiple`, `ResourceTargetById`, etc. directly from a service package

## Why

Customer report: `from workos.user_management import RoleSingle, RoleMultiple` triggers a private-import warning under strict pyright. Under PEP 484, a name is only treated as a public re-export when it is listed in `__all__` or imported via `X as X`.

The Python emitter was producing bare imports for resource-level `__init__.py` (all 19 service barrels in workos-python), even though `models.ts:473` already uses the `X as X` convention for the models barrel — so the codebase was internally inconsistent. This change makes the resource barrel match.

## Effect on workos-python

After regenerating workos-python with this change, all 19 service `__init__.py`s switch to the explicit form. Verified locally:

- `uv run pyright` clean
- `uv run pytest` — 1987 tests pass
- Strict-mode pyright (`# pyright: strict`) on a consumer file no longer warns on `from workos.user_management import RoleSingle, RoleMultiple` or `from workos.authorization import ResourceTargetById`

## Test plan

- [x] Updated 2 existing emitter tests in `test/python/client.test.ts` to assert the `X as X` form
- [x] `npm test` — 388 tests pass (44 files)
- [x] `npm run typecheck` — clean
- [x] `npm run build` then regenerated workos-python — verified all 19 service inits use the explicit form
- [x] Confirmed pyright in strict mode no longer warns on the customer's import pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)