### PR TITLE
chore: bump @workos/oagen to ^0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.12.0"
+        "@workos/oagen": "^0.15.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.12.0.tgz",
-      "integrity": "sha512-bfXANikWQQ/vJmbM1O7t+56NGI625vnObyaB24Npkh/JKRNc9073WwL5Wq2vR6m+ORinqTJKB8kOYU6MIhApqQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.15.0.tgz",
+      "integrity": "sha512-U1al58616PCGNBbapY8NZJ5pFenvCZQf4CaPScLakG4edUJAzZX5yOThAs4nDRIMUJJT9dRcLJjeUaH8WN8Y4Q==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.12.0"
+    "@workos/oagen": "^0.15.0"
   }
 }


### PR DESCRIPTION
## Why workos/openapi-spec#17 still shows breaking changes

oagen 0.13/0.14/0.15 ship rename-detection passes ([#49](https://github.com/workos/oagen/pull/49), [#51](https://github.com/workos/oagen/pull/51), [#53](https://github.com/workos/oagen/pull/53)) that downgrade type/enum renames from breaking to soft-risk in compat reports. But oagen-emitters declares \`\"@workos/oagen\": \"^0.12.0\"\` — a constraint that pins to 0.12.x and prevents npm from deduping with the root.

Concretely: when openapi-spec installs oagen 0.15.0 at the root, npm *also* installs a nested copy of oagen 0.12.0 under \`node_modules/@workos/oagen-emitters/node_modules/@workos/oagen\` to satisfy the \`^0.12.0\` constraint. At runtime, oagen-emitters' \`import { phpExtractor } from '@workos/oagen/compat'\` resolves through the nested 0.12.0 — so the new extractor + differ logic never runs.

Result: the compat report on PR #17 shows the same 11 breaking changes it would have shown before any of #49/#51/#53 were merged.

## What this PR changes

One-line: bump the dependency constraint to \`^0.15.0\` so npm can dedup to the root install. \`package-lock.json\` updated.

## Verified

Locally re-extracted + re-diffed all five language SDKs against PR #17's spec change with this bump applied:

| Language | Before this bump | After |
| --- | --- | --- |
| dotnet | 0 breaking | 0 breaking |
| go | 0 breaking | 0 breaking |
| php | 7 breaking | **0 breaking** |
| python | 3 breaking | **0 breaking** |
| ruby | 2 breaking | **0 breaking** |

(dotnet and go were already 0 because oagen-emitters' nested 0.12.0 happened to include the differ-side passes via re-export resolution, but the extractor changes from #53 — which give PHP/Python/Ruby their field/enum_member info — only kick in once oagen ≥ 0.15 is the resolved version.)

Once this lands and oagen-emitters cuts a release, openapi-spec only needs to bump oagen-emitters and CI on PR #17 should default-pass.

## Test plan

- [x] \`npm test\` — 399/399
- [x] \`npm install\` resolves \`@workos/oagen@0.15.0\` (no nested copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)