### PR TITLE
fix(emitters): repair regressions surfaced by shared-schema spec rev

### DIFF
--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -133,8 +133,11 @@ export const dotnetEmitter: Emitter = {
         lines.push('    {');
         lines.push('        public override bool CanConvert(Type objectType) => objectType == typeof(object);');
         lines.push('');
+        // Override returns `object?` to match Newtonsoft.Json 13+'s nullable
+        // signature; `JToken.ToObject<T>` is itself `T?`, so a non-nullable
+        // override would trigger CS8603 under <Nullable>enable</Nullable>.
         lines.push(
-          '        public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)',
+          '        public override object? ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)',
         );
         lines.push('        {');
         lines.push('            var jObject = JObject.Load(reader);');
@@ -194,8 +197,9 @@ export const dotnetEmitter: Emitter = {
         `        public override bool CanConvert(Type objectType) => typeof(${baseClass}).IsAssignableFrom(objectType);`,
       );
       lines.push('');
+      // See first converter — `object?` matches Newtonsoft 13+ to avoid CS8603.
       lines.push(
-        '        public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)',
+        '        public override object? ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)',
       );
       lines.push('        {');
       lines.push('            var jObject = JObject.Load(reader);');

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -7,6 +7,7 @@ import {
   emitJsonPropertyAttributes,
   setModelAliases,
   isModelAlias,
+  resolveModelName,
 } from './type-map.js';
 import {
   articleFor,
@@ -54,6 +55,17 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
     }
   }
 
+  const files: GeneratedFile[] = [];
+
+  // Compute and publish model aliases so mapTypeRef rewrites references.
+  // Must run BEFORE collectRequestBodyOnlyModelNames so the body/non-body
+  // tally collapses aliased pairs onto their canonical name — otherwise a
+  // model that's only a request body in name (e.g. `AddRolePermissionDto`)
+  // but is the canonical for a field-referenced alias (e.g. `SlimRole`)
+  // would be wrongly classified as body-only and skipped from emission,
+  // leaving every alias-rewritten field reference dangling.
+  primeModelAliases(models);
+
   // Models that are referenced ONLY as an operation request body (not by any
   // response, field, or other operation type) are dead surface in .NET because
   // the wrapper generator emits a per-operation `*Options` class containing
@@ -62,11 +74,6 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
   // (see workos-dotnet#248 with `CreateUserApiKey` /
   // `UserManagementCreateApiKeyOptions`). Skip emission for those.
   const requestBodyOnlyNames = collectRequestBodyOnlyModelNames(ctx.spec.services, models);
-
-  const files: GeneratedFile[] = [];
-
-  // Compute and publish model aliases so mapTypeRef rewrites references.
-  primeModelAliases(models);
 
   // Build a lookup of base model field C# names → C# types for inheritance.
   // Variant models skip inherited fields and use `new` for type-divergent ones.
@@ -453,17 +460,22 @@ function collectRequestBodyOnlyModelNames(services: Service[], models: Model[]):
   const requestBodyNames = new Set<string>();
   const otherReferences = new Set<string>();
 
+  // Resolve every reference through the alias map so structurally-identical
+  // models share a body/non-body classification. Without this, an alias being
+  // used as a field would only mark the alias name as non-body — leaving its
+  // canonical (which carries the same shape and gets emitted) wrongly tagged
+  // as body-only and skipped.
   const collect = (ref: TypeRef | undefined, into: Set<string>): void => {
     if (!ref) return;
     walkTypeRef(ref, {
-      model: (r) => into.add(r.name),
+      model: (r) => into.add(resolveModelName(r.name)),
     });
   };
 
   for (const service of services) {
     for (const op of service.operations) {
       if (op.requestBody?.kind === 'model') {
-        requestBodyNames.add(op.requestBody.name);
+        requestBodyNames.add(resolveModelName(op.requestBody.name));
       }
       collect(op.response, otherReferences);
       if (op.pagination) collect(op.pagination.itemType, otherReferences);

--- a/src/go/fixtures.ts
+++ b/src/go/fixtures.ts
@@ -46,7 +46,12 @@ export function generateFixtures(spec: { models: Model[]; enums: Enum[]; service
     });
   }
 
-  // Generate list fixtures for paginated responses
+  // Generate list fixtures for paginated responses. Multiple operations may
+  // share the same item model (e.g. several role-assignment list endpoints all
+  // returning UserRoleAssignmentList) — emit each fixture path once so the
+  // content-dedup pass below doesn't see N copies of the same path and drop
+  // the file entirely.
+  const seenListPaths = new Set<string>();
   for (const service of spec.services) {
     for (const op of service.operations) {
       if (op.pagination) {
@@ -55,6 +60,9 @@ export function generateFixtures(spec: { models: Model[]; enums: Enum[]; service
           const unwrapped = unwrapListModel(itemModel, modelMap);
           if (unwrapped) itemModel = unwrapped;
           if (itemModel.fields.length === 0) continue;
+          const path = `testdata/list_${fileName(itemModel.name)}.json`;
+          if (seenListPaths.has(path)) continue;
+          seenListPaths.add(path);
           const fixture = generateModelFixture(itemModel, modelMap, enumMap);
           const listFixture = {
             data: [fixture],
@@ -64,7 +72,7 @@ export function generateFixtures(spec: { models: Model[]; enums: Enum[]; service
             },
           };
           files.push({
-            path: `testdata/list_${fileName(itemModel.name)}.json`,
+            path,
             content: JSON.stringify(listFixture, null, 2),
           });
         }

--- a/src/python/client.ts
+++ b/src/python/client.ts
@@ -286,12 +286,10 @@ function generateServiceInits(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
       overwriteExisting: true,
     });
 
-    // Ensure models/__init__.py exists even if no models are assigned to this service
-    files.push({
-      path: `src/${ctx.namespace}/${dirName}/models/__init__.py`,
-      content: '',
-      skipIfExists: true,
-    });
+    // models/__init__.py is emitted unconditionally by `models.ts` — including
+    // an empty barrel for services with no models — so we don't need a safety
+    // net here. (A `skipIfExists` safety net previously caused stale imports
+    // to survive when the underlying module was pruned.)
   }
 
   return files;

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -447,6 +447,24 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     serviceDirModelPaths.add(`src/${ctx.namespace}/${dirName}/models`);
   }
 
+  // Emit an empty barrel for every service-models dir that has no symbols of
+  // its own (e.g. a service whose models live in another package via
+  // cross-domain aliases). Otherwise the live SDK can keep a stale
+  // `__init__.py` from a previous spec revision — when the underlying module
+  // gets pruned the dangling re-export survives and breaks pyright. Done here
+  // (not in client.ts) so a subsequent emission for the same path with real
+  // content always wins last-write-wins.
+  for (const dirPath of serviceDirModelPaths) {
+    if (!symbolsByDir.has(dirPath)) {
+      files.push({
+        path: `${dirPath}/__init__.py`,
+        content: '',
+        integrateTarget: true,
+        overwriteExisting: true,
+      });
+    }
+  }
+
   for (const [dirPath, names] of symbolsByDir) {
     // Use `import X as X` syntax for explicit re-exports (required by pyright strict)
     const uniqueNames = [...new Set(names)].sort();
@@ -719,7 +737,12 @@ function deserializeField(ref: any, accessor: string, isRequired: boolean, walru
           const dispatchMap = entries.map(([value, modelName]) => `"${value}": ${className(modelName)}`).join(', ');
           const dataExpr = isRequired ? accessor : walrusVar;
           const dataCast = `cast(Dict[str, Any], ${dataExpr})`;
-          const lookupExpr = `{${dispatchMap}}.get(${dataCast}.get("${ref.discriminator.property}"))`;
+          // The dispatch dict has `str` keys, so pyright (strict) rejects the
+          // raw `Any | None` returned by `.get(prop)` even though `dict.get`
+          // accepts any hashable. Cast through `str` to satisfy the parameter
+          // type — runtime semantics are unchanged because a missing/`None`
+          // discriminator simply misses the dispatch and falls through.
+          const lookupExpr = `{${dispatchMap}}.get(cast(str, ${dataCast}.get("${ref.discriminator.property}")))`;
           const branch = `(_disc.from_dict(${dataCast}) if (_disc := ${lookupExpr}) is not None else ${dataExpr})`;
           if (isRequired) return branch;
           return `(${branch}) if (${walrusVar} := ${accessor}) is not None else None`;
@@ -759,6 +782,12 @@ function serializeField(ref: any, accessor: string): string {
       const uniqueModels = [...new Set(modelVariants.map((v: any) => v.name))];
       if (uniqueModels.length === 1) {
         return `${accessor}.to_dict()`;
+      }
+      // Discriminated union: deserialize produced a dataclass instance for
+      // known discriminator values and the raw dict for unknowns. Round-trip
+      // both — call `.to_dict()` if it exists, otherwise pass through.
+      if (ref.discriminator && ref.discriminator.mapping && modelVariants.length > 0) {
+        return `${accessor}.to_dict() if hasattr(${accessor}, "to_dict") else ${accessor}`;
       }
       return accessor;
     }


### PR DESCRIPTION
## Summary

Three independent emitter fixes for fallout from a spec revision that introduced a shared `PaginationOrder` schema and `oneOf`+`discriminator` unions on `ApiKey` owner. Discovered while debugging [openapi-spec PR #20](https://github.com/workos/openapi-spec/pull/20), where every SDK except PHP and Ruby went red.

### `fix(go)` — paginated fixture paths
When several list endpoints share one item model (e.g. three role-assignment list operations all returning `UserRoleAssignmentList`), the pagination loop pushed the same `testdata/list_<item>.json` path N times. The trailing structural-dedup step then saw N≥3 identical paths under one content key, set `pathRewrites[path] = path` for the siblings, and the final `files.filter(f => !pathRewrites.has(f.path))` dropped *every* copy.

Restores `list_user_role_assignment.json`, `list_flag.json`, `list_authorization_permission.json`, `list_user_organization_membership_base_list_data.json`.

### `fix(dotnet)` — aliased canonicals + nullable `ReadJson`
1. `primeModelAliases` now runs before `collectRequestBodyOnlyModelNames`, and the body/non-body tally resolves every ref through `resolveModelName`. Otherwise an alias used as a field (`UserRoleAssignment.role` → `SlimRole`) only marks `SlimRole` as non-body; the canonical it rewrites to (`AddRolePermissionDto`, alphabetically first) gets misclassified body-only and skipped, leaving every alias-rewritten field reference dangling with `CS0246`.
2. Generated discriminator `ReadJson` overrides now return `object?`. Newtonsoft.Json 13+'s base signature is nullable and `JToken.ToObject<T>(serializer)` returns `T?`, so a non-nullable override fires `CS8603` under `<Nullable>enable</Nullable>`.

### `fix(python)` — barrels, discriminator key, union round-trip
1. The empty `models/__init__.py` safety net moved out of `generateServiceInits` (where it was `skipIfExists: true`) and into `generateModels`, which already emits real barrels for services with their own symbols. The old safety net preserved stale re-exports after the underlying module was pruned (e.g. the per-resource `UserManagementOrganizationMembershipGroupsOrder` collapsing into shared `PaginationOrder`), leaving pyright unable to resolve the import.
2. Cast the discriminator dispatch key to `str` so pyright accepts `dict[str, T].get(Any | None)`. Runtime semantics are unchanged.
3. Round-trip discriminated-union variants through `.to_dict()` (with a `hasattr` fallback for the raw-dict default branch) so `to_dict()` matches the wire shape after `from_dict` hydrates a variant dataclass.

## Test plan

Verified end-to-end against the live SDK repos at `main` using the openapi-spec PR #20 spec:

- [x] **workos-go** — `script/ci` → `ok github.com/workos/workos-go/v7`
- [x] **workos-python** — `nox -s ci` → ruff + pyright clean, **2039 passed**
- [x] **workos-dotnet** (after deleting the now-duplicate handwritten `Services/_common/Enums/PaginationOrder.cs`) — **0 errors**, **479 tests passed**

The handwritten dotnet enum is `@oagen-ignore-file` and predates the spec component; the generated enum (`Unknown`/`Normal`/`Desc`/`Asc`) is a strict superset and `ListOptions.cs`'s `PaginationOrder.Desc` reference resolves cleanly. That cleanup belongs in workos-dotnet, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)