### PR TITLE
fix(php): wrap degenerate-union models in fromArray/toArray

### DIFF
--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -134,6 +134,31 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 }
 
 /**
+ * Resolve a degenerate union to a single TypeRef when possible.
+ * - allOf: PHP collapses to the first variant (mirrors `mapTypeRef`).
+ * - oneOf/anyOf where every variant has the same generated PHP type: collapse
+ *   to that variant (e.g. discriminated unions whose branches the IR pinned to
+ *   one model name).
+ * Returns null when the union is genuinely polymorphic.
+ */
+function resolveDegenerateUnion(ref: TypeRef): TypeRef | null {
+  if (ref.kind !== 'union') return null;
+  if (ref.compositionKind === 'allOf') return ref.variants[0] ?? null;
+  if (ref.variants.length === 0) return null;
+  const signature = (v: TypeRef): string => {
+    if (v.kind === 'model') return `model:${v.name}`;
+    if (v.kind === 'enum') return `enum:${v.name}`;
+    return `kind:${v.kind}`;
+  };
+  const first = ref.variants[0];
+  const firstSig = signature(first);
+  for (const v of ref.variants) {
+    if (signature(v) !== firstSig) return null;
+  }
+  return first;
+}
+
+/**
  * Generate the fromArray accessor expression for a field.
  */
 function generateFromArrayAccessor(ref: TypeRef, wireName: string, required: boolean): string {
@@ -194,8 +219,11 @@ function generateFromArrayValue(ref: TypeRef, accessor: string): string {
       return accessor;
     case 'nullable':
       return generateFromArrayValue(ref.inner, accessor);
-    case 'union':
+    case 'union': {
+      const resolved = resolveDegenerateUnion(ref);
+      if (resolved) return generateFromArrayValue(resolved, accessor);
       return accessor;
+    }
     case 'map':
       return accessor;
     case 'literal':
@@ -225,6 +253,10 @@ function isComplexType(ref: TypeRef): boolean {
       return isComplexType(ref.items);
     case 'nullable':
       return isComplexType(ref.inner);
+    case 'union': {
+      const resolved = resolveDegenerateUnion(ref);
+      return resolved ? isComplexType(resolved) : false;
+    }
     default:
       return false;
   }
@@ -266,8 +298,11 @@ function generateToArrayValue(ref: TypeRef, accessor: string, nullable = false):
       return generateToArrayValue(ref.inner, accessor, true);
     case 'map':
       return accessor;
-    case 'union':
+    case 'union': {
+      const resolved = resolveDegenerateUnion(ref);
+      if (resolved) return generateToArrayValue(resolved, accessor, nullable);
       return accessor;
+    }
     case 'literal':
       return accessor;
   }


### PR DESCRIPTION
## Summary
- PHP `fromArray`/`toArray`/`isComplexType` returned the raw accessor for any `union` TypeRef. This includes the very common degenerate case where every oneOf/anyOf variant resolves to the same generated PHP type — e.g. a discriminated `owner` union whose IR variants both pin to `ApiKeyOwner`. The constructor correctly declared `public ApiKeyOwner $owner`, but `fromArray` passed the raw array, producing a runtime `TypeError` the moment the model was deserialized.
- Add a `resolveDegenerateUnion` helper that collapses such unions to a single TypeRef (mirroring how `joinUnionVariants` in `type-map.ts` already collapses them for type-hint emission), and route `generateFromArrayValue`, `generateToArrayValue`, and `isComplexType` through it before falling back to the raw-accessor default. Genuinely polymorphic unions (different model names per variant) still fall through to `accessor`, unchanged.
- Caught while triaging the workos/openapi-spec PR #17 CI: `Tests\Service\ApiKeysTest::testCreateValidation` was failing with `Argument #3 ($owner) must be of type WorkOS\Resource\ApiKeyOwner, array given`.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 388 emitter tests pass
- [x] Regenerate `workos-php` against the spec exhibiting the discriminated `ApiKey.owner` union; `vendor/bin/phpunit` passes 258/258 tests (was 1 error before this change)
- [x] Spot-check generated output: `ApiKey::fromArray` now emits `owner: ApiKeyOwner::fromArray($data['owner'])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)