### PR TITLE
feat(emitters): dispatch field-level discriminated unions and drop dead request bodies

### DIFF
--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -20,7 +20,7 @@ import { generateTests } from './tests.js';
 import { buildOperationsMap } from './manifest.js';
 import { generateWrapperOptionsClasses } from './wrappers.js';
 import { groupByMount } from '../shared/resolved-ops.js';
-import { discriminatedUnions } from './type-map.js';
+import { discriminatedUnions, resolveModelName } from './type-map.js';
 import { modelClassName } from './naming.js';
 
 /**
@@ -142,7 +142,7 @@ export const dotnetEmitter: Emitter = {
         lines.push('            switch (discriminatorValue)');
         lines.push('            {');
         for (const [value, modelName] of Object.entries(disc.mapping)) {
-          const csName = modelClassName(modelName);
+          const csName = modelClassName(resolveModelName(modelName));
           lines.push(`                case "${value}": return jObject.ToObject<${csName}>(serializer);`);
         }
         lines.push('                default: return jObject.ToObject<object>(serializer);');

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -1,4 +1,5 @@
-import type { Model, EmitterContext, GeneratedFile, TypeRef } from '@workos/oagen';
+import type { Model, EmitterContext, GeneratedFile, TypeRef, Service } from '@workos/oagen';
+import { walkTypeRef } from '@workos/oagen';
 import {
   mapTypeRef,
   isValueTypeRef,
@@ -53,6 +54,15 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
     }
   }
 
+  // Models that are referenced ONLY as an operation request body (not by any
+  // response, field, or other operation type) are dead surface in .NET because
+  // the wrapper generator emits a per-operation `*Options` class containing
+  // the same fields. The method signature consumes the Options class — the
+  // named entity is never instantiated by callers and just clutters the SDK
+  // (see workos-dotnet#248 with `CreateUserApiKey` /
+  // `UserManagementCreateApiKeyOptions`). Skip emission for those.
+  const requestBodyOnlyNames = collectRequestBodyOnlyModelNames(ctx.spec.services, models);
+
   const files: GeneratedFile[] = [];
 
   // Compute and publish model aliases so mapTypeRef rewrites references.
@@ -75,6 +85,7 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
 
   for (const model of models) {
     if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (requestBodyOnlyNames.has(model.name)) continue;
 
     const csClassName = modelClassName(model.name);
 
@@ -217,6 +228,14 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
 
       const isRequiredEnum = field.required && isEnumRef(field.type) && constInit === null;
       lines.push(...emitJsonPropertyAttributes(field.name, { isRequiredEnum }));
+      // Discriminated-union-typed field: attach the variant-dispatching converter
+      // so Newtonsoft picks the right subtype on deserialization. The converter
+      // name is keyed off the first IR variant model name (matches how
+      // `joinUnionVariants` registered it in `discriminatedUnions`).
+      const discriminatedUnionConverter = discriminatedUnionConverterName(field.type);
+      if (discriminatedUnionConverter) {
+        lines.push(`        [Newtonsoft.Json.JsonConverter(typeof(${discriminatedUnionConverter}))]`);
+      }
       const newMod = useNewModifier ? 'new ' : '';
       lines.push(`        public ${newMod}${csType} ${csFieldName} { get; ${setterModifier}set; }${initializer}`);
 
@@ -287,6 +306,24 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
   }
 
   return files;
+}
+
+/**
+ * Compute the name of the discriminator converter class for a field whose
+ * type is a discriminated union, mirroring the keying used in
+ * `joinUnionVariants` (first IR model variant name + "DiscriminatorConverter").
+ * Returns null when the type isn't a discriminated union with a populated
+ * mapping. Also walks through `nullable` so an optional discriminated field
+ * still gets the converter applied.
+ */
+function discriminatedUnionConverterName(ref: TypeRef): string | null {
+  const inner = ref.kind === 'nullable' ? ref.inner : ref;
+  if (inner.kind !== 'union') return null;
+  if (!inner.discriminator || !inner.discriminator.mapping) return null;
+  if (Object.keys(inner.discriminator.mapping).length === 0) return null;
+  const firstModel = inner.variants.find((v) => v.kind === 'model');
+  if (!firstModel || firstModel.kind !== 'model') return null;
+  return `${modelClassName(firstModel.name)}DiscriminatorConverter`;
 }
 
 /**
@@ -402,4 +439,55 @@ function structuralHash(model: Model, aliasOf: Map<string, string> = new Map()):
     .map((f) => `${f.name}:${JSON.stringify(normalizeTypeForHash(f.type, aliasOf))}:${f.required}`)
     .sort()
     .join('|');
+}
+
+/**
+ * Names of models referenced **only** as a named operation request body —
+ * i.e. never appearing in a response, an error, a paginated item type, or as
+ * a field type on another model. The .NET wrapper generator emits a
+ * per-operation `*Options` class containing the same fields, so the named
+ * entity is never instantiated by callers and just clutters the SDK
+ * (workos-dotnet#248: `CreateUserApiKey` vs `UserManagementCreateApiKeyOptions`).
+ */
+function collectRequestBodyOnlyModelNames(services: Service[], models: Model[]): Set<string> {
+  const requestBodyNames = new Set<string>();
+  const otherReferences = new Set<string>();
+
+  const collect = (ref: TypeRef | undefined, into: Set<string>): void => {
+    if (!ref) return;
+    walkTypeRef(ref, {
+      model: (r) => into.add(r.name),
+    });
+  };
+
+  for (const service of services) {
+    for (const op of service.operations) {
+      if (op.requestBody?.kind === 'model') {
+        requestBodyNames.add(op.requestBody.name);
+      }
+      collect(op.response, otherReferences);
+      if (op.pagination) collect(op.pagination.itemType, otherReferences);
+      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+        collect(p.type, otherReferences);
+      }
+      if (op.successResponses) {
+        for (const sr of op.successResponses) collect(sr.type, otherReferences);
+      }
+      for (const err of op.errors) {
+        if (err.type) collect(err.type, otherReferences);
+      }
+    }
+  }
+
+  for (const model of models) {
+    for (const field of model.fields) {
+      collect(field.type, otherReferences);
+    }
+  }
+
+  const result = new Set<string>();
+  for (const name of requestBodyNames) {
+    if (!otherReferences.has(name)) result.add(name);
+  }
+  return result;
 }

--- a/src/dotnet/type-map.ts
+++ b/src/dotnet/type-map.ts
@@ -200,11 +200,18 @@ function joinUnionVariants(_ref: UnionType, variants: string[]): string {
     return variants[0] ?? 'object';
   }
   const unique = [...new Set(variants)];
-  if (unique.length === 1) return unique[0];
 
-  // Discriminated union: register for converter generation and return first variant as base
+  // Discriminated union: register for converter generation BEFORE collapsing
+  // single-unique to avoid losing the discriminator when all variants alias
+  // to the same canonical model (structural dedup). The base type used for
+  // the converter name comes from the discriminator's IR variant names so
+  // it stays stable even when the C# class names get rewritten by aliases.
   if (_ref.discriminator && _ref.discriminator.mapping) {
-    const baseName = unique[0];
+    const irVariantNames = _ref.variants
+      .filter((v) => v.kind === 'model')
+      .map((v) => (v.kind === 'model' ? v.name : ''))
+      .filter(Boolean);
+    const baseName = irVariantNames[0] ?? unique[0];
     discriminatedUnions.set(baseName, {
       property: _ref.discriminator.property,
       mapping: _ref.discriminator.mapping,
@@ -214,6 +221,8 @@ function joinUnionVariants(_ref: UnionType, variants: string[]): string {
     // AnyOf<> doesn't support discriminator-based deserialization
     return 'object';
   }
+
+  if (unique.length === 1) return unique[0];
 
   if (unique.length >= 2 && unique.length <= 9) return `OneOf.OneOf<${unique.join(', ')}>`;
   // OneOf supports arity 2-9. Higher-arity unions collapse to `object`,

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -1,4 +1,5 @@
-import type { Model, EmitterContext, GeneratedFile } from '@workos/oagen';
+import type { Model, EmitterContext, GeneratedFile, TypeRef, Service } from '@workos/oagen';
+import { walkTypeRef } from '@workos/oagen';
 import { mapTypeRef } from './type-map.js';
 import { className, fieldName } from './naming.js';
 import { lowerFirstForDoc, fieldDocComment, articleFor } from '../shared/naming-utils.js';
@@ -6,6 +7,67 @@ import { lowerFirstForDoc, fieldDocComment, articleFor } from '../shared/naming-
 // Import and re-export shared model detection utilities
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 export { isListWrapperModel, isListMetadataModel };
+
+/**
+ * Collect names of models that are referenced **only** as a named request body
+ * model on an operation, with no other consumers (response types, pagination
+ * item types, error types, or fields on other models).
+ *
+ * The Go emitter synthesizes a `{Service}{Method}Params` struct from those
+ * request bodies (see `resources.ts:392`), and the method signature uses the
+ * synthesized struct — never the named model. So emitting the named model in
+ * `models.go` would leave callers with a duplicate, unused struct (the bug
+ * surfaced in workos-go#544 with `CreateUserAPIKey` /
+ * `UserManagementCreateAPIKeyParams`).
+ *
+ * Models in this set are skipped during model emission. Callers parameterize
+ * the API surface through `*Params` exclusively, which is the sole consumer
+ * of the spec's named request body schema.
+ */
+function collectRequestBodyOnlyModelNames(services: Service[], models: Model[]): Set<string> {
+  const requestBodyNames = new Set<string>();
+  const otherReferences = new Set<string>();
+
+  const collect = (ref: TypeRef | undefined, into: Set<string>): void => {
+    if (!ref) return;
+    walkTypeRef(ref, {
+      model: (r) => into.add(r.name),
+    });
+  };
+
+  for (const service of services) {
+    for (const op of service.operations) {
+      if (op.requestBody?.kind === 'model') {
+        requestBodyNames.add(op.requestBody.name);
+      }
+      collect(op.response, otherReferences);
+      if (op.pagination) collect(op.pagination.itemType, otherReferences);
+      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+        collect(p.type, otherReferences);
+      }
+      if (op.successResponses) {
+        for (const sr of op.successResponses) collect(sr.type, otherReferences);
+      }
+      for (const err of op.errors) {
+        if (err.type) collect(err.type, otherReferences);
+      }
+    }
+  }
+
+  // Field references — a request body model that's also a field type elsewhere
+  // is a reusable schema (e.g. consumed by webhook event data), so we keep it.
+  for (const model of models) {
+    for (const field of model.fields) {
+      collect(field.type, otherReferences);
+    }
+  }
+
+  const result = new Set<string>();
+  for (const name of requestBodyNames) {
+    if (!otherReferences.has(name)) result.add(name);
+  }
+  return result;
+}
 
 /**
  * Generate Go struct definitions from IR Models.
@@ -20,11 +82,14 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   lines.push(`package ${ctx.namespace}`);
   lines.push('');
 
+  const requestBodyOnly = collectRequestBodyOnlyModelNames(ctx.spec.services, models);
+
   // Build structural hash for deduplication
   const modelHashMap = new Map<string, string>();
   const hashGroups = new Map<string, string[]>();
   for (const model of models) {
     if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (requestBodyOnly.has(model.name)) continue;
     const hash = structuralHash(model);
     modelHashMap.set(model.name, hash);
     if (!hashGroups.has(hash)) hashGroups.set(hash, []);
@@ -48,6 +113,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   const batchedAliases = new Set<string>();
   for (const model of models) {
     if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (requestBodyOnly.has(model.name)) continue;
 
     const structName = className(model.name);
 

--- a/src/go/type-map.ts
+++ b/src/go/type-map.ts
@@ -82,6 +82,29 @@ function joinUnionVariants(_ref: UnionType, variants: string[]): string {
   }
   const unique = [...new Set(variants)];
   if (unique.length === 1) return unique[0];
-  // Go doesn't have union types; use interface{}
+  // Discriminated unions: Go has no sum types, so widen to the discriminator-
+  // resolver type when one is registered downstream (see resolveDiscriminatedUnionType).
+  // Fall back to interface{} for non-discriminated heterogeneous unions.
+  if (_ref.discriminator && _ref.discriminator.mapping) {
+    const resolverName = unionResolverName(_ref);
+    if (resolverName) return resolverName;
+  }
   return 'interface{}';
+}
+
+/**
+ * Pick a stable type name for a discriminated union's runtime resolver. Today
+ * we emit no resolver struct, so we treat the union's first model variant as
+ * the public type — matching the pre-discriminator behavior where Go just
+ * referenced one variant directly. The Owner field stays typed, callers
+ * can still inspect Type to detect the user variant (data loss on
+ * non-overlapping fields like organization_id is documented in the SDK
+ * compat report rather than fixed in the emitter — Go callers who need the
+ * user-only fields can json.Unmarshal the raw payload manually).
+ */
+function unionResolverName(ref: UnionType): string | null {
+  for (const v of ref.variants) {
+    if (v.kind === 'model') return `*${className(v.name)}`;
+  }
+  return null;
 }

--- a/src/kotlin/type-map.ts
+++ b/src/kotlin/type-map.ts
@@ -95,10 +95,17 @@ function joinUnionVariants(ref: UnionType, variants: string[]): string {
     return variants[0] ?? 'Any';
   }
   const unique = [...new Set(variants)];
-  if (unique.length === 1) return unique[0];
 
+  // Register discriminated unions BEFORE the single-unique collapse so we
+  // don't lose the dispatcher when every variant aliases to the same canonical
+  // type. The base type used at the call site is the IR variant name, which
+  // matches how the dispatcher infrastructure looks up registered unions.
   if (ref.discriminator && ref.discriminator.mapping) {
-    const baseName = unique[0];
+    const irVariantNames = ref.variants
+      .filter((v) => v.kind === 'model')
+      .map((v) => (v.kind === 'model' ? v.name : ''))
+      .filter(Boolean);
+    const baseName = irVariantNames[0] ?? unique[0];
     discriminatedUnions.set(baseName, {
       property: ref.discriminator.property,
       mapping: ref.discriminator.mapping,
@@ -107,6 +114,8 @@ function joinUnionVariants(ref: UnionType, variants: string[]): string {
     // Use the base sealed type; Jackson @JsonTypeInfo handles variant selection.
     return baseName;
   }
+
+  if (unique.length === 1) return unique[0];
 
   // Non-discriminated unions fall back to the Kotlin top type. A generic
   // AnyOf<> is planned for a future phase if emitter tests prove it necessary.

--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -220,6 +220,18 @@ function generateFromArrayValue(ref: TypeRef, accessor: string): string {
     case 'nullable':
       return generateFromArrayValue(ref.inner, accessor);
     case 'union': {
+      // Discriminated union: dispatch via match() on the discriminator
+      // property to call the matching variant's fromArray. Unknown values
+      // pass through as raw arrays so callers can introspect.
+      if (ref.discriminator && ref.discriminator.mapping) {
+        const entries = Object.entries(ref.discriminator.mapping);
+        if (entries.length > 0) {
+          const arms = entries
+            .map(([value, modelName]) => `'${value}' => ${className(modelName)}::fromArray(${accessor})`)
+            .join(', ');
+          return `match (${accessor}['${ref.discriminator.property}'] ?? null) { ${arms}, default => ${accessor} }`;
+        }
+      }
       const resolved = resolveDegenerateUnion(ref);
       if (resolved) return generateFromArrayValue(resolved, accessor);
       return accessor;

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -709,7 +709,22 @@ function deserializeField(ref: any, accessor: string, isRequired: boolean, walru
       return deserializeField(ref.inner, accessor, false, walrusVar);
     case 'union': {
       const modelVariants = (ref.variants ?? []).filter((v: any) => v.kind === 'model');
-      const uniqueModels = [...new Set(modelVariants.map((v: any) => v.name))];
+      const uniqueModels = [...new Set(modelVariants.map((v: any) => v.name))] as string[];
+      // Discriminated union: dispatch on the discriminator property to call
+      // the matching variant's from_dict. Unknown discriminator values fall
+      // back to the raw payload so callers can introspect.
+      if (ref.discriminator && ref.discriminator.mapping) {
+        const entries = Object.entries(ref.discriminator.mapping as Record<string, string>);
+        if (entries.length > 0) {
+          const dispatchMap = entries.map(([value, modelName]) => `"${value}": ${className(modelName)}`).join(', ');
+          const dataExpr = isRequired ? accessor : walrusVar;
+          const dataCast = `cast(Dict[str, Any], ${dataExpr})`;
+          const lookupExpr = `{${dispatchMap}}.get(${dataCast}.get("${ref.discriminator.property}"))`;
+          const branch = `(_disc.from_dict(${dataCast}) if (_disc := ${lookupExpr}) is not None else ${dataExpr})`;
+          if (isRequired) return branch;
+          return `(${branch}) if (${walrusVar} := ${accessor}) is not None else None`;
+        }
+      }
       if (uniqueModels.length === 1) {
         return deserializeField({ kind: 'model', name: uniqueModels[0] }, accessor, isRequired, walrusVar);
       }

--- a/src/ruby/models.ts
+++ b/src/ruby/models.ts
@@ -269,11 +269,30 @@ function deserializeExpression(
   }
 
   if (ref.kind === 'union') {
-    // Unions: if all variants are models, try each; otherwise return raw value.
-    const modelVariants = ref.variants.filter((v) => v.kind === 'model' && modelNames.has(v.name));
-    if (modelVariants.length > 0 && modelVariants.length === ref.variants.length) {
-      // Multiple model variants — default to first successful parse or raw value.
-      return accessor; // simplification: return raw, let user inspect
+    // Discriminated union: dispatch on the discriminator property to construct
+    // the matching variant. Unknown values fall back to the raw hash so callers
+    // can still introspect (rather than crashing on an unmapped discriminator).
+    if (ref.discriminator && ref.discriminator.mapping) {
+      const entries = Object.entries(ref.discriminator.mapping).filter(([, name]) => modelNames.has(name));
+      if (entries.length > 0) {
+        const propAccess = rubyHashAccessor(accessor, ref.discriminator.property);
+        const branches = entries
+          .map(([value, modelName]) => {
+            const cls = `WorkOS::${className(modelName)}`;
+            return `when ${JSON.stringify(value)} then ${cls}.new(${accessor})`;
+          })
+          .join(' ');
+        const dispatcher = `(case ${propAccess} ${branches} else ${accessor} end)`;
+        return `${accessor} ? ${dispatcher} : nil`;
+      }
+    }
+    // Non-discriminated union of models: pick the first variant as a best-
+    // effort typed wrapper. Preserves the pre-discriminator behavior of
+    // wrapping inline-variant unions whose owner used to be a single model.
+    const firstModelVariant = ref.variants.find((v) => v.kind === 'model' && modelNames.has(v.name));
+    if (firstModelVariant && firstModelVariant.kind === 'model') {
+      const cls = `WorkOS::${className(firstModelVariant.name)}`;
+      return `${accessor} ? ${cls}.new(${accessor}) : nil`;
     }
     return accessor;
   }


### PR DESCRIPTION
## Summary

Two related fixes surfaced by the api_keys spec rename in workos/openapi-spec@058a0a4 — see [Ruby PR #477](https://github.com/workos/workos-ruby/pull/477#discussion_r3178905245) and [Go PR #544](https://github.com/workos/workos-go/pull/544#discussion_r3178904428) for the original reports.

**Depends on workos/oagen#57** for the IR changes that surface `discriminator.mapping` and distinct variant model refs on inline `oneOf` unions.

### Bug 1 — Type erasure on `ApiKey.owner` and webhook event variants

`ApiKey.owner` and the `ApiKey{Created,Revoked}Data.owner` payloads went from single inline objects to `oneOf` discriminated unions. Each emitter now honors the IR's discriminator info to generate typed dispatch:

- **Ruby** (`ruby/models.ts`): `case hash[:owner][:type] when "organization" then …` ternary in the deserialize expression. Falls back to the first variant for non-discriminated unions.
- **Python** (`python/models.ts`): walrus-`:=` lookup table dispatching to the matching variant's `from_dict`. Unknown discriminator values fall through to the raw payload.
- **PHP** (`php/models.ts`): `match ($data['owner']['type'] ?? null) { 'organization' => ApiKeyOwner::fromArray(…), … }` in `fromArray`.
- **.NET** (`dotnet/{type-map,models,index}.ts`): registers the union before the unique-collapse so structural model aliasing doesn't lose the dispatcher; uses IR variant names as the converter base name; resolves aliases when emitting `case` arms; emits a per-field `[Newtonsoft.Json.JsonConverter(typeof(<Base>DiscriminatorConverter))]` attribute via the new `discriminatedUnionConverterName` helper.
- **Kotlin** (`kotlin/type-map.ts`): same registration-before-collapse change so the existing sealed-class infrastructure picks up field-level unions.
- **Go** (`go/type-map.ts`): keeps current behavior (Go has no sum types) — widens to the first variant pointer when discriminator is present, so the existing typed `Owner *APIKeyOwner` access pattern is preserved rather than degrading to `interface{}`.

### Bug 2 — Dead `CreateUserAPIKey` / `CreateUserApiKey.cs`

Go and .NET shipped a named request-body schema (e.g. `CreateUserAPIKey`) alongside the synthesized `*Params` / `*Options` struct generated for the same operation. The method signature only consumes the synthesized struct, leaving the named entity as dead public surface (workos-go#544: `CreateUserAPIKey`, workos-dotnet#248: `CreateUserApiKey.cs`).

Both `dotnet/models.ts` and `go/models.ts` now compute a `collectRequestBodyOnlyModelNames` set (models referenced *only* as a named operation request body — never on a response, error, paginated item, or model field) and skip those during emission. Other languages (Ruby/Python/PHP) consume the named model in fixtures or constructor signatures and are unaffected.

## Test plan

- [x] `npm test` passes
- [x] End-to-end generation against the buggy `058a0a4` spec produces typed dispatch in Ruby/Python/PHP/.NET, preserved typed access in Go/Kotlin, and removes `CreateUserAPIKey` from `models.go` and `CreateUserApiKey.cs` from .NET `Entities/`
- [ ] Compat reports green across language SDKs once openapi-spec re-runs the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)