### PR TITLE
feat(dotnet): honor enum default as zero variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.17.3"
+        "@workos/oagen": "^0.18.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.17.3.tgz",
-      "integrity": "sha512-jrDIVOIlFqOAhmcEp4B7zxHfshWUzec8mAjsBsfRAcgFdDvScogUCkXB8MGa5f7Bl/mYpCVikH9zf4w1RoF+8g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.18.0.tgz",
+      "integrity": "sha512-LUBfMwncHeK9+XukbkFeIKT3IA8l2LCK75Lbr7fl/pcVjmyVkowm208Ju8hJ23wbMUTkHg3ddZmyCnt3kf6uEA==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.17.3"
+    "@workos/oagen": "^0.18.0"
   }
 }

--- a/src/dotnet/enums.ts
+++ b/src/dotnet/enums.ts
@@ -70,18 +70,37 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
     lines.push('    [STJS.JsonConverter(typeof(WorkOSStringEnumConverterFactory))]');
     lines.push(`    public enum ${typeName}`);
     lines.push('    {');
-    // Unknown sentinel as first member (value 0) for forward-compatibility
-    lines.push(`        [EnumMember(Value = "unknown")]`);
-    lines.push(`        Unknown,`);
-    lines.push('');
+
+    // If the spec defines a default that matches a member, promote it to
+    // ordinal 0 so `default(EnumType)` returns that variant. Other members
+    // get explicit ascending ordinals, and the Unknown sentinel is pushed
+    // to a high explicit ordinal (99) so it never sits at 0.
+    const defaultMatch =
+      enumDef.default !== undefined ? uniqueValues.find((v) => v.value === enumDef.default) : undefined;
+
+    const orderedValues = defaultMatch
+      ? [defaultMatch, ...uniqueValues.filter((v) => v !== defaultMatch)]
+      : uniqueValues;
 
     const usedNames = new Set<string>();
-    usedNames.add('Unknown');
-    // Track used EnumMember wire values to avoid duplicates (sentinel uses "unknown")
     const usedWireValues = new Set<string>();
-    usedWireValues.add('unknown');
-    for (let i = 0; i < uniqueValues.length; i++) {
-      const v = uniqueValues[i];
+
+    if (defaultMatch) {
+      // Reserve the sentinel name and wire value so spec values that collide
+      // with "unknown"/Unknown still get the existing skip/dedup behavior.
+      usedNames.add('Unknown');
+      usedWireValues.add('unknown');
+    } else {
+      // Existing behavior: Unknown sentinel at ordinal 0.
+      lines.push(`        [EnumMember(Value = "unknown")]`);
+      lines.push(`        Unknown,`);
+      lines.push('');
+      usedNames.add('Unknown');
+      usedWireValues.add('unknown');
+    }
+
+    for (let i = 0; i < orderedValues.length; i++) {
+      const v = orderedValues[i];
       // Skip values whose wire representation collides with the sentinel
       if (usedWireValues.has(String(v.value))) continue;
       usedWireValues.add(String(v.value));
@@ -102,8 +121,15 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         lines.push(`        [System.Obsolete("${msg}")]`);
       }
       lines.push(`        [EnumMember(Value = "${v.value}")]`);
-      const comma = i < uniqueValues.length - 1 ? ',' : ',';
-      lines.push(`        ${memberName}${comma}`);
+      // Explicit ordinals only when we promoted a default to position 0.
+      const ordinal = defaultMatch ? ` = ${i}` : '';
+      lines.push(`        ${memberName}${ordinal},`);
+    }
+
+    if (defaultMatch) {
+      lines.push('');
+      lines.push(`        [EnumMember(Value = "unknown")]`);
+      lines.push(`        Unknown = 99,`);
     }
 
     lines.push('    }');

--- a/test/dotnet/enums.test.ts
+++ b/test/dotnet/enums.test.ts
@@ -152,6 +152,152 @@ describe('dotnet/enums', () => {
     expect(files).toHaveLength(0);
   });
 
+  it('promotes spec-default member to ordinal 0 and pushes Unknown to 99', () => {
+    const enums: Enum[] = [
+      {
+        name: 'PaginationOrder',
+        values: [
+          { name: 'NORMAL', value: 'normal' },
+          { name: 'DESC', value: 'desc' },
+          { name: 'ASC', value: 'asc' },
+        ],
+        default: 'desc',
+      },
+    ];
+
+    const service: Service = {
+      name: 'Test',
+      operations: [
+        {
+          name: 'test',
+          httpMethod: 'get',
+          path: '/test',
+          pathParams: [],
+          queryParams: [{ name: 'order', type: { kind: 'enum', name: 'PaginationOrder' }, required: false }],
+          headerParams: [],
+          response: { kind: 'primitive', type: 'unknown' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const files = generateEnums(enums, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], enums },
+    });
+    expect(files).toHaveLength(1);
+    expect(files[0].content).toMatchInlineSnapshot(`
+      "namespace WorkOS
+      {
+          using System.Runtime.Serialization;
+          using Newtonsoft.Json;
+          using STJS = System.Text.Json.Serialization;
+
+          /// <summary>Represents pagination order values.</summary>
+          [JsonConverter(typeof(WorkOSNewtonsoftStringEnumConverter))]
+          [STJS.JsonConverter(typeof(WorkOSStringEnumConverterFactory))]
+          public enum PaginationOrder
+          {
+              [EnumMember(Value = "desc")]
+              Desc = 0,
+              [EnumMember(Value = "normal")]
+              Normal = 1,
+              [EnumMember(Value = "asc")]
+              Asc = 2,
+
+              [EnumMember(Value = "unknown")]
+              Unknown = 99,
+          }
+      }"
+    `);
+  });
+
+  it('falls back to Unknown=0 layout when no default is set', () => {
+    const enums: Enum[] = [
+      {
+        name: 'Status',
+        values: [
+          { name: 'ACTIVE', value: 'active' },
+          { name: 'INACTIVE', value: 'inactive' },
+        ],
+      },
+    ];
+
+    const service: Service = {
+      name: 'Test',
+      operations: [
+        {
+          name: 'test',
+          httpMethod: 'get',
+          path: '/test',
+          pathParams: [],
+          queryParams: [{ name: 'status', type: { kind: 'enum', name: 'Status' }, required: false }],
+          headerParams: [],
+          response: { kind: 'primitive', type: 'unknown' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const files = generateEnums(enums, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], enums },
+    });
+    expect(files).toHaveLength(1);
+    const content = files[0].content;
+    // No explicit ordinals when no default
+    expect(content).not.toMatch(/= \d+,/);
+    // Unknown sentinel emitted first (no = N)
+    const unknownIdx = content.indexOf('Unknown,');
+    const activeIdx = content.indexOf('Active,');
+    expect(unknownIdx).toBeGreaterThan(0);
+    expect(unknownIdx).toBeLessThan(activeIdx);
+  });
+
+  it('drops a spec value that collides with the unknown sentinel even when default is set', () => {
+    const enums: Enum[] = [
+      {
+        name: 'WithUnknown',
+        values: [
+          { name: 'NORMAL', value: 'normal' },
+          { name: 'UNKNOWN', value: 'unknown' },
+        ],
+        default: 'normal',
+      },
+    ];
+
+    const service: Service = {
+      name: 'Test',
+      operations: [
+        {
+          name: 'test',
+          httpMethod: 'get',
+          path: '/test',
+          pathParams: [],
+          queryParams: [{ name: 'x', type: { kind: 'enum', name: 'WithUnknown' }, required: false }],
+          headerParams: [],
+          response: { kind: 'primitive', type: 'unknown' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const files = generateEnums(enums, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], enums },
+    });
+    expect(files).toHaveLength(1);
+    const content = files[0].content;
+    expect(content).toContain('Normal = 0,');
+    expect(content).toContain('Unknown = 99,');
+    // The spec's "unknown" wire value collides with the sentinel and is dropped,
+    // so the body should not contain a non-99 ordinal for Unknown.
+    expect(content).not.toMatch(/Unknown = [0-8],/);
+  });
+
   it('generates deprecated enum values with Obsolete attribute', () => {
     const enums: Enum[] = [
       {


### PR DESCRIPTION
## Summary

When the spec defines `default:` on an enum schema, the C# emitter now promotes that member to ordinal 0 so `default(EnumType)` returns the spec-default variant. Other members get explicit ascending ordinals (`= 1, = 2, …`) and the synthetic `Unknown` sentinel is moved to a high explicit ordinal (`= 99`). The `EnumMember(Value = "unknown")` attribute is preserved so JSON deserialization of unrecognized values still maps to `Unknown`.

For any enum **without** a spec `default:`, the emitted layout is byte-identical to before this change (Unknown at implicit 0, spec values follow with no explicit ordinals). So this is a no-op for the vast majority of generated enums.

Depends on workos/oagen#66 — that PR adds the `Enum.default` field to the IR; this PR consumes it. Once oagen releases, the dep bump in `package.json` is the only follow-up needed here. CI on this PR will fail until that release lands.

## Behavioral change

This is technically a one-time breaking change for any C# enum that *does* have a spec `default:` — `default(EnumType)` will return a different variant after the regenerated SDK lands. Today, exactly one enum is affected:

- `PaginationOrder` — `default(PaginationOrder)` shifts from `Unknown` to `Desc`.

Other languages are unaffected: Go uses typed string constants, Ruby/Python/PHP/Node use string-valued enums, and Kotlin uses wire-value-driven `enum class` with `@JsonEnumDefaultValue` for forward-compat — none of them have a zero-variant concept.

## Test plan

- [x] New inline-snapshot test for `PaginationOrder` matches the desired layout (`Desc = 0`, `Normal = 1`, `Asc = 2`, `Unknown = 99`)
- [x] Regression test confirms enums without `default:` still emit the existing `Unknown,` first / no-explicit-ordinal layout
- [x] Collision test: a spec value of `"unknown"` is correctly dropped (sentinel guard preserved) when default is set
- [x] Full oagen-emitters suite passes locally against a linked build of oagen#66 (365/365)
- [ ] After oagen release: bump `@workos/oagen` in `package.json`, re-run CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)