### PR TITLE
fix(go): stop SSO auth code leaking into request URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.16.0"
+        "@workos/oagen": "^0.17.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.16.0.tgz",
-      "integrity": "sha512-0rUFFXcrEUSnQPejCcnetpVc9eAbcjcT5K5gDbN6W2MSRTGMACo8ZkBaH9sWxvuFRu33JTWcjqifo0h5xpIXTg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.17.0.tgz",
+      "integrity": "sha512-Up1ZBixYYNbjuSop5g19N6zeZkmRvblnBQVyeXK25y33jgmzEm41CObXL2s0/OtQOpXqd3vcqMNme/pfSIcBew==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.16.0"
+    "@workos/oagen": "^0.17.0"
   }
 }

--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -410,9 +410,11 @@ function generateParamsStruct(
         const isOptional = !field.required;
         const goType = isOptional ? makeOptional(mapTypeRef(field.type)) : mapTypeRef(field.type);
         const jsonTag = field.required ? `json:"${field.name}"` : `json:"${field.name},omitempty"`;
-        // If this field also appears in query params, emit a url tag too
-        const isAlsoQueryParam = op.queryParams.some((qp) => !hidden.has(qp.name) && fieldName(qp.name) === goField);
-        const urlTag = isAlsoQueryParam ? ` url:"${field.name}${field.required ? '' : ',omitempty'}"` : '';
+        // Body fields are JSON-marshaled into the request body. Emit `url:"-"`
+        // so go-querystring's default field-name fallback doesn't also place
+        // them in the URL — important when the spec duplicates a field as both
+        // body and query param (e.g. /sso/token's `code`).
+        const urlTag = ' url:"-"';
         if (field.description) {
           const fdLines = field.description.split('\n').filter((l) => l.trim());
           lines.push(`\t// ${fieldDocComment(goField, fdLines[0])}`);

--- a/test/go/resources.test.ts
+++ b/test/go/resources.test.ts
@@ -220,9 +220,45 @@ describe('go/resources', () => {
     const files = generateResources(services, makeCtx(spec));
     const content = files[0].content;
     expect(content).toContain('type UsersCreateParams struct {');
-    expect(content).toContain('Email string `json:"email"`');
+    expect(content).toContain('Email string `json:"email" url:"-"`');
     expect(content).toContain('Notify *bool `url:"notify,omitempty" json:"-"`');
     expect(content).toContain('request(ctx, "POST", "/users", params, params, &result, opts)');
+  });
+
+  it('does not emit url tag for body fields shadowed by a same-named query param', () => {
+    // Spec quirk: an operation lists the same field name in both `parameters`
+    // (in: query) and `requestBody`. The body field must not also leak into
+    // the URL query string (e.g. /sso/token's `code` carries an auth code).
+    const services: Service[] = [
+      {
+        name: 'Sso',
+        operations: [
+          makeOp({
+            name: 'getProfileAndToken',
+            httpMethod: 'post',
+            path: '/sso/token',
+            requestBody: { kind: 'model', name: 'TokenQueryDto' },
+            queryParams: [
+              {
+                name: 'code',
+                type: { kind: 'primitive', type: 'string' },
+                required: true,
+              },
+            ],
+          }),
+        ],
+      },
+    ];
+    const spec = makeSpec(services, [
+      {
+        name: 'TokenQueryDto',
+        fields: [{ name: 'code', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ]);
+    const files = generateResources(services, makeCtx(spec));
+    const content = files[0].content;
+    expect(content).toContain('Code string `json:"code" url:"-"`');
+    expect(content).not.toContain('json:"code" url:"code"');
   });
 
   it('emits Deprecated comment for deprecated body field in params struct', () => {

--- a/test/kotlin/resources.test.ts
+++ b/test/kotlin/resources.test.ts
@@ -42,6 +42,35 @@ function ctxFor(services: Service[], enums = baseSpec.enums): EmitterContext {
 }
 
 describe('kotlin/resources', () => {
+  it('wraps every path-template interpolation in encodePathSegment', () => {
+    const services: Service[] = [
+      {
+        name: 'Users',
+        operations: [
+          {
+            name: 'getUser',
+            httpMethod: 'get',
+            path: '/users/{id}/groups/{groupId}',
+            pathParams: [
+              { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+              { name: 'groupId', type: { kind: 'primitive', type: 'string' }, required: true },
+            ],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'primitive', type: 'unknown' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const files = generateResources(services, ctxFor(services));
+    const file = files.find((f) => f.path.endsWith('/Users.kt'))!;
+    expect(file.content).toContain('import com.workos.common.http.encodePathSegment');
+    expect(file.content).toContain('path = "/users/${encodePathSegment(id)}/groups/${encodePathSegment(groupId)}"');
+    expect(file.content).not.toMatch(/path = "[^"]*\$id[^{]/);
+  });
+
   it('collapses duplicated query/body params into a single Kotlin parameter', () => {
     const services: Service[] = [
       {


### PR DESCRIPTION
## Summary
- **Go #22 (security):** OpenAPI spec lists `code` as both a query and body parameter on `/sso/token`. The emitter was tagging the body field `json:"code" url:"code"`, so the Go SDK sent the SSO authorization code in both the JSON body **and** the URL query string. This commit marks every params-struct body field with `url:"-"` so go-querystring's default field-name fallback can't append it to the URL.
- **Kotlin #49 (regression test):** the Kotlin emitter already wraps every `{param}` path interpolation in `encodePathSegment(...)`, but no test pinned that behavior. Add coverage so a future refactor can't silently regress to bare `$id` interpolation and reintroduce path-traversal.
- **Dep bump:** `@workos/oagen` `^0.16.0` → `^0.17.0`.
- Verified by regenerating workos-go and running its `script/ci` (fmt/build/vet/test all pass).

## Test plan
- [x] `npm test` (401 passed)
- [x] `npm run typecheck`
- [x] regenerate workos-go and run `script/ci`
- [ ] regenerate workos-kotlin and confirm `path = "...${encodePathSegment(...)}..."` for every spec-driven path param (helper itself is HAND code in the SDK)