### PR TITLE
fix(kotlin): make ktlintFormat actually run after generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.17.0"
+        "@workos/oagen": "^0.17.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
         "@types/node": "^25.6.0",
         "husky": "^9.1.7",
-        "oxfmt": "^0.47.0",
-        "oxlint": "^1.62.0",
+        "oxfmt": "^0.48.0",
+        "oxlint": "^1.63.0",
         "prettier": "^3.8.3",
         "tsdown": "^0.21.10",
         "tsx": "^4.21.0",
@@ -928,9 +928,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.47.0.tgz",
-      "integrity": "sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.48.0.tgz",
+      "integrity": "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==",
       "cpu": [
         "arm"
       ],
@@ -945,9 +945,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.47.0.tgz",
-      "integrity": "sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.48.0.tgz",
+      "integrity": "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==",
       "cpu": [
         "arm64"
       ],
@@ -962,9 +962,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.47.0.tgz",
-      "integrity": "sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.48.0.tgz",
+      "integrity": "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==",
       "cpu": [
         "arm64"
       ],
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.47.0.tgz",
-      "integrity": "sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.48.0.tgz",
+      "integrity": "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==",
       "cpu": [
         "x64"
       ],
@@ -996,9 +996,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.47.0.tgz",
-      "integrity": "sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.48.0.tgz",
+      "integrity": "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==",
       "cpu": [
         "x64"
       ],
@@ -1013,9 +1013,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.47.0.tgz",
-      "integrity": "sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.48.0.tgz",
+      "integrity": "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==",
       "cpu": [
         "arm"
       ],
@@ -1030,9 +1030,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.47.0.tgz",
-      "integrity": "sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.48.0.tgz",
+      "integrity": "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==",
       "cpu": [
         "arm"
       ],
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.47.0.tgz",
-      "integrity": "sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.48.0.tgz",
+      "integrity": "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==",
       "cpu": [
         "arm64"
       ],
@@ -1067,9 +1067,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.47.0.tgz",
-      "integrity": "sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.48.0.tgz",
+      "integrity": "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==",
       "cpu": [
         "arm64"
       ],
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.47.0.tgz",
-      "integrity": "sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.48.0.tgz",
+      "integrity": "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==",
       "cpu": [
         "ppc64"
       ],
@@ -1107,9 +1107,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.47.0.tgz",
-      "integrity": "sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.48.0.tgz",
+      "integrity": "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.47.0.tgz",
-      "integrity": "sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.48.0.tgz",
+      "integrity": "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==",
       "cpu": [
         "riscv64"
       ],
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.47.0.tgz",
-      "integrity": "sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.48.0.tgz",
+      "integrity": "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==",
       "cpu": [
         "s390x"
       ],
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.47.0.tgz",
-      "integrity": "sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.48.0.tgz",
+      "integrity": "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==",
       "cpu": [
         "x64"
       ],
@@ -1187,9 +1187,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.47.0.tgz",
-      "integrity": "sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.48.0.tgz",
+      "integrity": "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==",
       "cpu": [
         "x64"
       ],
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.47.0.tgz",
-      "integrity": "sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.48.0.tgz",
+      "integrity": "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==",
       "cpu": [
         "arm64"
       ],
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.47.0.tgz",
-      "integrity": "sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.48.0.tgz",
+      "integrity": "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.47.0.tgz",
-      "integrity": "sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.48.0.tgz",
+      "integrity": "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==",
       "cpu": [
         "ia32"
       ],
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.47.0.tgz",
-      "integrity": "sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.48.0.tgz",
+      "integrity": "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==",
       "cpu": [
         "x64"
       ],
@@ -1275,9 +1275,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.62.0.tgz",
-      "integrity": "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.63.0.tgz",
+      "integrity": "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==",
       "cpu": [
         "arm"
       ],
@@ -1292,9 +1292,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.62.0.tgz",
-      "integrity": "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.63.0.tgz",
+      "integrity": "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==",
       "cpu": [
         "arm64"
       ],
@@ -1309,9 +1309,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.62.0.tgz",
-      "integrity": "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.63.0.tgz",
+      "integrity": "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==",
       "cpu": [
         "arm64"
       ],
@@ -1326,9 +1326,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.62.0.tgz",
-      "integrity": "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.63.0.tgz",
+      "integrity": "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==",
       "cpu": [
         "x64"
       ],
@@ -1343,9 +1343,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.62.0.tgz",
-      "integrity": "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.63.0.tgz",
+      "integrity": "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==",
       "cpu": [
         "x64"
       ],
@@ -1360,9 +1360,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.62.0.tgz",
-      "integrity": "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.63.0.tgz",
+      "integrity": "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==",
       "cpu": [
         "arm"
       ],
@@ -1377,9 +1377,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.62.0.tgz",
-      "integrity": "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.63.0.tgz",
+      "integrity": "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==",
       "cpu": [
         "arm"
       ],
@@ -1394,9 +1394,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.62.0.tgz",
-      "integrity": "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.63.0.tgz",
+      "integrity": "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==",
       "cpu": [
         "arm64"
       ],
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.62.0.tgz",
-      "integrity": "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.63.0.tgz",
+      "integrity": "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==",
       "cpu": [
         "arm64"
       ],
@@ -1434,9 +1434,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.62.0.tgz",
-      "integrity": "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.63.0.tgz",
+      "integrity": "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1454,9 +1454,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.62.0.tgz",
-      "integrity": "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.63.0.tgz",
+      "integrity": "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==",
       "cpu": [
         "riscv64"
       ],
@@ -1474,9 +1474,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.62.0.tgz",
-      "integrity": "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.63.0.tgz",
+      "integrity": "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1494,9 +1494,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.62.0.tgz",
-      "integrity": "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.63.0.tgz",
+      "integrity": "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==",
       "cpu": [
         "s390x"
       ],
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.62.0.tgz",
-      "integrity": "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.63.0.tgz",
+      "integrity": "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==",
       "cpu": [
         "x64"
       ],
@@ -1534,9 +1534,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.62.0.tgz",
-      "integrity": "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.63.0.tgz",
+      "integrity": "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==",
       "cpu": [
         "x64"
       ],
@@ -1554,9 +1554,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.62.0.tgz",
-      "integrity": "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.63.0.tgz",
+      "integrity": "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==",
       "cpu": [
         "arm64"
       ],
@@ -1571,9 +1571,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.62.0.tgz",
-      "integrity": "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.63.0.tgz",
+      "integrity": "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==",
       "cpu": [
         "arm64"
       ],
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.62.0.tgz",
-      "integrity": "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.63.0.tgz",
+      "integrity": "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==",
       "cpu": [
         "ia32"
       ],
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.62.0.tgz",
-      "integrity": "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.63.0.tgz",
+      "integrity": "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==",
       "cpu": [
         "x64"
       ],
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.17.0.tgz",
-      "integrity": "sha512-Up1ZBixYYNbjuSop5g19N6zeZkmRvblnBQVyeXK25y33jgmzEm41CObXL2s0/OtQOpXqd3vcqMNme/pfSIcBew==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.17.2.tgz",
+      "integrity": "sha512-btU5ED3c1E719RUxzgNbYZNrE7p4O+iLmyd9S/ioruJS2Yzc5b8+ttjw0ZQLurxfNXcoA61fI2kwh912WIIiNg==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",
@@ -2201,7 +2201,7 @@
         "tree-sitter-c-sharp": "^0.23.1",
         "tree-sitter-elixir": "^0.3.5",
         "tree-sitter-go": "^0.23.4",
-        "tree-sitter-kotlin": "^0.3.8",
+        "tree-sitter-kotlin": "github:fwcd/tree-sitter-kotlin#f66d2908542e93c0204c6c241f794afe4e9cd5d1",
         "tree-sitter-php": "^0.23.12",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-ruby": "^0.21.0",
@@ -2287,29 +2287,23 @@
       }
     },
     "node_modules/@workos/oagen/node_modules/tree-sitter-kotlin": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/tree-sitter-kotlin/-/tree-sitter-kotlin-0.3.8.tgz",
-      "integrity": "sha512-A4obq6bjzmYrA+F0JLLoheFPcofFkctNaZSpnDd+GPn1SfVZLY4/GG4C0cYVBTOShuPBGGAOPLM1JWLZQV4m1g==",
+      "version": "0.4.0",
+      "resolved": "git+ssh://git@github.com/fwcd/tree-sitter-kotlin.git#f66d2908542e93c0204c6c241f794afe4e9cd5d1",
+      "integrity": "sha512-onbogYgMICW34xos1mQNJEKnoq+m643z9MBC+AYa7mn4mH/KU4VJZnMVLcTViUErJ8h99KTRQbPH6wPlQLpepg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.0"
+        "tree-sitter": "^0.21.1"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
           "optional": true
         }
       }
-    },
-    "node_modules/@workos/oagen/node_modules/tree-sitter-kotlin/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
     },
     "node_modules/@workos/oagen/node_modules/tree-sitter-php": {
       "version": "0.23.12",
@@ -3589,9 +3583,9 @@
       "license": "MIT"
     },
     "node_modules/oxfmt": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.47.0.tgz",
-      "integrity": "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.48.0.tgz",
+      "integrity": "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3607,31 +3601,31 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.47.0",
-        "@oxfmt/binding-android-arm64": "0.47.0",
-        "@oxfmt/binding-darwin-arm64": "0.47.0",
-        "@oxfmt/binding-darwin-x64": "0.47.0",
-        "@oxfmt/binding-freebsd-x64": "0.47.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.47.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.47.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.47.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.47.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.47.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.47.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.47.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.47.0",
-        "@oxfmt/binding-linux-x64-musl": "0.47.0",
-        "@oxfmt/binding-openharmony-arm64": "0.47.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.47.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.47.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.47.0"
+        "@oxfmt/binding-android-arm-eabi": "0.48.0",
+        "@oxfmt/binding-android-arm64": "0.48.0",
+        "@oxfmt/binding-darwin-arm64": "0.48.0",
+        "@oxfmt/binding-darwin-x64": "0.48.0",
+        "@oxfmt/binding-freebsd-x64": "0.48.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.48.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.48.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.48.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.48.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.48.0",
+        "@oxfmt/binding-linux-x64-musl": "0.48.0",
+        "@oxfmt/binding-openharmony-arm64": "0.48.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.48.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.48.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.48.0"
       }
     },
     "node_modules/oxlint": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.62.0.tgz",
-      "integrity": "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.63.0.tgz",
+      "integrity": "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3644,28 +3638,28 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.62.0",
-        "@oxlint/binding-android-arm64": "1.62.0",
-        "@oxlint/binding-darwin-arm64": "1.62.0",
-        "@oxlint/binding-darwin-x64": "1.62.0",
-        "@oxlint/binding-freebsd-x64": "1.62.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.62.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.62.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.62.0",
-        "@oxlint/binding-linux-arm64-musl": "1.62.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.62.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.62.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.62.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.62.0",
-        "@oxlint/binding-linux-x64-gnu": "1.62.0",
-        "@oxlint/binding-linux-x64-musl": "1.62.0",
-        "@oxlint/binding-openharmony-arm64": "1.62.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.62.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.62.0",
-        "@oxlint/binding-win32-x64-msvc": "1.62.0"
+        "@oxlint/binding-android-arm-eabi": "1.63.0",
+        "@oxlint/binding-android-arm64": "1.63.0",
+        "@oxlint/binding-darwin-arm64": "1.63.0",
+        "@oxlint/binding-darwin-x64": "1.63.0",
+        "@oxlint/binding-freebsd-x64": "1.63.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.63.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.63.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.63.0",
+        "@oxlint/binding-linux-arm64-musl": "1.63.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.63.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.63.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.63.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.63.0",
+        "@oxlint/binding-linux-x64-gnu": "1.63.0",
+        "@oxlint/binding-linux-x64-musl": "1.63.0",
+        "@oxlint/binding-openharmony-arm64": "1.63.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.63.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.63.0",
+        "@oxlint/binding-win32-x64-msvc": "1.63.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.18.0"
+        "oxlint-tsgolint": ">=0.22.1"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@commitlint/config-conventional": "^20.5.3",
     "@types/node": "^25.6.0",
     "husky": "^9.1.7",
-    "oxfmt": "^0.47.0",
-    "oxlint": "^1.62.0",
+    "oxfmt": "^0.48.0",
+    "oxlint": "^1.63.0",
     "prettier": "^3.8.3",
     "tsdown": "^0.21.10",
     "tsx": "^4.21.0",
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.17.0"
+    "@workos/oagen": "^0.17.2"
   }
 }

--- a/src/kotlin/index.ts
+++ b/src/kotlin/index.ts
@@ -93,15 +93,17 @@ export const kotlinEmitter: Emitter = {
   },
 
   formatCommand(targetDir: string): FormatCommand | null {
-    // ktlint enforces a 140-char max line length that cannot be auto-corrected
-    // by the Gradle plugin alone, but `./gradlew ktlintFormat` fixes most
-    // violations (trailing whitespace, import ordering, etc.) across all
-    // generated files. The file list appended by oagen is ignored — Gradle
-    // reformats the whole source set.
+    // `./gradlew ktlintFormat` fixes whitespace, import ordering, and most
+    // wrapping/line-length violations across the whole source set. The file
+    // list appended by oagen is ignored — Gradle reformats every Kotlin
+    // file. oagen's writer already runs the spawned process with
+    // `cwd: targetDir`, so we don't `cd` again (an additional `cd` re-resolves
+    // a relative `targetDir` against itself and silently lands in a missing
+    // directory, which is what was causing this command to no-op in practice).
     if (!fs.existsSync(path.join(targetDir, 'gradlew'))) return null;
     return {
       cmd: 'bash',
-      args: ['-c', `cd ${JSON.stringify(targetDir)} && ./gradlew ktlintFormat --quiet 2>/dev/null; true`, '--'],
+      args: ['-c', './gradlew ktlintFormat --quiet >/dev/null 2>&1; true'],
     };
   },
 };


### PR DESCRIPTION
## Summary

The kotlin emitter's `formatCommand` was a silent no-op in practice. Generated kotlin sources never got `./gradlew ktlintFormat`'d, so they accumulated long-line and arg-wrapping violations that ktlint *can* auto-correct — the formatter just wasn't getting invoked.

## Root cause

`formatCommand` returned a bash invocation that re-`cd`'d into `targetDir` before running gradle:

```ts
return {
  cmd: 'bash',
  args: ['-c', `cd ${JSON.stringify(targetDir)} && ./gradlew ktlintFormat --quiet 2>/dev/null; true`, '--'],
};
```

oagen's writer already spawns the process with `cwd: targetDir` ([orchestrator.ts](https://github.com/workos/oagen/blob/main/src/engine/writer.ts) `execFileAsync(..., { cwd: targetDir, ... })`), and callers (e.g. `openapi-spec/scripts/sdk-generate.sh`) pass `targetDir` **as a path relative to the caller's cwd** (`../backend/workos-kotlin`).

So inside the spawned shell — already `chdir`'d into the resolved absolute targetDir — re-running `cd ../backend/workos-kotlin` resolves **relative to that already-resolved path**, landing in `/Users/.../backend/workos-kotlin/../backend/workos-kotlin`, which doesn't exist. `cd` exits non-zero, `&&` short-circuits, gradle never runs, the trailing `; true` swallows the failure, and oagen prints `[oagen] formatting N file(s) with bash` while having formatted nothing.

## Fix

Drop the redundant `cd` (and the no-longer-needed `--` arg-passthrough placeholder). The spawn cwd is already correct — just run gradle directly:

```ts
return {
  cmd: 'bash',
  args: ['-c', './gradlew ktlintFormat --quiet >/dev/null 2>&1; true'],
};
```

Kept `; true` so a non-formatter ktlint failure never blocks the generation pipeline. Switched the redirect to `>/dev/null 2>&1` for symmetry.

## Test plan

- [x] Reproduced in `workos-kotlin`: pre-fix, `./gradlew ktlintCheck` after a fresh regen reported 100+ violations (long path strings, unwrapped args). Post-fix, the same flow reports zero violations.
- [x] `git checkout . && git clean -fd` + regen → working tree is ktlint-clean
- [x] Second consecutive regen → byte-identical output (idempotent)
- [x] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)