### PR TITLE
fix: surface schema/SDK drift across PHP, Python, Go, Ruby emitters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.18.0"
+        "@workos/oagen": "^0.18.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.3",
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.18.0.tgz",
-      "integrity": "sha512-LUBfMwncHeK9+XukbkFeIKT3IA8l2LCK75Lbr7fl/pcVjmyVkowm208Ju8hJ23wbMUTkHg3ddZmyCnt3kf6uEA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.18.1.tgz",
+      "integrity": "sha512-zRapCaSAYPW7nTQktM6IkQuXTjczcALiX2dvW8gFwMtOyz4b6oVSLFQP5kEd4oByEvSqJ53voRVMUatqCYy3vQ==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.18.0"
+    "@workos/oagen": "^0.18.1"
   }
 }

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -198,7 +198,16 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push('');
   }
 
-  // Emit shared PaginationParams struct for list operations to embed
+  // Emit shared PaginationParams struct for list operations to embed.
+  //
+  // The Order field's type is derived from the spec rather than hardcoded:
+  // when every paginated `order` query parameter $refs the same top-level
+  // enum (typically `PaginationOrder` in the WorkOS spec), we emit the typed
+  // enum so callers get compile-time validation. Otherwise we fall back to
+  // *string. The fallback handles older specs that don't lift the enum into a
+  // named component schema.
+  const orderEnumType = detectSharedOrderEnum(ctx.spec.services);
+  const orderGoType = orderEnumType ? `*${className(orderEnumType)}` : '*string';
   lines.push('// PaginationParams contains common pagination parameters for list operations.');
   lines.push('type PaginationParams struct {');
   lines.push('\t// Before is a cursor for reverse pagination.');
@@ -207,8 +216,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   lines.push('\tAfter *string `url:"after,omitempty" json:"-"`');
   lines.push('\t// Limit is the maximum number of items to return per page.');
   lines.push('\tLimit *int `url:"limit,omitempty" json:"-"`');
-  lines.push('\t// Order is the sort order for results (asc or desc).');
-  lines.push('\tOrder *string `url:"order,omitempty" json:"-"`');
+  lines.push('\t// Order is the sort order for results.');
+  lines.push(`\tOrder ${orderGoType} \`url:"order,omitempty" json:"-"\``);
   lines.push('}');
   lines.push('');
 
@@ -309,6 +318,42 @@ function humanize(name: string): string {
 
 function lowerFirst(s: string): string {
   return lowerFirstForDoc(s);
+}
+
+/**
+ * If every paginated list operation's `order` query parameter $refs the same
+ * top-level enum, return that enum's IR name. Otherwise return null. When
+ * the spec is consistent this lifts `PaginationParams.Order` from `*string`
+ * to `*PaginationOrder` (or whatever the spec calls it), giving callers
+ * compile-time validation.
+ *
+ * We require strict consistency: if any operation uses a primitive string for
+ * `order`, or two operations reference different enums, we conservatively
+ * stay on `*string` so the shared struct doesn't lie about its accepted
+ * values.
+ */
+function detectSharedOrderEnum(services: Service[]): string | null {
+  let candidate: string | null = null;
+  let sawAny = false;
+  for (const service of services) {
+    for (const op of service.operations) {
+      if (!op.pagination) continue;
+      const orderParam = op.queryParams.find((p) => p.name === 'order');
+      if (!orderParam) continue;
+      sawAny = true;
+      const enumName = unwrapEnumName(orderParam.type);
+      if (!enumName) return null;
+      if (candidate === null) candidate = enumName;
+      else if (candidate !== enumName) return null;
+    }
+  }
+  return sawAny ? candidate : null;
+}
+
+function unwrapEnumName(ref: TypeRef): string | null {
+  if (ref.kind === 'enum') return ref.name;
+  if (ref.kind === 'nullable') return unwrapEnumName(ref.inner);
+  return null;
 }
 
 /**

--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -313,6 +313,26 @@ function generateToArrayValue(ref: TypeRef, accessor: string, nullable = false):
     case 'union': {
       const resolved = resolveDegenerateUnion(ref);
       if (resolved) return generateToArrayValue(resolved, accessor, nullable);
+      // Polymorphic union of model variants: PHP dispatches to the concrete
+      // instance's toArray() at runtime, so a single ->toArray() call serializes
+      // any branch correctly without a match here.
+      if (ref.variants.every((v) => v.kind === 'model')) {
+        return `${accessor}${ns}->toArray()`;
+      }
+      // Heterogeneous unions involving models or enums have no uniform
+      // serialization strategy (->toArray() vs ->value vs raw scalar), so fail
+      // at codegen time rather than silently emitting a raw object that breaks
+      // the toArray contract. Pure scalar unions (e.g. string|int) fall
+      // through to the bare accessor below — that is correct.
+      if (ref.variants.some((v) => v.kind === 'model' || v.kind === 'enum')) {
+        const summary = ref.variants
+          .map((v) => (v.kind === 'model' ? `model:${v.name}` : v.kind === 'enum' ? `enum:${v.name}` : v.kind))
+          .join(' | ');
+        throw new Error(
+          `[php emitter] Cannot generate toArray for heterogeneous union: ${summary}. ` +
+            `Unions must be all-model or all-scalar; mixed and all-enum unions are not yet supported.`,
+        );
+      }
       return accessor;
     }
     case 'literal':

--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -221,15 +221,19 @@ function generateFromArrayValue(ref: TypeRef, accessor: string): string {
       return generateFromArrayValue(ref.inner, accessor);
     case 'union': {
       // Discriminated union: dispatch via match() on the discriminator
-      // property to call the matching variant's fromArray. Unknown values
-      // pass through as raw arrays so callers can introspect.
+      // property to call the matching variant's fromArray. An unknown
+      // discriminator value would otherwise assign a raw array to a typed
+      // property and crash later with a confusing TypeError, so throw
+      // immediately with the offending value.
       if (ref.discriminator && ref.discriminator.mapping) {
         const entries = Object.entries(ref.discriminator.mapping);
         if (entries.length > 0) {
           const arms = entries
             .map(([value, modelName]) => `'${value}' => ${className(modelName)}::fromArray(${accessor})`)
             .join(', ');
-          return `match (${accessor}['${ref.discriminator.property}'] ?? null) { ${arms}, default => ${accessor} }`;
+          const discProp = ref.discriminator.property;
+          const throwArm = `default => throw new \\UnexpectedValueException(sprintf('Unknown ${discProp}: %s', json_encode(${accessor}['${discProp}'] ?? null)))`;
+          return `match (${accessor}['${discProp}'] ?? null) { ${arms}, ${throwArm} }`;
         }
       }
       const resolved = resolveDegenerateUnion(ref);

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -301,9 +301,10 @@ function generateMethod(
     const phpName = fieldName(q.name);
     if (seenDocParams.has(phpName)) continue;
     seenDocParams.add(phpName);
-    // order params with enum defaults are non-nullable (they default to Desc, not null)
-    const isNonNullableOrder = q.name === 'order' && q.type.kind === 'enum';
-    const nullSuffix = !q.required && !isNonNullableOrder && !docType.endsWith('|null') ? '|null' : '';
+    // Spec-defaulted enum params are non-nullable (the signature default is the
+    // enum case, never null). Without a spec default, the param is nullable.
+    const hasEnumDefault = q.default != null && q.type.kind === 'enum';
+    const nullSuffix = !q.required && !hasEnumDefault && !docType.endsWith('|null') ? '|null' : '';
     const prefix = q.deprecated ? '(deprecated) ' : '';
     let desc = q.description ? ` ${prefix}${q.description}` : q.deprecated ? ' (deprecated)' : '';
     if (q.default != null) desc += ` Defaults to ${JSON.stringify(q.default)}.`;
@@ -682,16 +683,14 @@ function buildMethodParams(
     usedNames.add(phpName);
     if (q.required) {
       required.push(`${phpType} $${phpName}`);
-    } else if (q.name === 'order') {
-      // Hardcode order default to desc for pagination consistency
-      if (q.type.kind === 'enum') {
-        const enumType = mapTypeRef(q.type, { qualified: true });
-        const caseName = toPascalCase('desc');
-        optional.push(`${enumType} $${phpName} = ${enumType}::${caseName}`);
-      } else {
-        const nullableType = phpType.startsWith('?') ? phpType : `?${phpType}`;
-        optional.push(`${nullableType} $${phpName} = 'desc'`);
-      }
+    } else if (q.default != null && q.type.kind === 'enum') {
+      // Spec-provided default for an enum-typed param: emit a non-nullable
+      // typed default (e.g. PaginationOrder $order = PaginationOrder::Desc).
+      // Only enums are safe to default this way — primitives stay nullable so
+      // callers can distinguish "unset" from "explicit value".
+      const enumType = mapTypeRef(q.type, { qualified: true });
+      const caseName = toPascalCase(String(q.default));
+      optional.push(`${enumType} $${phpName} = ${enumType}::${caseName}`);
     } else {
       const nullableType = phpType.startsWith('?') ? phpType : `?${phpType}`;
       optional.push(`${nullableType} $${phpName} = null`);
@@ -756,9 +755,10 @@ function buildQueryArray(op: Operation, hiddenParams?: Set<string>): string[] {
     .map((q) => {
       const phpName = fieldName(q.name);
       if (isEnumType(q.type)) {
-        // order params with enum defaults are non-nullable (default to Desc, not null)
-        const isNonNullableOrder = q.name === 'order' && q.type.kind === 'enum';
-        const nullsafe = q.required || isNonNullableOrder ? '' : '?';
+        // Mirrors the signature: enum params with a spec default are
+        // non-nullable, so we can dereference ->value without the nullsafe op.
+        const hasEnumDefault = q.default != null && q.type.kind === 'enum';
+        const nullsafe = q.required || hasEnumDefault ? '' : '?';
         return `'${q.name}' => $${phpName}${nullsafe}->value,`;
       }
       return `'${q.name}' => $${phpName},`;

--- a/src/python/enums.ts
+++ b/src/python/enums.ts
@@ -312,25 +312,39 @@ function enumValueHash(enumDef: Enum): string {
 }
 
 export function assignEnumsToServices(enums: Enum[], services: Service[]): Map<string, string> {
-  const enumToService = new Map<string, string>();
+  const enumToServices = new Map<string, Set<string>>();
   const enumNames = new Set(enums.map((e) => e.name));
 
   for (const service of services) {
+    const serviceRefs = new Set<string>();
+    const collect = (ref: any) => {
+      walkTypeRef(ref, { enum: (r: any) => serviceRefs.add(r.name) });
+    };
     for (const op of service.operations) {
-      const refs = new Set<string>();
-      const collect = (ref: any) => {
-        walkTypeRef(ref, { enum: (r: any) => refs.add(r.name) });
-      };
       if (op.requestBody) collect(op.requestBody);
       collect(op.response);
       for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
         collect(p.type);
       }
-      for (const name of refs) {
-        if (enumNames.has(name) && !enumToService.has(name)) {
-          enumToService.set(name, service.name);
-        }
+    }
+    for (const name of serviceRefs) {
+      if (!enumNames.has(name)) continue;
+      let bucket = enumToServices.get(name);
+      if (!bucket) {
+        bucket = new Set();
+        enumToServices.set(name, bucket);
       }
+      bucket.add(service.name);
+    }
+  }
+
+  // Enums referenced by exactly one service are owned by that service. Enums
+  // referenced by 2+ services are shared and intentionally left unassigned so
+  // downstream resolveDir() falls back to 'common/'.
+  const enumToService = new Map<string, string>();
+  for (const [name, owners] of enumToServices) {
+    if (owners.size === 1) {
+      enumToService.set(name, [...owners][0]);
     }
   }
 

--- a/src/python/enums.ts
+++ b/src/python/enums.ts
@@ -1,6 +1,7 @@
-import type { Enum, EmitterContext, GeneratedFile, Service } from '@workos/oagen';
-import { toUpperSnakeCase, walkTypeRef } from '@workos/oagen';
+import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
+import { toUpperSnakeCase } from '@workos/oagen';
 import { className, fileName, buildMountDirMap, dirToModule } from './naming.js';
+import { computeSchemaPlacement } from './shared-schemas.js';
 
 /**
  * Convert a PascalCase class name to a human-readable lowercase string,
@@ -21,14 +22,18 @@ function humanizeClassName(name: string): string {
 export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
   if (enums.length === 0) return [];
 
-  const enumToService = assignEnumsToServices(enums, ctx.spec.services);
+  // Tests sometimes pass enums that aren't in ctx.spec.enums, so synthesize a
+  // spec view with the passed-in enums to keep the placement logic accurate.
+  const placementSpec = enums === ctx.spec.enums ? ctx.spec : { ...ctx.spec, enums };
+  const placement = computeSchemaPlacement(placementSpec, ctx);
+  const enumToService = placement.enumToService;
   const mountDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (mountDirMap.get(irService) ?? 'common') : 'common';
   const files: GeneratedFile[] = [];
   const compatAliases = collectCompatEnumAliases(enums, ctx);
 
-  const aliasOf = collectEnumAliasOf(enums);
+  const aliasOf = placement.enumAliases;
 
   for (const enumDef of enums) {
     const service = enumToService.get(enumDef.name);
@@ -260,31 +265,9 @@ export function collectCompatEnumAliases(enums: Enum[], ctx: EmitterContext): Ma
   return aliases;
 }
 
-function collectEnumAliasOf(enums: Enum[]): Map<string, string> {
-  const hashGroups = new Map<string, string[]>();
-  for (const enumDef of enums) {
-    const hash = [...enumDef.values]
-      .map((v) => String(v.value))
-      .sort()
-      .join('|');
-    if (!hashGroups.has(hash)) hashGroups.set(hash, []);
-    hashGroups.get(hash)!.push(enumDef.name);
-  }
-
-  const aliasOf = new Map<string, string>();
-  for (const [, names] of hashGroups) {
-    if (names.length <= 1) continue;
-    const sorted = [...names].sort();
-    const canonical = sorted[0];
-    for (let i = 1; i < sorted.length; i++) {
-      aliasOf.set(sorted[i], canonical);
-    }
-  }
-  return aliasOf;
-}
-
 export function collectGeneratedEnumSymbolsByDir(enums: Enum[], ctx: EmitterContext): Map<string, string[]> {
-  const enumToService = assignEnumsToServices(enums, ctx.spec.services);
+  const placementSpec = enums === ctx.spec.enums ? ctx.spec : { ...ctx.spec, enums };
+  const enumToService = computeSchemaPlacement(placementSpec, ctx).enumToService;
   const mountDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (mountDirMap.get(irService) ?? 'common') : 'common';
@@ -309,44 +292,4 @@ function enumValueHash(enumDef: Enum): string {
     .map((value) => String(value.value))
     .sort()
     .join('|');
-}
-
-export function assignEnumsToServices(enums: Enum[], services: Service[]): Map<string, string> {
-  const enumToServices = new Map<string, Set<string>>();
-  const enumNames = new Set(enums.map((e) => e.name));
-
-  for (const service of services) {
-    const serviceRefs = new Set<string>();
-    const collect = (ref: any) => {
-      walkTypeRef(ref, { enum: (r: any) => serviceRefs.add(r.name) });
-    };
-    for (const op of service.operations) {
-      if (op.requestBody) collect(op.requestBody);
-      collect(op.response);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
-        collect(p.type);
-      }
-    }
-    for (const name of serviceRefs) {
-      if (!enumNames.has(name)) continue;
-      let bucket = enumToServices.get(name);
-      if (!bucket) {
-        bucket = new Set();
-        enumToServices.set(name, bucket);
-      }
-      bucket.add(service.name);
-    }
-  }
-
-  // Enums referenced by exactly one service are owned by that service. Enums
-  // referenced by 2+ services are shared and intentionally left unassigned so
-  // downstream resolveDir() falls back to 'common/'.
-  const enumToService = new Map<string, string>();
-  for (const [name, owners] of enumToServices) {
-    if (owners.size === 1) {
-      enumToService.set(name, [...owners][0]);
-    }
-  }
-
-  return enumToService;
 }

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -1,9 +1,9 @@
-import type { Model, Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
-import { assignModelsToServices, collectFieldDependencies, planOperation, walkTypeRef } from '@workos/oagen';
+import type { Model, EmitterContext, GeneratedFile } from '@workos/oagen';
+import { collectFieldDependencies, walkTypeRef } from '@workos/oagen';
 import { mapTypeRef } from './type-map.js';
 import { className, fieldName, fileName, buildMountDirMap, dirToModule } from './naming.js';
-import { assignEnumsToServices, collectGeneratedEnumSymbolsByDir } from './enums.js';
-import { findSharedSchemas } from './shared-schemas.js';
+import { collectGeneratedEnumSymbolsByDir } from './enums.js';
+import { computeSchemaPlacement } from './shared-schemas.js';
 
 /**
  * Generate Python dataclass model files from IR Model definitions.
@@ -12,17 +12,19 @@ import { findSharedSchemas } from './shared-schemas.js';
 export function generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
   if (models.length === 0) return [];
 
-  const modelToService = assignModelsToServices(models, ctx.spec.services, ctx.modelHints);
-  const enumToService = assignEnumsToServices(ctx.spec.enums, ctx.spec.services);
-  // Models referenced (transitively) by 2+ services are shared; route them to
-  // common/ rather than the first alphabetical service that happens to use them.
-  // assignModelsToServices uses first-wins, so we strip shared assignments here.
-  // Hinted models bypass the shared rule (an explicit pin always wins).
-  const hintedNames = new Set(Object.keys(ctx.modelHints ?? {}));
-  const { models: sharedModelNames } = findSharedSchemas(ctx.spec);
-  for (const name of sharedModelNames) {
-    if (!hintedNames.has(name)) modelToService.delete(name);
-  }
+  // Tests sometimes pass models that aren't in ctx.spec.models, so synthesize
+  // a spec view with the passed-in models to keep the placement logic accurate.
+  const placementSpec = models === ctx.spec.models ? ctx.spec : { ...ctx.spec, models };
+  const placement = computeSchemaPlacement(placementSpec, ctx);
+  const {
+    modelToService,
+    enumToService,
+    originalModelToService,
+    originalEnumToService,
+    relocatedModels,
+    relocatedEnums,
+    modelAliases: aliasOf,
+  } = placement;
   const mountDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (mountDirMap.get(irService) ?? 'common') : 'common';
@@ -31,32 +33,9 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // Overrides fileName() for symbols that live in a differently-named file.
   // Used for variant type aliases (e.g. EventSchemaVariant → event_schema).
   const symbolToFile = new Map<string, string>();
-  const modelUsage = collectModelUsage(ctx.spec);
-
-  // Build recursive structural hashes for deduplication.
-  // Model/enum references are resolved bottom-up so structurally-identical
-  // model trees (e.g. event context/actor sub-models) get the same hash.
-  const recursiveHashes = buildRecursiveHashMap(models, ctx.spec.enums);
-  const hashGroups = new Map<string, string[]>(); // hash -> model names
-  for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
-    const hash = recursiveHashes.get(model.name) ?? '';
-    if (!hashGroups.has(hash)) hashGroups.set(hash, []);
-    hashGroups.get(hash)!.push(model.name);
-  }
-
-  // For each group of identical models, pick canonical (alphabetically first)
-  const aliasOf = new Map<string, string>(); // alias name -> canonical name
-  for (const [, names] of hashGroups) {
-    if (names.length <= 1) continue;
-    const sorted = [...names].sort((a, b) => compareAliasPriority(a, b, modelUsage));
-    const canonical = sorted[0];
-    for (let i = 1; i < sorted.length; i++) {
-      if (canAliasModels(canonical, sorted[i], modelUsage)) {
-        aliasOf.set(sorted[i], canonical);
-      }
-    }
-  }
+  // Track each emitted symbol's natural (pre-relocation) service so we can
+  // re-export relocated symbols from their original service barrel for BC.
+  const symbolToOriginalService = new Map<string, string>();
 
   // Track emitted file paths to prevent duplicates when synthetic models from
   // oneOf enrichment collide with existing IR models in snake_case.
@@ -189,6 +168,12 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       symbolToFile.set(variantTypeName, fileName(model.name));
       emittedModelSymbolsByDir.get(dirName)!.push(unknownClassName);
       symbolToFile.set(unknownClassName, fileName(model.name));
+      const dispatcherNatural = originalModelToService.get(model.name);
+      if (dispatcherNatural) {
+        symbolToOriginalService.set(model.name, dispatcherNatural);
+        symbolToOriginalService.set(variantTypeName, dispatcherNatural);
+        symbolToOriginalService.set(unknownClassName, dispatcherNatural);
+      }
       continue;
     }
 
@@ -224,6 +209,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       });
       if (!emittedModelSymbolsByDir.has(dirName)) emittedModelSymbolsByDir.set(dirName, []);
       emittedModelSymbolsByDir.get(dirName)!.push(model.name);
+      const aliasNatural = originalModelToService.get(model.name);
+      if (aliasNatural) symbolToOriginalService.set(model.name, aliasNatural);
       continue;
     }
 
@@ -428,15 +415,21 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     });
     if (!emittedModelSymbolsByDir.has(dirName)) emittedModelSymbolsByDir.set(dirName, []);
     emittedModelSymbolsByDir.get(dirName)!.push(model.name);
+    const regularNatural = originalModelToService.get(model.name);
+    if (regularNatural) symbolToOriginalService.set(model.name, regularNatural);
   }
 
   // Generate __init__.py barrel files for each models/ directory
-  // Include both models and enums
-  const symbolsByDir = new Map<string, string[]>();
+  // Include both models and enums.
+  // A direct symbol lives in the file at `dirPath/<file>.py`. A re-exported
+  // symbol was relocated to common/ but is being mirrored from its natural
+  // service barrel for backwards compatibility.
+  type BarrelSymbol = { name: string; reExport?: { fromDir: string; file: string } };
+  const symbolsByDir = new Map<string, BarrelSymbol[]>();
   for (const [dirName, names] of emittedModelSymbolsByDir) {
     const key = `src/${ctx.namespace}/${dirName}/models`;
     if (!symbolsByDir.has(key)) symbolsByDir.set(key, []);
-    symbolsByDir.get(key)!.push(...names);
+    for (const name of names) symbolsByDir.get(key)!.push({ name });
   }
 
   // Also include enums in the barrels using the enum emitter's actual output placement.
@@ -446,7 +439,37 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   for (const [dirName, names] of enumSymbolsByDir) {
     const key = `src/${ctx.namespace}/${dirName}/models`;
     if (!symbolsByDir.has(key)) symbolsByDir.set(key, []);
-    symbolsByDir.get(key)!.push(...names);
+    for (const name of names) symbolsByDir.get(key)!.push({ name });
+  }
+
+  // Backwards-compat re-exports: every relocated model is also re-exported
+  // from its pre-relocation service barrel so existing
+  // `from workos.<service>.models import X` imports keep working.
+  const commonDirName = 'common';
+  const addReExport = (naturalService: string | undefined, name: string, sourceFile: string): void => {
+    if (!naturalService) return;
+    const naturalDir = mountDirMap.get(naturalService) ?? naturalService;
+    if (naturalDir === commonDirName) return;
+    const key = `src/${ctx.namespace}/${naturalDir}/models`;
+    if (!symbolsByDir.has(key)) symbolsByDir.set(key, []);
+    symbolsByDir.get(key)!.push({ name, reExport: { fromDir: commonDirName, file: sourceFile } });
+  };
+
+  for (const symbol of symbolToOriginalService.keys()) {
+    // Only re-export symbols that ended up relocated (i.e. their owning model is in relocatedModels)
+    // or whose dispatcher parent is relocated.
+    const naturalService = symbolToOriginalService.get(symbol)!;
+    // Find what file the symbol lives in (in common/)
+    const file = symbolToFile.get(symbol) ?? fileName(symbol);
+    // Only re-export if it actually got relocated — that is, if its primary
+    // model name (or the parent it shares a file with) is in relocatedModels.
+    const primaryName = file === fileName(symbol) ? symbol : reverseLookupModelByFile(file, ctx);
+    if (primaryName && !relocatedModels.has(primaryName)) continue;
+    addReExport(naturalService, symbol, file);
+  }
+  for (const enumName of relocatedEnums) {
+    const naturalService = originalEnumToService.get(enumName);
+    addReExport(naturalService, enumName, fileName(enumName));
   }
 
   // Build set of service directory model paths — these get their parent __init__.py
@@ -475,13 +498,28 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     }
   }
 
-  for (const [dirPath, names] of symbolsByDir) {
+  for (const [dirPath, symbols] of symbolsByDir) {
+    // Deduplicate by symbol name (a direct emission always wins over a stale
+    // re-export with the same name).
+    const seen = new Map<string, BarrelSymbol>();
+    for (const sym of symbols) {
+      const existing = seen.get(sym.name);
+      if (!existing || (existing.reExport && !sym.reExport)) seen.set(sym.name, sym);
+    }
+    const uniqueSymbols = [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+
     // Use `import X as X` syntax for explicit re-exports (required by pyright strict)
-    const uniqueNames = [...new Set(names)].sort();
     const importLines: string[] = [];
-    for (const name of uniqueNames) {
-      const fileNameForSymbol = symbolToFile.get(name) ?? fileName(name);
-      importLines.push(`from .${fileNameForSymbol} import ${className(name)} as ${className(name)}`);
+    for (const sym of uniqueSymbols) {
+      const cls = className(sym.name);
+      if (sym.reExport) {
+        importLines.push(
+          `from ${ctx.namespace}.${dirToModule(sym.reExport.fromDir)}.models.${sym.reExport.file} import ${cls} as ${cls}`,
+        );
+      } else {
+        const fileNameForSymbol = symbolToFile.get(sym.name) ?? fileName(sym.name);
+        importLines.push(`from .${fileNameForSymbol} import ${cls} as ${cls}`);
+      }
     }
     const imports = importLines.join('\n');
     files.push({
@@ -496,9 +534,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     // which includes both the resource class re-export and model star import.
     if (!serviceDirModelPaths.has(dirPath)) {
       const parentDir = dirPath.replace(/\/models$/, '');
-      const reExports = [...new Set(names)]
-        .sort()
-        .map((name) => `from .models import ${className(name)} as ${className(name)}`)
+      const reExports = uniqueSymbols
+        .map((sym) => `from .models import ${className(sym.name)} as ${className(sym.name)}`)
         .join('\n');
       files.push({
         path: `${parentDir}/__init__.py`,
@@ -510,6 +547,18 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   }
 
   return files;
+}
+
+/**
+ * Given a snake_case file name, return the IR model name that owns it.
+ * Used to attribute dispatcher children (FooVariant, FooUnknown) to their
+ * parent model when computing relocation re-exports.
+ */
+function reverseLookupModelByFile(file: string, ctx: EmitterContext): string | undefined {
+  for (const m of ctx.spec.models) {
+    if (fileName(m.name) === file) return m.name;
+  }
+  return undefined;
 }
 
 function collectTypingImports(ref: any, imports: Set<string>): void {
@@ -587,73 +636,6 @@ function collectReachableEnumNames(ctx: EmitterContext): Set<string> {
   }
 
   return referencedEnums;
-}
-
-function collectModelUsage(spec: EmitterContext['spec']): {
-  requestOnly: Set<string>;
-  response: Set<string>;
-  mixed: Set<string>;
-} {
-  const request = new Set<string>();
-  const response = new Set<string>();
-
-  for (const service of spec.services) {
-    for (const op of service.operations) {
-      const plan = planOperation(op);
-      if (plan.responseModelName) {
-        response.add(plan.responseModelName);
-      }
-      if (op.pagination?.itemType.kind === 'model') {
-        response.add(op.pagination.itemType.name);
-      }
-      if (op.requestBody?.kind === 'model') {
-        request.add(op.requestBody.name);
-      }
-      if (op.requestBody?.kind === 'union') {
-        for (const variant of op.requestBody.variants ?? []) {
-          if (variant.kind === 'model') request.add(variant.name);
-        }
-      }
-    }
-  }
-
-  const mixed = new Set<string>();
-  for (const name of request) {
-    if (response.has(name)) mixed.add(name);
-  }
-
-  const requestOnly = new Set([...request].filter((name) => !mixed.has(name)));
-  const responseOnly = new Set([...response].filter((name) => !mixed.has(name)));
-
-  return { requestOnly, response: responseOnly, mixed };
-}
-
-function compareAliasPriority(left: string, right: string, usage: ReturnType<typeof collectModelUsage>): number {
-  const score = (name: string): number => {
-    if (usage.response.has(name)) return 0;
-    if (usage.mixed.has(name)) return 1;
-    if (usage.requestOnly.has(name)) return 2;
-    return 3;
-  };
-
-  const diff = score(left) - score(right);
-  if (diff !== 0) return diff;
-  return left.localeCompare(right);
-}
-
-function canAliasModels(canonical: string, alias: string, usage: ReturnType<typeof collectModelUsage>): boolean {
-  // Don't alias when both models produce the same file name — the TypeAlias
-  // file would import from itself (e.g., FooBar aliased to Foo_bar).
-  if (fileName(canonical) === fileName(alias)) return false;
-  // Don't alias across request/response boundaries — a request-only model
-  // and a response-only model may look identical today but evolve independently.
-  if (
-    (usage.response.has(canonical) && usage.requestOnly.has(alias)) ||
-    (usage.response.has(alias) && usage.requestOnly.has(canonical))
-  ) {
-    return false;
-  }
-  return true;
 }
 
 function isOptionalField(modelName: string, field: Model['fields'][number], ctx: EmitterContext): boolean {
@@ -804,89 +786,6 @@ function serializeField(ref: any, accessor: string): string {
     default:
       return accessor;
   }
-}
-
-/**
- * Build recursive structural hashes for all models.
- *
- * Model references are resolved to their own structural hash (bottom-up) and
- * enum references are resolved to their value-set hash.  This means
- * structurally-identical model *trees* — like the dozens of per-event Context /
- * ContextActor / ContextGoogleAnalyticsSession sub-models in the spec — get
- * the same hash even though their IR names differ.
- */
-function buildRecursiveHashMap(models: Model[], enums: Enum[]): Map<string, string> {
-  const modelByName = new Map(models.map((m) => [m.name, m]));
-  const hashCache = new Map<string, string>();
-  const visiting = new Set<string>(); // cycle guard
-
-  // Pre-compute enum value hashes so identically-valued enums hash the same.
-  const enumVH = new Map<string, string>();
-  for (const e of enums) {
-    enumVH.set(
-      e.name,
-      [...e.values]
-        .map((v) => String(v.value))
-        .sort()
-        .join('|'),
-    );
-  }
-
-  function modelHash(name: string): string {
-    const cached = hashCache.get(name);
-    if (cached != null) return cached;
-    if (visiting.has(name)) return `m:${name}`; // cycle — fall back to name
-    visiting.add(name);
-
-    const model = modelByName.get(name);
-    if (!model) {
-      visiting.delete(name);
-      return `m:${name}`; // unknown model
-    }
-
-    const hash = [...model.fields]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((f) => `${f.name}:${deepTypeHash(f.type)}:${f.required}`)
-      .join('|');
-
-    visiting.delete(name);
-    hashCache.set(name, hash);
-    return hash;
-  }
-
-  function deepTypeHash(ref: any): string {
-    switch (ref.kind) {
-      case 'primitive':
-        return `p:${ref.type}${ref.format ? `:${ref.format}` : ''}`;
-      case 'model':
-        return `m:{${modelHash(ref.name)}}`;
-      case 'enum': {
-        const vh = enumVH.get(ref.name);
-        return vh != null ? `e:{${vh}}` : `e:${ref.name}`;
-      }
-      case 'array':
-        return `a:${deepTypeHash(ref.items)}`;
-      case 'nullable':
-        return `n:${deepTypeHash(ref.inner)}`;
-      case 'union':
-        return `u:${(ref.variants ?? [])
-          .map((v: any) => deepTypeHash(v))
-          .sort()
-          .join(',')}`;
-      case 'map':
-        return `d:${deepTypeHash(ref.valueType)}`;
-      case 'literal':
-        return `l:${String(ref.value)}`;
-      default:
-        return 'unknown';
-    }
-  }
-
-  for (const model of models) {
-    modelHash(model.name);
-  }
-
-  return hashCache;
 }
 
 // Import and re-export shared model detection utilities

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -347,12 +347,22 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push(`    def from_dict(cls, data: Dict[str, Any]) -> "${modelClassName}":`);
     lines.push(`        """Deserialize from a dictionary."""`);
     lines.push('        try:');
-    lines.push('            return cls(');
+
+    const preludeLines: string[] = [];
+    const fieldAssignmentLines: string[] = [];
 
     for (const field of [...requiredFields, ...optionalFields]) {
       const pyFieldName = fieldName(field.name);
       const wireKey = field.name; // Wire keys are snake_case from the spec
       const isRequired = !isOptionalField(model.name, field, ctx);
+
+      const discPrelude = renderDiscriminatedUnionPrelude(field, pyFieldName, wireKey, modelClassName, isRequired);
+      if (discPrelude) {
+        preludeLines.push(...discPrelude.prelude);
+        fieldAssignmentLines.push(`                ${pyFieldName}=${discPrelude.expr},`);
+        continue;
+      }
+
       let accessor: string;
       if (field.type.kind === 'literal' && isRequired) {
         // Required literal fields have a statically known value; use .get() with a default
@@ -366,9 +376,12 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       const deserRequired = isRequired && field.type.kind !== 'nullable';
       const walrusVar = `_v_${pyFieldName}`;
       const deserExpr = deserializeField(field.type, accessor, deserRequired, walrusVar);
-      lines.push(`                ${pyFieldName}=${deserExpr},`);
+      fieldAssignmentLines.push(`                ${pyFieldName}=${deserExpr},`);
     }
 
+    for (const preludeLine of preludeLines) lines.push(preludeLine);
+    lines.push('            return cls(');
+    for (const assignment of fieldAssignmentLines) lines.push(assignment);
     lines.push('            )');
     lines.push('        except (KeyError, ValueError) as e:');
     lines.push(`            _raise_deserialize_error("${modelClassName}", e)`);
@@ -675,6 +688,87 @@ function isDateTimeType(ref: any): boolean {
   return ref.kind === 'primitive' && ref.type === 'string' && ref.format === 'date-time';
 }
 
+/**
+ * If `field` is a discriminated-union (or nullable-wrapped discriminated-union)
+ * field, return prelude statements that perform strict dispatch and an
+ * expression for the `cls(...)` call. Returns null otherwise.
+ *
+ * Strict dispatch means: an unknown discriminator value raises ValueError
+ * naming the parent class, field, observed value, and valid options. The
+ * caller's `try/except` block converts that into `_raise_deserialize_error`.
+ */
+function renderDiscriminatedUnionPrelude(
+  field: any,
+  pyFieldName: string,
+  wireKey: string,
+  parentClassName: string,
+  isRequired: boolean,
+): { prelude: string[]; expr: string } | null {
+  let unionRef: any = null;
+  let nullable = false;
+  if (field.type.kind === 'union' && field.type.discriminator?.mapping) {
+    unionRef = field.type;
+  } else if (
+    field.type.kind === 'nullable' &&
+    field.type.inner.kind === 'union' &&
+    field.type.inner.discriminator?.mapping
+  ) {
+    unionRef = field.type.inner;
+    nullable = true;
+  }
+  if (!unionRef) return null;
+
+  const mapping = unionRef.discriminator.mapping as Record<string, string>;
+  const entries = Object.entries(mapping);
+  if (entries.length === 0) return null;
+
+  const discProp = unionRef.discriminator.property as string;
+  const rawVar = `_${pyFieldName}_raw`;
+  const dataVar = `_${pyFieldName}_data`;
+  const typeVar = `_${pyFieldName}_disc`;
+  const mapVar = `_${pyFieldName}_disc_map`;
+  const clsVar = `_${pyFieldName}_cls`;
+  const valueVar = `_${pyFieldName}_value`;
+  const indent = '            ';
+
+  const dispatchBlock = (innerIndent: string): string[] => {
+    const lines: string[] = [];
+    lines.push(`${innerIndent}${dataVar} = cast(Dict[str, Any], ${rawVar})`);
+    lines.push(`${innerIndent}${typeVar} = cast(str, ${dataVar}.get("${discProp}"))`);
+    lines.push(`${innerIndent}${mapVar}: Dict[str, Any] = {`);
+    for (const [value, variantModelName] of entries) {
+      lines.push(`${innerIndent}    "${value}": ${className(variantModelName)},`);
+    }
+    lines.push(`${innerIndent}}`);
+    lines.push(`${innerIndent}${clsVar} = ${mapVar}.get(${typeVar})`);
+    lines.push(`${innerIndent}if ${clsVar} is None:`);
+    lines.push(`${innerIndent}    raise ValueError(`);
+    lines.push(
+      `${innerIndent}        f"Unknown discriminator '${discProp}' for ${parentClassName}.${pyFieldName}: {${typeVar}!r}. "`,
+    );
+    lines.push(`${innerIndent}        f"Expected one of {sorted(${mapVar})}."`);
+    lines.push(`${innerIndent}    )`);
+    return lines;
+  };
+
+  const prelude: string[] = [];
+  if (isRequired && !nullable) {
+    prelude.push(`${indent}${rawVar} = data["${wireKey}"]`);
+    prelude.push(...dispatchBlock(indent));
+    return { prelude, expr: `${clsVar}.from_dict(${dataVar})` };
+  }
+
+  // Optional or nullable: handle missing/None explicitly.
+  const accessor = isRequired ? `data["${wireKey}"]` : `data.get("${wireKey}")`;
+  prelude.push(`${indent}${rawVar} = ${accessor}`);
+  prelude.push(`${indent}if ${rawVar} is None:`);
+  prelude.push(`${indent}    ${valueVar} = None`);
+  prelude.push(`${indent}else:`);
+  prelude.push(...dispatchBlock(indent + '    '));
+  prelude.push(`${indent}    ${valueVar} = ${clsVar}.from_dict(${dataVar})`);
+  return { prelude, expr: valueVar };
+}
+
 function deserializeField(ref: any, accessor: string, isRequired: boolean, walrusVar: string = '_v'): string {
   if (isDateTimeType(ref)) {
     if (isRequired) {
@@ -718,28 +812,10 @@ function deserializeField(ref: any, accessor: string, isRequired: boolean, walru
     case 'nullable':
       return deserializeField(ref.inner, accessor, false, walrusVar);
     case 'union': {
+      // Discriminated unions are handled by `renderDiscriminatedUnionPrelude`
+      // before deserializeField is called, so they never reach this branch.
       const modelVariants = (ref.variants ?? []).filter((v: any) => v.kind === 'model');
       const uniqueModels = [...new Set(modelVariants.map((v: any) => v.name))] as string[];
-      // Discriminated union: dispatch on the discriminator property to call
-      // the matching variant's from_dict. Unknown discriminator values fall
-      // back to the raw payload so callers can introspect.
-      if (ref.discriminator && ref.discriminator.mapping) {
-        const entries = Object.entries(ref.discriminator.mapping as Record<string, string>);
-        if (entries.length > 0) {
-          const dispatchMap = entries.map(([value, modelName]) => `"${value}": ${className(modelName)}`).join(', ');
-          const dataExpr = isRequired ? accessor : walrusVar;
-          const dataCast = `cast(Dict[str, Any], ${dataExpr})`;
-          // The dispatch dict has `str` keys, so pyright (strict) rejects the
-          // raw `Any | None` returned by `.get(prop)` even though `dict.get`
-          // accepts any hashable. Cast through `str` to satisfy the parameter
-          // type — runtime semantics are unchanged because a missing/`None`
-          // discriminator simply misses the dispatch and falls through.
-          const lookupExpr = `{${dispatchMap}}.get(cast(str, ${dataCast}.get("${ref.discriminator.property}")))`;
-          const branch = `(_disc.from_dict(${dataCast}) if (_disc := ${lookupExpr}) is not None else ${dataExpr})`;
-          if (isRequired) return branch;
-          return `(${branch}) if (${walrusVar} := ${accessor}) is not None else None`;
-        }
-      }
       if (uniqueModels.length === 1) {
         return deserializeField({ kind: 'model', name: uniqueModels[0] }, accessor, isRequired, walrusVar);
       }
@@ -775,11 +851,11 @@ function serializeField(ref: any, accessor: string): string {
       if (uniqueModels.length === 1) {
         return `${accessor}.to_dict()`;
       }
-      // Discriminated union: deserialize produced a dataclass instance for
-      // known discriminator values and the raw dict for unknowns. Round-trip
-      // both — call `.to_dict()` if it exists, otherwise pass through.
+      // Discriminated union: from_dict always produces a concrete dataclass
+      // instance (unknown discriminators raise instead of falling back to a
+      // raw dict), so the serialized field is unconditionally `.to_dict()`-able.
       if (ref.discriminator && ref.discriminator.mapping && modelVariants.length > 0) {
-        return `${accessor}.to_dict() if hasattr(${accessor}, "to_dict") else ${accessor}`;
+        return `${accessor}.to_dict()`;
       }
       return accessor;
     }

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -3,6 +3,7 @@ import { assignModelsToServices, collectFieldDependencies, planOperation, walkTy
 import { mapTypeRef } from './type-map.js';
 import { className, fieldName, fileName, buildMountDirMap, dirToModule } from './naming.js';
 import { assignEnumsToServices, collectGeneratedEnumSymbolsByDir } from './enums.js';
+import { findSharedSchemas } from './shared-schemas.js';
 
 /**
  * Generate Python dataclass model files from IR Model definitions.
@@ -13,6 +14,15 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
   const modelToService = assignModelsToServices(models, ctx.spec.services, ctx.modelHints);
   const enumToService = assignEnumsToServices(ctx.spec.enums, ctx.spec.services);
+  // Models referenced (transitively) by 2+ services are shared; route them to
+  // common/ rather than the first alphabetical service that happens to use them.
+  // assignModelsToServices uses first-wins, so we strip shared assignments here.
+  // Hinted models bypass the shared rule (an explicit pin always wins).
+  const hintedNames = new Set(Object.keys(ctx.modelHints ?? {}));
+  const { models: sharedModelNames } = findSharedSchemas(ctx.spec);
+  for (const name of sharedModelNames) {
+    if (!hintedNames.has(name)) modelToService.delete(name);
+  }
   const mountDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (mountDirMap.get(irService) ?? 'common') : 'common';

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -293,11 +293,16 @@ function emitMethodSignature(
     lines.push('        limit: Optional[int] = None,');
     lines.push('        before: Optional[str] = None,');
     lines.push('        after: Optional[str] = None,');
-    // Use typed enum for order param if the spec provides one, otherwise fall back to str
+    // Use typed enum for order param if the spec provides one, otherwise fall
+    // back to str. The default value comes from the spec's `default:` field;
+    // when the spec drops the default, we surface that as `None` rather than
+    // silently restoring "desc" client-side (which would mask a server-side
+    // behavior change from the caller).
     const orderParam = op.queryParams.find((p) => p.name === 'order');
     const orderType =
       orderParam && orderParam.type.kind === 'enum' ? mapTypeRefUnquoted(orderParam.type, specEnumNames, true) : 'str';
-    lines.push(`        order: Optional[${orderType}] = "desc",`);
+    const orderDefault = orderParam?.default != null ? pythonLiteral(orderParam.default) : 'None';
+    lines.push(`        order: Optional[${orderType}] = ${orderDefault},`);
     // Additional non-pagination query params
     for (const param of op.queryParams) {
       if (['limit', 'before', 'after', 'order'].includes(param.name)) continue;

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -12,14 +12,7 @@ import type {
 
 /** Extend Parameter with `explode` until @workos/oagen publishes the field. */
 type ParameterExt = Parameter & { explode?: boolean };
-import {
-  planOperation,
-  toPascalCase,
-  toSnakeCase,
-  collectModelRefs,
-  collectEnumRefs,
-  assignModelsToServices,
-} from '@workos/oagen';
+import { planOperation, toPascalCase, toSnakeCase, collectModelRefs, collectEnumRefs } from '@workos/oagen';
 import { mapTypeRefUnquoted } from './type-map.js';
 import {
   className,
@@ -49,8 +42,7 @@ import {
   clientFieldExpression,
 } from './wrappers.js';
 import { buildPythonPathExpression } from './path-expression.js';
-import { assignEnumsToServices } from './enums.js';
-import { findSharedSchemas } from './shared-schemas.js';
+import { computeSchemaPlacement } from './shared-schemas.js';
 
 /**
  * Compute the Python parameter name for a body field, prefixing with `body_` if it
@@ -1138,15 +1130,8 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
     const actualModelImports = [...modelImports];
 
     // Split imports into same-service and cross-service (using mount-based dirs)
-    const modelToServiceMap = assignModelsToServices(ctx.spec.models, ctx.spec.services, ctx.modelHints);
-    // Models referenced by 2+ services are shared and emitted under common/.
-    // Strip their assignments here so resolveModelDir() falls back to 'common'.
-    // Hinted models bypass the shared rule.
-    const hintedModels = new Set(Object.keys(ctx.modelHints ?? {}));
-    const { models: sharedModels } = findSharedSchemas(ctx.spec);
-    for (const name of sharedModels) {
-      if (!hintedModels.has(name)) modelToServiceMap.delete(name);
-    }
+    const placement = computeSchemaPlacement(ctx.spec, ctx);
+    const modelToServiceMap = new Map(placement.modelToService);
     // Discriminator variant type aliases (e.g. EventSchemaVariant) live in the same
     // service as their dispatcher model, so ensure they resolve to the same directory.
     for (const model of ctx.spec.models) {
@@ -1189,7 +1174,7 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
     // Enum imports — same-service vs cross-service. Shared enums (referenced
     // by 2+ services) are intentionally absent from this map so they resolve
     // to common/ via the resolveDir() fallback below.
-    const enumToServiceMap = assignEnumsToServices(ctx.spec.enums, ctx.spec.services);
+    const enumToServiceMap = placement.enumToService;
 
     const localEnums: string[] = [];
     const crossServiceEnums = new Map<string, string[]>();

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -49,6 +49,8 @@ import {
   clientFieldExpression,
 } from './wrappers.js';
 import { buildPythonPathExpression } from './path-expression.js';
+import { assignEnumsToServices } from './enums.js';
+import { findSharedSchemas } from './shared-schemas.js';
 
 /**
  * Compute the Python parameter name for a body field, prefixing with `body_` if it
@@ -1133,6 +1135,14 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
 
     // Split imports into same-service and cross-service (using mount-based dirs)
     const modelToServiceMap = assignModelsToServices(ctx.spec.models, ctx.spec.services, ctx.modelHints);
+    // Models referenced by 2+ services are shared and emitted under common/.
+    // Strip their assignments here so resolveModelDir() falls back to 'common'.
+    // Hinted models bypass the shared rule.
+    const hintedModels = new Set(Object.keys(ctx.modelHints ?? {}));
+    const { models: sharedModels } = findSharedSchemas(ctx.spec);
+    for (const name of sharedModels) {
+      if (!hintedModels.has(name)) modelToServiceMap.delete(name);
+    }
     // Discriminator variant type aliases (e.g. EventSchemaVariant) live in the same
     // service as their dispatcher model, so ensure they resolve to the same directory.
     for (const model of ctx.spec.models) {
@@ -1172,30 +1182,10 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
       }
     }
 
-    // Enum imports — same-service vs cross-service
-    const enumToServiceMap = new Map<string, string>();
-    for (const e of ctx.spec.enums) {
-      // Find which service uses this enum by walking full type trees
-      for (const svc of ctx.spec.services) {
-        for (const op of svc.operations) {
-          const refs = new Set<string>();
-          // Walk all type refs (including nested nullable/array/union) to find enums
-          const allTypeRefs = [
-            op.response,
-            ...(op.requestBody ? [op.requestBody] : []),
-            ...op.pathParams.map((p) => p.type),
-            ...op.queryParams.map((p) => p.type),
-            ...op.headerParams.map((p) => p.type),
-          ];
-          for (const typeRef of allTypeRefs) {
-            for (const ref of collectEnumRefs(typeRef)) refs.add(ref);
-          }
-          if (refs.has(e.name) && !enumToServiceMap.has(e.name)) {
-            enumToServiceMap.set(e.name, svc.name);
-          }
-        }
-      }
-    }
+    // Enum imports — same-service vs cross-service. Shared enums (referenced
+    // by 2+ services) are intentionally absent from this map so they resolve
+    // to common/ via the resolveDir() fallback below.
+    const enumToServiceMap = assignEnumsToServices(ctx.spec.enums, ctx.spec.services);
 
     const localEnums: string[] = [];
     const crossServiceEnums = new Map<string, string[]>();

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -303,7 +303,11 @@ function emitMethodSignature(
     const orderParam = op.queryParams.find((p) => p.name === 'order');
     const orderType =
       orderParam && orderParam.type.kind === 'enum' ? mapTypeRefUnquoted(orderParam.type, specEnumNames, true) : 'str';
-    const orderDefault = orderParam?.default != null ? pythonLiteral(orderParam.default) : 'None';
+    const orderDefaultRaw = orderParam?.default;
+    const orderDefault =
+      typeof orderDefaultRaw === 'string' || typeof orderDefaultRaw === 'number' || typeof orderDefaultRaw === 'boolean'
+        ? pythonLiteral(orderDefaultRaw)
+        : 'None';
     lines.push(`        order: Optional[${orderType}] = ${orderDefault},`);
     // Additional non-pagination query params
     for (const param of op.queryParams) {

--- a/src/python/shared-schemas.ts
+++ b/src/python/shared-schemas.ts
@@ -1,5 +1,7 @@
-import type { ApiSpec } from '@workos/oagen';
-import { walkTypeRef } from '@workos/oagen';
+import type { ApiSpec, EmitterContext, Enum, Model, Service } from '@workos/oagen';
+import { assignModelsToServices, collectFieldDependencies, planOperation, walkTypeRef } from '@workos/oagen';
+import { fileName } from './naming.js';
+import { detectDiscriminators } from '../shared/model-utils.js';
 
 /**
  * Walk every operation across all services and tally, per schema, the set of
@@ -7,8 +9,8 @@ import { walkTypeRef } from '@workos/oagen';
  * service are "shared" — they should be emitted under common/ rather than
  * the first alphabetical service that happens to use them.
  *
- * Transitive walk for models follows model->model field references to a fixed
- * point; enums are leaves.
+ * Transitive walk for models follows model->model field references AND
+ * discriminator variant mappings to a fixed point; enums are leaves.
  */
 export function findSharedSchemas(spec: ApiSpec): { models: Set<string>; enums: Set<string> } {
   const modelsByName = new Map(spec.models.map((m) => [m.name, m]));
@@ -49,7 +51,9 @@ export function findSharedSchemas(spec: ApiSpec): { models: Set<string>; enums: 
       }
     }
 
-    // Transitively expand model references via field types.
+    // Transitively expand model references via field types AND discriminator
+    // variant mappings (dispatchers route to variants without listing them as
+    // fields, so plain field-walking misses them).
     const queue = [...directModels];
     while (queue.length > 0) {
       const name = queue.pop()!;
@@ -65,6 +69,15 @@ export function findSharedSchemas(spec: ApiSpec): { models: Set<string>; enums: 
           },
           enum: (r) => directEnums.add(r.name),
         });
+      }
+      const disc = (model as { discriminator?: { property: string; mapping: Record<string, string> } }).discriminator;
+      if (disc?.mapping) {
+        for (const variantName of Object.values(disc.mapping)) {
+          if (!directModels.has(variantName)) {
+            directModels.add(variantName);
+            queue.push(variantName);
+          }
+        }
       }
     }
 
@@ -82,4 +95,394 @@ export function findSharedSchemas(spec: ApiSpec): { models: Set<string>; enums: 
   }
 
   return { models: sharedModels, enums: sharedEnums };
+}
+
+/**
+ * Final placement decisions for every model and enum in the spec. Computed
+ * once and consumed by every Python emitter pass (models, enums, resources,
+ * tests) so they all agree on which symbols live in `common/` and which live
+ * in a service directory.
+ */
+export interface SchemaPlacement {
+  /** Model -> service. Models in common/ are absent. */
+  modelToService: Map<string, string>;
+  /** Enum -> service. Enums in common/ are absent. */
+  enumToService: Map<string, string>;
+  /** Pre-relocation model -> service. Used to attach BC re-exports to the natural service barrel. */
+  originalModelToService: Map<string, string>;
+  /** Pre-relocation enum -> service. */
+  originalEnumToService: Map<string, string>;
+  /** Models relocated to common/ (the union of initial sharing + closure expansion). */
+  relocatedModels: Set<string>;
+  /** Enums relocated to common/. */
+  relocatedEnums: Set<string>;
+  /** Model alias name -> canonical model name (Python-only structural dedup). */
+  modelAliases: Map<string, string>;
+  /** Enum alias name -> canonical enum name. */
+  enumAliases: Map<string, string>;
+}
+
+export function computeSchemaPlacement(spec: ApiSpec, ctx: EmitterContext): SchemaPlacement {
+  // Annotate models with implicit discriminators so the closure can follow
+  // dispatcher → variant edges. detectDiscriminators is idempotent.
+  const annotatedModels = detectDiscriminators(spec.models);
+  if (annotatedModels !== spec.models) {
+    spec = { ...spec, models: annotatedModels };
+  }
+  const modelsByName = new Map(spec.models.map((m) => [m.name, m]));
+  const hintedModels = new Set(Object.keys(ctx.modelHints ?? {}));
+
+  const originalModelToService = assignModelsToServices(spec.models, spec.services, ctx.modelHints);
+  const originalEnumToService = assignEnumsToServicesNatural(spec.enums, spec.services);
+
+  // Precompute Python-specific structural alias maps so the closure can
+  // promote a canonical when its alias is shared.
+  const modelAliases = computeModelAliases(spec);
+  const enumAliases = computeEnumAliases(spec.enums);
+
+  const initial = findSharedSchemas(spec);
+
+  // Ensure aliases imply their canonical: if the alias is shared, the canonical
+  // must follow it into common/, otherwise the alias file would import from a
+  // service directory.
+  for (const [aliasName, canonicalName] of modelAliases) {
+    if (initial.models.has(aliasName)) initial.models.add(canonicalName);
+  }
+  for (const [aliasName, canonicalName] of enumAliases) {
+    if (initial.enums.has(aliasName)) initial.enums.add(canonicalName);
+  }
+
+  // Initial common/-bound set: everything findSharedSchemas flagged (minus
+  // hinted models — direct shares respect explicit pins) plus everything that
+  // is unassigned from the natural placement and not pinned.
+  const sharedModels = new Set<string>();
+  for (const name of initial.models) {
+    if (!hintedModels.has(name)) sharedModels.add(name);
+  }
+  for (const model of spec.models) {
+    if (!originalModelToService.has(model.name) && !hintedModels.has(model.name)) {
+      sharedModels.add(model.name);
+    }
+  }
+  const sharedEnums = new Set(initial.enums);
+  for (const enumDef of spec.enums) {
+    if (!originalEnumToService.has(enumDef.name)) sharedEnums.add(enumDef.name);
+  }
+
+  // Closure: any model/enum referenced by a model that ends up in common/
+  // must also be in common/, otherwise the emitted common/ file would reach
+  // back into a service package and create a circular-import hazard. Hints
+  // are *not* a stop signal here — the closure is structural. If a hinted
+  // model is reachable from common/, leaving it pinned to a service would
+  // re-introduce the back-edge. BC for the pinned import path is preserved
+  // via re-exports from the natural service barrel.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const name of sharedModels) {
+      const model = modelsByName.get(name);
+      if (!model) continue;
+      const deps = collectEmittedDependencies(model, modelAliases);
+      for (const dep of deps.models) {
+        if (sharedModels.has(dep)) continue;
+        if (!modelsByName.has(dep)) continue;
+        sharedModels.add(dep);
+        changed = true;
+      }
+      for (const dep of deps.enums) {
+        if (sharedEnums.has(dep)) continue;
+        sharedEnums.add(dep);
+        changed = true;
+      }
+    }
+  }
+
+  // Build final assignment maps by relocating shared symbols to common/
+  // (i.e. removing them from the per-service assignment).
+  const modelToService = new Map(originalModelToService);
+  for (const name of sharedModels) {
+    modelToService.delete(name);
+  }
+  const enumToService = new Map(originalEnumToService);
+  for (const name of sharedEnums) {
+    enumToService.delete(name);
+  }
+
+  // relocatedModels = models with a natural service that ended up in common/.
+  // Models without a natural service were never in a service barrel, so they
+  // don't need a BC re-export. Hinted models DO get re-exported from the
+  // hinted service so existing imports keep resolving.
+  const relocatedModels = new Set<string>();
+  for (const name of sharedModels) {
+    if (!originalModelToService.has(name)) continue;
+    relocatedModels.add(name);
+  }
+  const relocatedEnums = new Set<string>();
+  for (const name of sharedEnums) {
+    if (!originalEnumToService.has(name)) continue;
+    relocatedEnums.add(name);
+  }
+
+  return {
+    modelToService,
+    enumToService,
+    originalModelToService,
+    originalEnumToService,
+    relocatedModels,
+    relocatedEnums,
+    modelAliases,
+    enumAliases,
+  };
+}
+
+/**
+ * Dependencies the emitter will materialize for a model's generated file.
+ * Captures alias canonicals, discriminator variants, and field-level model+enum
+ * references so the placement closure can decide whether the dependency must
+ * also live in `common/`.
+ */
+function collectEmittedDependencies(
+  model: Model,
+  modelAliases: Map<string, string>,
+): { models: Set<string>; enums: Set<string> } {
+  const models = new Set<string>();
+  const enums = new Set<string>();
+
+  const canonical = modelAliases.get(model.name);
+  if (canonical) {
+    models.add(canonical);
+    return { models, enums };
+  }
+
+  const disc = (model as { discriminator?: { property: string; mapping: Record<string, string> } }).discriminator;
+  if (disc?.mapping) {
+    for (const variant of Object.values(disc.mapping)) models.add(variant);
+  }
+
+  const fieldDeps = collectFieldDependencies(model);
+  for (const m of fieldDeps.models) models.add(m);
+  for (const e of fieldDeps.enums) enums.add(e);
+
+  return { models, enums };
+}
+
+interface ModelUsage {
+  requestOnly: Set<string>;
+  response: Set<string>;
+  mixed: Set<string>;
+}
+
+function collectModelUsage(spec: ApiSpec): ModelUsage {
+  const request = new Set<string>();
+  const response = new Set<string>();
+
+  for (const service of spec.services) {
+    for (const op of service.operations) {
+      const plan = planOperation(op);
+      if (plan.responseModelName) response.add(plan.responseModelName);
+      if (op.pagination?.itemType.kind === 'model') response.add(op.pagination.itemType.name);
+      if (op.requestBody?.kind === 'model') request.add(op.requestBody.name);
+      if (op.requestBody?.kind === 'union') {
+        for (const variant of op.requestBody.variants ?? []) {
+          if (variant.kind === 'model') request.add(variant.name);
+        }
+      }
+    }
+  }
+
+  const mixed = new Set<string>();
+  for (const name of request) if (response.has(name)) mixed.add(name);
+  const requestOnly = new Set([...request].filter((name) => !mixed.has(name)));
+  const responseOnly = new Set([...response].filter((name) => !mixed.has(name)));
+
+  return { requestOnly, response: responseOnly, mixed };
+}
+
+function compareAliasPriority(left: string, right: string, usage: ModelUsage): number {
+  const score = (name: string): number => {
+    if (usage.response.has(name)) return 0;
+    if (usage.mixed.has(name)) return 1;
+    if (usage.requestOnly.has(name)) return 2;
+    return 3;
+  };
+
+  const diff = score(left) - score(right);
+  if (diff !== 0) return diff;
+  return left.localeCompare(right);
+}
+
+function canAliasModels(canonical: string, alias: string, usage: ModelUsage): boolean {
+  // Aliases that snake_case-collide with their canonical would self-import.
+  if (fileName(canonical) === fileName(alias)) return false;
+  // Don't alias across the request/response boundary — they may evolve apart.
+  if (
+    (usage.response.has(canonical) && usage.requestOnly.has(alias)) ||
+    (usage.response.has(alias) && usage.requestOnly.has(canonical))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Compute the Python emitter's structural model dedup map: alias -> canonical.
+ * Mirrors the logic in models.ts so the placement closure can promote
+ * canonicals when their aliases are shared.
+ */
+export function computeModelAliases(spec: ApiSpec): Map<string, string> {
+  const recursiveHashes = buildRecursiveHashMap(spec.models, spec.enums);
+  const usage = collectModelUsage(spec);
+
+  const hashGroups = new Map<string, string[]>();
+  for (const model of spec.models) {
+    if (model.fields.length === 0 && !(model as { discriminator?: unknown }).discriminator) {
+      // skipped by emit anyway when listmeta/wrapper, but we rely on emit-side filter.
+    }
+    const hash = recursiveHashes.get(model.name) ?? '';
+    if (!hashGroups.has(hash)) hashGroups.set(hash, []);
+    hashGroups.get(hash)!.push(model.name);
+  }
+
+  const aliasOf = new Map<string, string>();
+  for (const [, names] of hashGroups) {
+    if (names.length <= 1) continue;
+    const sorted = [...names].sort((a, b) => compareAliasPriority(a, b, usage));
+    const canonical = sorted[0];
+    for (let i = 1; i < sorted.length; i++) {
+      if (canAliasModels(canonical, sorted[i], usage)) {
+        aliasOf.set(sorted[i], canonical);
+      }
+    }
+  }
+  return aliasOf;
+}
+
+/**
+ * Compute the Python emitter's structural enum dedup map: alias -> canonical.
+ * Mirrors the logic in enums.ts.
+ */
+export function computeEnumAliases(enums: Enum[]): Map<string, string> {
+  const hashGroups = new Map<string, string[]>();
+  for (const enumDef of enums) {
+    const hash = [...enumDef.values]
+      .map((v) => String(v.value))
+      .sort()
+      .join('|');
+    if (!hashGroups.has(hash)) hashGroups.set(hash, []);
+    hashGroups.get(hash)!.push(enumDef.name);
+  }
+
+  const aliasOf = new Map<string, string>();
+  for (const [, names] of hashGroups) {
+    if (names.length <= 1) continue;
+    const sorted = [...names].sort();
+    const canonical = sorted[0];
+    for (let i = 1; i < sorted.length; i++) {
+      aliasOf.set(sorted[i], canonical);
+    }
+  }
+  return aliasOf;
+}
+
+/**
+ * Recursive structural hashing for models so dedup runs against deeply-equal
+ * shapes, not just same-named ones. Cycles fall back to the model name.
+ */
+function buildRecursiveHashMap(models: Model[], enums: Enum[]): Map<string, string> {
+  const modelByName = new Map(models.map((m) => [m.name, m]));
+  const hashCache = new Map<string, string>();
+  const visiting = new Set<string>();
+
+  const enumVH = new Map<string, string>();
+  for (const e of enums) {
+    enumVH.set(
+      e.name,
+      [...e.values]
+        .map((v) => String(v.value))
+        .sort()
+        .join('|'),
+    );
+  }
+
+  function modelHash(name: string): string {
+    const cached = hashCache.get(name);
+    if (cached != null) return cached;
+    if (visiting.has(name)) return `m:${name}`;
+    visiting.add(name);
+
+    const model = modelByName.get(name);
+    if (!model) {
+      visiting.delete(name);
+      return `m:${name}`;
+    }
+
+    const hash = [...model.fields]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((f) => `${f.name}:${deepTypeHash(f.type)}:${f.required}`)
+      .join('|');
+
+    visiting.delete(name);
+    hashCache.set(name, hash);
+    return hash;
+  }
+
+  function deepTypeHash(ref: any): string {
+    switch (ref.kind) {
+      case 'primitive':
+        return `p:${ref.type}${ref.format ? `:${ref.format}` : ''}`;
+      case 'model':
+        return `m:{${modelHash(ref.name)}}`;
+      case 'enum': {
+        const vh = enumVH.get(ref.name);
+        return vh != null ? `e:{${vh}}` : `e:${ref.name}`;
+      }
+      case 'array':
+        return `a:${deepTypeHash(ref.items)}`;
+      case 'nullable':
+        return `n:${deepTypeHash(ref.inner)}`;
+      case 'union':
+        return `u:${(ref.variants ?? [])
+          .map((v: any) => deepTypeHash(v))
+          .sort()
+          .join(',')}`;
+      case 'map':
+        return `d:${deepTypeHash(ref.valueType)}`;
+      case 'literal':
+        return `l:${String(ref.value)}`;
+      default:
+        return 'unknown';
+    }
+  }
+
+  for (const model of models) modelHash(model.name);
+  return hashCache;
+}
+
+/**
+ * Natural enum-to-service assignment without sharing logic — the first service
+ * (alphabetically by spec order) to reference an enum wins.
+ */
+function assignEnumsToServicesNatural(enums: Enum[], services: Service[]): Map<string, string> {
+  const enumNames = new Set(enums.map((e) => e.name));
+  const enumToService = new Map<string, string>();
+
+  for (const service of services) {
+    const refs = new Set<string>();
+    const collect = (ref: any): void => {
+      walkTypeRef(ref, { enum: (r: any) => refs.add(r.name) });
+    };
+    for (const op of service.operations) {
+      if (op.requestBody) collect(op.requestBody);
+      collect(op.response);
+      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+        collect(p.type);
+      }
+    }
+    for (const name of refs) {
+      if (!enumNames.has(name)) continue;
+      if (!enumToService.has(name)) enumToService.set(name, service.name);
+    }
+  }
+
+  return enumToService;
 }

--- a/src/python/shared-schemas.ts
+++ b/src/python/shared-schemas.ts
@@ -1,0 +1,85 @@
+import type { ApiSpec } from '@workos/oagen';
+import { walkTypeRef } from '@workos/oagen';
+
+/**
+ * Walk every operation across all services and tally, per schema, the set of
+ * services that transitively reference it. Schemas referenced by more than one
+ * service are "shared" — they should be emitted under common/ rather than
+ * the first alphabetical service that happens to use them.
+ *
+ * Transitive walk for models follows model->model field references to a fixed
+ * point; enums are leaves.
+ */
+export function findSharedSchemas(spec: ApiSpec): { models: Set<string>; enums: Set<string> } {
+  const modelsByName = new Map(spec.models.map((m) => [m.name, m]));
+  const modelToServices = new Map<string, Set<string>>();
+  const enumToServices = new Map<string, Set<string>>();
+
+  const note = (map: Map<string, Set<string>>, name: string, service: string): void => {
+    let bucket = map.get(name);
+    if (!bucket) {
+      bucket = new Set();
+      map.set(name, bucket);
+    }
+    bucket.add(service);
+  };
+
+  for (const service of spec.services) {
+    const directModels = new Set<string>();
+    const directEnums = new Set<string>();
+    const collect = (ref: unknown): void => {
+      walkTypeRef(ref as never, {
+        model: (r) => directModels.add(r.name),
+        enum: (r) => directEnums.add(r.name),
+      });
+    };
+
+    for (const op of service.operations) {
+      if (op.requestBody) collect(op.requestBody);
+      collect(op.response);
+      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+        collect(p.type);
+      }
+      if (op.pagination) collect(op.pagination.itemType);
+      for (const err of op.errors) {
+        if (err.type) collect(err.type);
+      }
+      for (const sr of op.successResponses ?? []) {
+        collect(sr.type);
+      }
+    }
+
+    // Transitively expand model references via field types.
+    const queue = [...directModels];
+    while (queue.length > 0) {
+      const name = queue.pop()!;
+      const model = modelsByName.get(name);
+      if (!model) continue;
+      for (const field of model.fields) {
+        walkTypeRef(field.type as never, {
+          model: (r) => {
+            if (!directModels.has(r.name)) {
+              directModels.add(r.name);
+              queue.push(r.name);
+            }
+          },
+          enum: (r) => directEnums.add(r.name),
+        });
+      }
+    }
+
+    for (const name of directModels) note(modelToServices, name, service.name);
+    for (const name of directEnums) note(enumToServices, name, service.name);
+  }
+
+  const sharedModels = new Set<string>();
+  for (const [name, services] of modelToServices) {
+    if (services.size >= 2) sharedModels.add(name);
+  }
+  const sharedEnums = new Set<string>();
+  for (const [name, services] of enumToServices) {
+    if (services.size >= 2) sharedEnums.add(name);
+  }
+
+  return { models: sharedModels, enums: sharedEnums };
+}

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -32,6 +32,7 @@ import {
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { pythonLiteral } from './wrappers.js';
+import { findSharedSchemas } from './shared-schemas.js';
 
 /**
  * Resolve the Python class name to use for isinstance checks on paginated items.
@@ -228,6 +229,13 @@ function generateServiceTest(
 
   // Group imports by their actual service directory (models may live in different services)
   const modelToServiceMap = assignModelsToServices(spec.models, spec.services, ctx.modelHints);
+  // Models referenced by 2+ services are shared and emitted under common/.
+  // Strip their assignments here so resolveModelDir() falls back to 'common'.
+  const hintedModels = new Set(Object.keys(ctx.modelHints ?? {}));
+  const { models: sharedModels } = findSharedSchemas(spec);
+  for (const name of sharedModels) {
+    if (!hintedModels.has(name)) modelToServiceMap.delete(name);
+  }
   const mountDirMap = buildMountDirMap(ctx);
   const resolveModelDir = (modelName: string) => {
     const svc = modelToServiceMap.get(modelName);

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -8,7 +8,7 @@ import type {
   Model,
   ResolvedOperation,
 } from '@workos/oagen';
-import { planOperation, toSnakeCase, assignModelsToServices } from '@workos/oagen';
+import { planOperation, toSnakeCase } from '@workos/oagen';
 import {
   className,
   fileName,
@@ -22,7 +22,6 @@ import { resolveResourceClassName, bodyParamName } from './resources.js';
 import { buildServiceAccessPaths } from './client.js';
 import { generateFixtures, generateModelFixture } from './fixtures.js';
 import { isListWrapperModel, isListMetadataModel } from './models.js';
-import { assignEnumsToServices } from './enums.js';
 import {
   groupByMount,
   buildResolvedLookup,
@@ -32,7 +31,7 @@ import {
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { pythonLiteral } from './wrappers.js';
-import { findSharedSchemas } from './shared-schemas.js';
+import { computeSchemaPlacement } from './shared-schemas.js';
 
 /**
  * Resolve the Python class name to use for isinstance checks on paginated items.
@@ -228,22 +227,14 @@ function generateServiceTest(
   });
 
   // Group imports by their actual service directory (models may live in different services)
-  const modelToServiceMap = assignModelsToServices(spec.models, spec.services, ctx.modelHints);
-  // Models referenced by 2+ services are shared and emitted under common/.
-  // Strip their assignments here so resolveModelDir() falls back to 'common'.
-  const hintedModels = new Set(Object.keys(ctx.modelHints ?? {}));
-  const { models: sharedModels } = findSharedSchemas(spec);
-  for (const name of sharedModels) {
-    if (!hintedModels.has(name)) modelToServiceMap.delete(name);
-  }
+  const placement = computeSchemaPlacement(spec, ctx);
+  const modelToServiceMap = placement.modelToService;
+  const enumToServiceMap = placement.enumToService;
   const mountDirMap = buildMountDirMap(ctx);
   const resolveModelDir = (modelName: string) => {
     const svc = modelToServiceMap.get(modelName);
     return svc ? (mountDirMap.get(svc) ?? 'common') : 'common';
   };
-
-  // Group enum imports by service directory
-  const enumToServiceMap = assignEnumsToServices(spec.enums, spec.services);
   const resolveEnumDir = (enumName: string) => {
     const svc = enumToServiceMap.get(enumName);
     return svc ? (mountDirMap.get(svc) ?? 'common') : 'common';
@@ -1410,7 +1401,10 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
   );
   if (models.length === 0) return null;
 
-  const modelToService = assignModelsToServices(spec.models, spec.services, ctx.modelHints);
+  // The round-trip test imports models from their *natural* (pre-relocation)
+  // service so existing callers keep working — those imports resolve via the
+  // BC re-exports that the model emitter writes into each service barrel.
+  const modelToService = computeSchemaPlacement(spec, ctx).originalModelToService;
   const roundTripDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (roundTripDirMap.get(irService) ?? 'common') : 'common';

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -293,7 +293,10 @@ function emitMethod(args: {
     const n = safeParamName(q.name);
     if (seenParamNames.has(n)) continue;
     seenParamNames.add(n);
-    const defaultVal = q.name === 'order' ? rubyStringLit('desc') : 'nil';
+    // Spec is the source of truth for defaults. If the OpenAPI parameter has
+    // a `default`, surface it in the Ruby keyword arg signature; otherwise
+    // default to nil so the param is omitted from the request unless set.
+    const defaultVal = q.default != null ? rubyDefaultLiteral(q.default) : 'nil';
     sigParts.push(`${n}: ${defaultVal}`);
   }
 
@@ -881,6 +884,15 @@ void methodName;
 /** Render a Ruby single-quoted string literal, escaping embedded quotes and backslashes. */
 function rubyStringLit(s: string): string {
   return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+/** Render an arbitrary spec-default value as a Ruby literal for a method-arg default. */
+function rubyDefaultLiteral(value: unknown): string {
+  if (typeof value === 'string') return rubyStringLit(value);
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'nil';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (value === null) return 'nil';
+  return 'nil';
 }
 
 /**

--- a/test/go/models.test.ts
+++ b/test/go/models.test.ts
@@ -256,10 +256,125 @@ describe('go/models', () => {
       	After *string \`url:"after,omitempty" json:"-"\`
       	// Limit is the maximum number of items to return per page.
       	Limit *int \`url:"limit,omitempty" json:"-"\`
-      	// Order is the sort order for results (asc or desc).
+      	// Order is the sort order for results.
       	Order *string \`url:"order,omitempty" json:"-"\`
       }
       "
     `);
+  });
+
+  it('types PaginationParams.Order with the spec enum when every list op shares the same enum', () => {
+    const specWithSharedEnum: ApiSpec = {
+      ...emptySpec,
+      enums: [
+        {
+          name: 'PaginationOrder',
+          values: [
+            { name: 'normal', value: 'normal' },
+            { name: 'desc', value: 'desc' },
+            { name: 'asc', value: 'asc' },
+          ],
+        },
+      ],
+      services: [
+        {
+          name: 'Connections',
+          operations: [
+            {
+              name: 'listConnections',
+              httpMethod: 'get',
+              path: '/connections',
+              pathParams: [],
+              queryParams: [
+                { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+                { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+                { name: 'order', type: { kind: 'enum', name: 'PaginationOrder' }, required: false },
+              ],
+              headerParams: [],
+              response: { kind: 'array', items: { kind: 'model', name: 'Organization' } },
+              errors: [],
+              pagination: {
+                strategy: 'cursor',
+                param: 'after',
+                dataPath: 'data',
+                itemType: { kind: 'model', name: 'Organization' },
+              },
+              injectIdempotencyKey: false,
+            },
+          ],
+        },
+      ],
+    };
+    const ctxTyped: EmitterContext = { namespace: 'workos', namespacePascal: 'WorkOS', spec: specWithSharedEnum };
+    const models: Model[] = [
+      {
+        name: 'Organization',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+    const content = generateModels(models, ctxTyped)[0].content;
+    expect(content).toContain('Order *PaginationOrder `url:"order,omitempty" json:"-"`');
+    expect(content).not.toContain('Order *string `url:"order,omitempty"');
+  });
+
+  it('falls back to *string when not every list op uses the same Order enum', () => {
+    const specMixed: ApiSpec = {
+      ...emptySpec,
+      services: [
+        {
+          name: 'Connections',
+          operations: [
+            {
+              name: 'listConnections',
+              httpMethod: 'get',
+              path: '/connections',
+              pathParams: [],
+              queryParams: [
+                { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+                { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+                { name: 'order', type: { kind: 'enum', name: 'PaginationOrder' }, required: false },
+              ],
+              headerParams: [],
+              response: { kind: 'array', items: { kind: 'model', name: 'Organization' } },
+              errors: [],
+              pagination: {
+                strategy: 'cursor',
+                param: 'after',
+                dataPath: 'data',
+                itemType: { kind: 'model', name: 'Organization' },
+              },
+              injectIdempotencyKey: false,
+            },
+            {
+              name: 'listOrganizations',
+              httpMethod: 'get',
+              path: '/organizations',
+              pathParams: [],
+              queryParams: [
+                { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+                { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+                { name: 'order', type: { kind: 'primitive', type: 'string' }, required: false },
+              ],
+              headerParams: [],
+              response: { kind: 'array', items: { kind: 'model', name: 'Organization' } },
+              errors: [],
+              pagination: {
+                strategy: 'cursor',
+                param: 'after',
+                dataPath: 'data',
+                itemType: { kind: 'model', name: 'Organization' },
+              },
+              injectIdempotencyKey: false,
+            },
+          ],
+        },
+      ],
+    };
+    const ctxMixed: EmitterContext = { namespace: 'workos', namespacePascal: 'WorkOS', spec: specMixed };
+    const models: Model[] = [
+      { name: 'Organization', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const content = generateModels(models, ctxMixed)[0].content;
+    expect(content).toContain('Order *string `url:"order,omitempty" json:"-"`');
   });
 });

--- a/test/go/resources.test.ts
+++ b/test/go/resources.test.ts
@@ -168,6 +168,76 @@ describe('go/resources', () => {
     expect(content).toContain('newIterator[User](ctx, s.client, "GET", "/users", nil, "after", "data", opts,');
   });
 
+  it('propagates spec defaults into the newIterator defaults map', () => {
+    const services: Service[] = [
+      {
+        name: 'Users',
+        operations: [
+          makeOp({
+            name: 'listUsers',
+            httpMethod: 'get',
+            path: '/users',
+            queryParams: [
+              { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+              {
+                name: 'limit',
+                type: { kind: 'primitive', type: 'integer' },
+                required: false,
+                default: 10,
+              },
+              {
+                name: 'order',
+                type: { kind: 'primitive', type: 'string' },
+                required: false,
+                default: 'desc',
+              },
+            ],
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'User' },
+            },
+          }),
+        ],
+      },
+    ];
+    const spec = makeSpec(services);
+    const content = generateResources(services, makeCtx(spec))[0].content;
+    expect(content).toMatch(/newIterator\[User\][^\n]*map\[string\]string\{"limit": "10", "order": "desc"\}/);
+  });
+
+  it('omits defaults from newIterator when the spec carries no defaults (no client-side hardcode)', () => {
+    const services: Service[] = [
+      {
+        name: 'Users',
+        operations: [
+          makeOp({
+            name: 'listUsers',
+            httpMethod: 'get',
+            path: '/users',
+            queryParams: [
+              { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+              { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+              { name: 'order', type: { kind: 'primitive', type: 'string' }, required: false },
+            ],
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'User' },
+            },
+          }),
+        ],
+      },
+    ];
+    const spec = makeSpec(services);
+    const content = generateResources(services, makeCtx(spec))[0].content;
+    // Last argument to newIterator must be `nil`, not a map literal.
+    expect(content).toMatch(/newIterator\[User\][^\n]*opts, nil\)/);
+    expect(content).not.toContain('"order": "desc"');
+  });
+
   it('generates delete methods returning error', () => {
     const services: Service[] = [
       {

--- a/test/php/models.test.ts
+++ b/test/php/models.test.ts
@@ -495,4 +495,77 @@ describe('generateModels', () => {
     expect(file!.content).toContain('@var array<string>|null');
     expect(file!.content).not.toContain('|null|null');
   });
+
+  it('emits ->toArray() for polymorphic union of model variants', () => {
+    const models: Model[] = [
+      {
+        name: 'ApiKey',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          {
+            name: 'owner',
+            type: {
+              kind: 'union',
+              variants: [
+                { kind: 'model', name: 'ApiKeyOwner' },
+                { kind: 'model', name: 'UserApiKeyOwner' },
+              ],
+              discriminator: {
+                property: 'type',
+                mapping: { apiKey: 'ApiKeyOwner', user: 'UserApiKeyOwner' },
+              },
+            },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'ApiKeyOwner',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'UserApiKeyOwner',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    const specWithModels = { ...emptySpec, models };
+    const result = generateModels(models, { ...ctx, spec: specWithModels });
+
+    const file = findModel(result, 'ApiKey');
+    expect(file).toBeDefined();
+    // toArray must dispatch to the concrete instance, not emit the bare object.
+    expect(file!.content).toContain("'owner' => $this->owner->toArray()");
+    expect(file!.content).not.toMatch(/'owner' => \$this->owner,/);
+  });
+
+  it('throws at codegen time for heterogeneous union mixing model and scalar', () => {
+    const models: Model[] = [
+      {
+        name: 'Thing',
+        fields: [
+          {
+            name: 'value',
+            type: {
+              kind: 'union',
+              variants: [
+                { kind: 'model', name: 'SomeModel' },
+                { kind: 'primitive', type: 'string' },
+              ],
+            },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'SomeModel',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    const specWithModels = { ...emptySpec, models };
+    expect(() => generateModels(models, { ...ctx, spec: specWithModels })).toThrow(
+      /heterogeneous union.*model:SomeModel \| primitive/,
+    );
+  });
 });

--- a/test/php/models.test.ts
+++ b/test/php/models.test.ts
@@ -537,6 +537,10 @@ describe('generateModels', () => {
     // toArray must dispatch to the concrete instance, not emit the bare object.
     expect(file!.content).toContain("'owner' => $this->owner->toArray()");
     expect(file!.content).not.toMatch(/'owner' => \$this->owner,/);
+    // fromArray match on discriminator must throw on unknown values, not pass through raw.
+    expect(file!.content).toContain("match ($data['owner']['type'] ?? null)");
+    expect(file!.content).toContain('throw new \\UnexpectedValueException');
+    expect(file!.content).not.toMatch(/default => \$data\['owner'\]/);
   });
 
   it('throws at codegen time for heterogeneous union mixing model and scalar', () => {

--- a/test/php/resources.test.ts
+++ b/test/php/resources.test.ts
@@ -122,6 +122,101 @@ describe('generateResources', () => {
     expect(result[0].content).toContain('Organization::fromArray($response)');
   });
 
+  it('reads the order param default from the spec rather than hardcoding desc', () => {
+    const orderEnum = {
+      name: 'PaginationOrder',
+      values: [
+        { name: 'desc', value: 'desc' },
+        { name: 'asc', value: 'asc' },
+      ],
+    };
+    const specWithOrder: ApiSpec = {
+      ...emptySpec,
+      enums: [orderEnum],
+      services: [
+        {
+          name: 'Organizations',
+          operations: [
+            {
+              name: 'listOrganizations',
+              httpMethod: 'get',
+              path: '/organizations',
+              pathParams: [],
+              queryParams: [
+                { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+                { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+                {
+                  name: 'order',
+                  type: { kind: 'enum', name: 'PaginationOrder' },
+                  required: false,
+                  default: 'desc',
+                },
+              ],
+              headerParams: [],
+              response: { kind: 'model', name: 'Organization' },
+              errors: [],
+              pagination: {
+                strategy: 'cursor',
+                param: 'after',
+                dataPath: 'data',
+                itemType: { kind: 'model', name: 'Organization' },
+              },
+              injectIdempotencyKey: false,
+            },
+          ],
+        },
+      ],
+    };
+    const content = generateResources(specWithOrder.services, { ...ctx, spec: specWithOrder })[0].content;
+    // With a spec default, the param is non-nullable and defaults to the enum case.
+    expect(content).toMatch(/PaginationOrder \$order = .*PaginationOrder::Desc/);
+  });
+
+  it('emits ?order = null when the spec carries no default for `order`', () => {
+    const orderEnum = {
+      name: 'PaginationOrder',
+      values: [
+        { name: 'desc', value: 'desc' },
+        { name: 'asc', value: 'asc' },
+      ],
+    };
+    const specNoDefault: ApiSpec = {
+      ...emptySpec,
+      enums: [orderEnum],
+      services: [
+        {
+          name: 'Organizations',
+          operations: [
+            {
+              name: 'listOrganizations',
+              httpMethod: 'get',
+              path: '/organizations',
+              pathParams: [],
+              queryParams: [
+                { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+                { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+                { name: 'order', type: { kind: 'enum', name: 'PaginationOrder' }, required: false },
+              ],
+              headerParams: [],
+              response: { kind: 'model', name: 'Organization' },
+              errors: [],
+              pagination: {
+                strategy: 'cursor',
+                param: 'after',
+                dataPath: 'data',
+                itemType: { kind: 'model', name: 'Organization' },
+              },
+              injectIdempotencyKey: false,
+            },
+          ],
+        },
+      ],
+    };
+    const content = generateResources(specNoDefault.services, { ...ctx, spec: specNoDefault })[0].content;
+    expect(content).toMatch(/\?\\WorkOS\\Resource\\PaginationOrder \$order = null/);
+    expect(content).not.toMatch(/PaginationOrder::Desc/);
+  });
+
   it('generates paginated list method', () => {
     const result = generateResources(services, ctx);
 

--- a/test/python/enums.test.ts
+++ b/test/python/enums.test.ts
@@ -110,6 +110,97 @@ describe('generateEnums', () => {
     expect(files[0].path).toBe('src/workos/organizations/models/org_status.py');
   });
 
+  it('places enum in common/ when referenced by 2+ services', () => {
+    const makeService = (name: string, opName: string): Service => ({
+      name,
+      operations: [
+        {
+          name: opName,
+          httpMethod: 'get',
+          path: `/${name.toLowerCase()}`,
+          pathParams: [],
+          queryParams: [
+            {
+              name: 'order',
+              type: { kind: 'enum', name: 'PaginationOrder' },
+              required: false,
+            },
+          ],
+          headerParams: [],
+          response: { kind: 'primitive', type: 'unknown' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    });
+
+    const enums: Enum[] = [
+      {
+        name: 'PaginationOrder',
+        values: [
+          { name: 'NORMAL', value: 'normal' },
+          { name: 'DESC', value: 'desc' },
+          { name: 'ASC', value: 'asc' },
+        ],
+      },
+    ];
+
+    // Authorization comes alphabetically first; without the shared rule the
+    // enum would land under authorization/. Two services referencing it must
+    // route it to common/ instead.
+    const services = [makeService('Authorization', 'listAuthz'), makeService('Organizations', 'listOrgs')];
+
+    const files = generateEnums(enums, {
+      ...ctx,
+      spec: { ...emptySpec, services },
+    });
+
+    const enumFile = files.find((f) => f.path.endsWith('pagination_order.py'));
+    expect(enumFile).toBeDefined();
+    expect(enumFile!.path).toBe('src/workos/common/models/pagination_order.py');
+    // No service-local copy should exist.
+    expect(files.find((f) => f.path === 'src/workos/authorization/models/pagination_order.py')).toBeUndefined();
+    expect(files.find((f) => f.path === 'src/workos/organizations/models/pagination_order.py')).toBeUndefined();
+  });
+
+  it('keeps enum in service dir when only one service references it', () => {
+    const service: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'listOrgs',
+          httpMethod: 'get',
+          path: '/orgs',
+          pathParams: [],
+          queryParams: [
+            {
+              name: 'order',
+              type: { kind: 'enum', name: 'OnlyOrgsOrder' },
+              required: false,
+            },
+          ],
+          headerParams: [],
+          response: { kind: 'primitive', type: 'unknown' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const enums: Enum[] = [
+      {
+        name: 'OnlyOrgsOrder',
+        values: [{ name: 'ASC', value: 'asc' }],
+      },
+    ];
+
+    const files = generateEnums(enums, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service] },
+    });
+    expect(files[0].path).toBe('src/workos/organizations/models/only_orgs_order.py');
+  });
+
   it('deduplicates values that produce the same string', () => {
     const enums: Enum[] = [
       {

--- a/test/python/models.test.ts
+++ b/test/python/models.test.ts
@@ -812,4 +812,149 @@ describe('generateModels', () => {
     expect(contextBFile.content).toContain('TypeAlias');
     expect(contextBFile.content).not.toContain('@dataclass');
   });
+
+  it('places a model in common/ when referenced by 2+ services', () => {
+    const sharedModel: Model = {
+      name: 'PageInfo',
+      fields: [
+        { name: 'page_number', type: { kind: 'primitive', type: 'string' }, required: true },
+        { name: 'page_size', type: { kind: 'primitive', type: 'string' }, required: true },
+      ],
+    };
+    const orgsService: Service = {
+      name: 'Authorization',
+      operations: [
+        {
+          name: 'listAuthz',
+          httpMethod: 'get',
+          path: '/authz',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'PageInfo' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const usersService: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'listOrgs',
+          httpMethod: 'get',
+          path: '/orgs',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'PageInfo' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const models: Model[] = [sharedModel];
+
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services: [orgsService, usersService], models },
+    };
+
+    const files = generateModels(models, ctxWithServices);
+    const sharedFile = files.find((f) => f.path.endsWith('/page_info.py'));
+    expect(sharedFile).toBeDefined();
+    expect(sharedFile!.path).toBe('src/workos/common/models/page_info.py');
+    // No service-local copy of the shared model.
+    expect(files.find((f) => f.path === 'src/workos/authorization/models/page_info.py')).toBeUndefined();
+    expect(files.find((f) => f.path === 'src/workos/organizations/models/page_info.py')).toBeUndefined();
+    // common/__init__.py and common/models/__init__.py both re-export PageInfo.
+    const commonInit = files.find((f) => f.path === 'src/workos/common/__init__.py');
+    expect(commonInit).toBeDefined();
+    expect(commonInit!.content).toContain('from .models import PageInfo as PageInfo');
+    const commonModelsInit = files.find((f) => f.path === 'src/workos/common/models/__init__.py');
+    expect(commonModelsInit).toBeDefined();
+    expect(commonModelsInit!.content).toContain('from .page_info import PageInfo as PageInfo');
+  });
+
+  it('keeps a model in service dir when only one service references it', () => {
+    const onlyModel: Model = {
+      name: 'OnlyOrg',
+      fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+    };
+    const service: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'getOrg',
+          httpMethod: 'get',
+          path: '/orgs/{id}',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'OnlyOrg' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], models: [onlyModel] },
+    };
+
+    const files = generateModels([onlyModel], ctxWithServices);
+    const file = files.find((f) => f.path.endsWith('/only_org.py'));
+    expect(file!.path).toBe('src/workos/organizations/models/only_org.py');
+  });
+
+  it('respects modelHints over the shared rule', () => {
+    const sharedModel: Model = {
+      name: 'PinnedThing',
+      fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+    };
+    const a: Service = {
+      name: 'Authorization',
+      operations: [
+        {
+          name: 'a',
+          httpMethod: 'get',
+          path: '/a',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'PinnedThing' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const b: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'b',
+          httpMethod: 'get',
+          path: '/b',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'PinnedThing' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    // PinnedThing is referenced by 2 services but explicitly pinned to Authorization.
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services: [a, b], models: [sharedModel] },
+      modelHints: { PinnedThing: 'Authorization' },
+    };
+
+    const files = generateModels([sharedModel], ctxWithServices);
+    expect(files.find((f) => f.path === 'src/workos/authorization/models/pinned_thing.py')).toBeDefined();
+    expect(files.find((f) => f.path === 'src/workos/common/models/pinned_thing.py')).toBeUndefined();
+  });
 });

--- a/test/python/models.test.ts
+++ b/test/python/models.test.ts
@@ -709,6 +709,86 @@ describe('generateModels', () => {
     expect(barrel!.content).toContain('EventSchemaVariant');
   });
 
+  it('emits strict dispatch (no raw-dict fallback, no hasattr) for fields typed as a discriminated union', () => {
+    const service: Service = {
+      name: 'ApiKeys',
+      operations: [
+        {
+          name: 'getApiKey',
+          httpMethod: 'get',
+          path: '/api_keys/{id}',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'ApiKeyCreatedData' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const models: Model[] = [
+      {
+        name: 'ApiKeyCreatedData',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          {
+            name: 'owner',
+            type: {
+              kind: 'union',
+              variants: [
+                { kind: 'model', name: 'ApiKeyCreatedDataOwner' },
+                { kind: 'model', name: 'UserApiKeyCreatedDataOwner' },
+              ],
+              discriminator: {
+                property: 'type',
+                mapping: {
+                  organization: 'ApiKeyCreatedDataOwner',
+                  user: 'UserApiKeyCreatedDataOwner',
+                },
+              },
+            },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'ApiKeyCreatedDataOwner',
+        fields: [
+          { name: 'type', type: { kind: 'literal', value: 'organization' }, required: true },
+          { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+      {
+        name: 'UserApiKeyCreatedDataOwner',
+        fields: [
+          { name: 'type', type: { kind: 'literal', value: 'user' }, required: true },
+          { name: 'user_id', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+    ];
+
+    const files = generateModels(models, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], models },
+    });
+
+    const parent = files.find((f) => f.path.endsWith('api_key_created_data.py'))!;
+    expect(parent).toBeDefined();
+
+    // from_dict performs strict dispatch and raises on unknown discriminator
+    expect(parent.content).toContain('"Unknown discriminator');
+    expect(parent.content).toContain('ApiKeyCreatedData.owner');
+    expect(parent.content).toContain('Expected one of {sorted(');
+    // Old lax fallback patterns are gone
+    expect(parent.content).not.toContain('else data["owner"]');
+    expect(parent.content).not.toContain('else data[');
+
+    // to_dict no longer needs the hasattr workaround
+    expect(parent.content).not.toContain('hasattr');
+    expect(parent.content).toContain('result["owner"] = self.owner.to_dict()');
+  });
+
   it('deduplicates models with recursively identical sub-model references', () => {
     const service: Service = {
       name: 'Events',

--- a/test/python/resources.test.ts
+++ b/test/python/resources.test.ts
@@ -167,6 +167,51 @@ describe('generateResources', () => {
       'after: An object ID that defines your place in the list. When the ID is not present, you are at the end of the list.',
     );
     expect(content).toContain('order: Order the results by the creation time.');
+    // The spec has no `default` for `order` here, so the SDK must NOT
+    // hardcode 'desc' on the client. Server's default applies instead.
+    expect(content).toContain('order: Optional[str] = None,');
+    expect(content).not.toContain('order: Optional[str] = "desc"');
+  });
+
+  it('reads pagination order default from the spec rather than hardcoding "desc"', () => {
+    const models: Model[] = [
+      { name: 'Organization', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const services: Service[] = [
+      {
+        name: 'Organizations',
+        operations: [
+          {
+            name: 'listOrganizations',
+            httpMethod: 'get',
+            path: '/organizations',
+            pathParams: [],
+            queryParams: [
+              { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+              { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+              {
+                name: 'order',
+                type: { kind: 'primitive', type: 'string' },
+                required: false,
+                default: 'desc',
+              },
+            ],
+            headerParams: [],
+            response: { kind: 'model', name: 'OrganizationList' },
+            errors: [],
+            injectIdempotencyKey: false,
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'Organization' },
+            },
+          },
+        ],
+      },
+    ];
+    const content = generateResources(services, { ...ctx, spec: { ...emptySpec, services, models } })[0].content;
+    expect(content).toContain('order: Optional[str] = "desc",');
   });
 
   it('indents multiline argument descriptions in docstrings', () => {

--- a/test/ruby/resources.test.ts
+++ b/test/ruby/resources.test.ts
@@ -187,6 +187,64 @@ describe('ruby/resources', () => {
     expect(content).toContain('ListStruct.from_response(');
   });
 
+  it('reads pagination order default from the spec rather than hardcoding "desc"', () => {
+    const services: Service[] = [
+      {
+        name: 'Organizations',
+        operations: [
+          makeOp({
+            name: 'listOrganizations',
+            queryParams: [
+              { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+              { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+              {
+                name: 'order',
+                type: { kind: 'primitive', type: 'string' },
+                required: false,
+                default: 'desc',
+              },
+            ],
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'Organization' },
+            },
+          }),
+        ],
+      },
+    ];
+    const content = generateResources(services, makeCtx(makeSpec(services)))[0].content;
+    expect(content).toContain("order: 'desc'");
+  });
+
+  it("emits order: nil when the spec carries no default (no 'desc' hardcode)", () => {
+    const services: Service[] = [
+      {
+        name: 'Organizations',
+        operations: [
+          makeOp({
+            name: 'listOrganizations',
+            queryParams: [
+              { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+              { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+              { name: 'order', type: { kind: 'primitive', type: 'string' }, required: false },
+            ],
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'Organization' },
+            },
+          }),
+        ],
+      },
+    ];
+    const content = generateResources(services, makeCtx(makeSpec(services)))[0].content;
+    expect(content).toContain('order: nil');
+    expect(content).not.toContain("order: 'desc'");
+  });
+
   // ── P0-3: paginated response shape detection ──────────────────────────
 
   it('generates ListStruct for paginated endpoints with array response type', () => {


### PR DESCRIPTION
## Summary
- **Python**: route schemas referenced by 2+ services to `common/`, close back-edges by relocating transitively-reachable models, and re-export relocated symbols from their original service barrels for BC. Narrow `Parameter.default` before `pythonLiteral`.
- **Python (breaking)**: discriminated-union `from_dict` now raises `ValueError` naming the parent, field, observed value, and valid options instead of silently returning the raw dict; `to_dict` drops the `hasattr` workaround.
- **PHP (breaking)**: discriminated-union `fromArray()` throws `\UnexpectedValueException` on unknown discriminator values instead of falling through to a raw-array passthrough that crashed later as a confusing `TypeError`.
- **PHP**: emit `->toArray()` on polymorphic union properties (was emitting bare `$this->prop`); throw at codegen time for heterogeneous model+enum+scalar unions where no uniform serialization exists.
- **PHP / Python / Ruby**: stop hardcoding `desc` as the pagination `order` default — read `Parameter.default` from the IR so the spec stays authoritative (matches Go behavior; see workos/workos-go#545).
- **Go**: type `PaginationParams.Order` with the shared `PaginationOrder` enum when every paginated `order` param \$refs the same top-level enum; fall back to `*string` when ops diverge.
- Bump oagen.

## Test plan
- [ ] \`script/ci\` in oagen-emitters
- [ ] Regenerate workos-python and run its \`script/ci\`; verify pyright passes at the BC service-package import paths
- [ ] Regenerate workos-php and run its \`script/ci\`; confirm \`fromArray\` on a union now throws \`\UnexpectedValueException\` for an unknown discriminator and \`toArray()\` round-trips polymorphic union properties
- [ ] Regenerate workos-go and confirm \`PaginationParams.Order\` is \`*PaginationOrder\` for paginated list ops
- [ ] Regenerate workos-ruby and confirm list methods no longer hardcode \`order: 'desc'\` when the spec omits the default
- [ ] Spot-check that paginated requests no longer send \`order=desc\` unless the spec sets it