### PR TITLE
fix(node): generate tests for adopted services and fix related bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.19.0"
+        "@workos/oagen": "^0.19.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.1",
         "@commitlint/config-conventional": "^21.0.1",
-        "@types/node": "^25.8.0",
+        "@types/node": "^25.9.0",
         "husky": "^9.1.7",
         "oxfmt": "^0.50.0",
         "oxlint": "^1.65.0",
         "prettier": "^3.8.3",
         "tsdown": "^0.22.0",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.6"
       },
@@ -1772,9 +1772,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1895,9 +1895,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.19.0.tgz",
-      "integrity": "sha512-j+KdHuATfqfNtZymCjlGwrbEZ2Nu4TeSFE/krgd49hEOQo7QcHk2I5JI75NwdLLq2cvoFEnKjI3lfFYzvWx7NA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.19.1.tgz",
+      "integrity": "sha512-HzHwzw5BrqVfEi6yAtj73u0gVe/6yhmbRDY+ASxiaQyhNhB0p2btGhzyaeLqxMJe89bOfODyyZFp4XpCGubAHA==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",
@@ -4134,9 +4134,9 @@
       "optional": true
     },
     "node_modules/tsx": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
-      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
+      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
-    "@types/node": "^25.8.0",
+    "@types/node": "^25.9.0",
     "husky": "^9.1.7",
     "oxfmt": "^0.50.0",
     "oxlint": "^1.65.0",
     "prettier": "^3.8.3",
     "tsdown": "^0.22.0",
-    "tsx": "^4.22.0",
+    "tsx": "^4.22.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.19.0"
+    "@workos/oagen": "^0.19.1"
   }
 }

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -315,10 +315,19 @@ function applyLiveSurface(files: GeneratedFile[], ctx: EmitterContext, surface: 
     // user has hand-tuned, or leave it pointing at sibling files that no
     // longer have the same shape. Treat existing test/fixture files as
     // frozen even when they carry the auto-gen header.
+    //
+    // Adopted-service directories are treated like owned dirs for this
+    // purpose: adoption means oagen created the directory from scratch, so
+    // by construction there is no hand-written content to preserve and
+    // emitting tests/fixtures is safe. Rule (a) still drops files that
+    // somehow exist hand-written.
     if (isUserOwnedAfterFirstEmit(f.path)) {
+      const dir = topLevelDir(f.path);
+      const isAdoptedDir = dir !== undefined && policy.adoptedServiceDirs.has(dir);
+      const isManagedDir = ownedPath || isAdoptedDir;
       if (surface.files.has(f.path) && !surface.autogenFiles.has(f.path)) continue;
-      if (!ownedPath && !surface.autogenFiles.has(f.path)) continue;
-      if (ownedPath && !policy.regenerateOwnedTests) continue;
+      if (!isManagedDir && !surface.autogenFiles.has(f.path)) continue;
+      if (isManagedDir && !policy.regenerateOwnedTests) continue;
     }
 
     // Previously auto-generated files → fully overwrite so spec changes

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -10,6 +10,7 @@ import {
   resolveInterfaceName,
   wireInterfaceName,
   resolveMethodName,
+  isAdoptedModelName,
 } from './naming.js';
 import {
   collectFieldDependencies,
@@ -119,6 +120,12 @@ function isSupportedFieldType(
       if (ref.name === ownerModelName) return true;
       const resolvedName = resolveInterfaceName(ref.name, ctx);
       if (ctx.apiSurface?.interfaces?.[resolvedName] || ctx.apiSurface?.typeAliases?.[resolvedName]) return true;
+      // Adopted-service models will have their interfaces emitted in this
+      // same pass, so the field reference will resolve once writing is done.
+      // Without this, fields like `UserManagementLoginRequest.user` get
+      // silently dropped on first emission because the target interface
+      // (`UserObject` under the adopted `connect/` dir) hasn't landed yet.
+      if (isAdoptedModelName(ref.name)) return true;
       const relPath = `src/${shared.resolveDir(shared.modelToService.get(ref.name))}/interfaces/${fileName(ref.name)}.interface.ts`;
       return liveSurfaceHasManagedFile(relPath);
     }

--- a/src/node/naming.ts
+++ b/src/node/naming.ts
@@ -65,6 +65,9 @@ let adoptedModelNames: Set<string> = new Set();
 export function setAdoptedModelNames(names: Set<string>): void {
   adoptedModelNames = names;
 }
+export function isAdoptedModelName(name: string): boolean {
+  return adoptedModelNames.has(name);
+}
 
 /**
  * Wire/response interface name.

--- a/src/node/path-expression.ts
+++ b/src/node/path-expression.ts
@@ -14,8 +14,14 @@ import { fieldName } from './naming.js';
  *   "/orgs"            → `'orgs'`
  *   "/orgs/{id}"       → `` `orgs/${encodeURIComponent(id)}` ``
  *   "/orgs/{id}/foo"   → `` `orgs/${encodeURIComponent(id)}/foo` ``
+ *
+ * `paramNameMap` lets a caller override the local variable name used for a
+ * spec parameter — used by the options-object code path so the URL template
+ * references the SDK's public field name (e.g. `organizationMembershipId`)
+ * instead of the spec's path-param name (e.g. `omId`), avoiding a
+ * destructure rename in the method body.
  */
-export function buildNodePathExpression(rawPath: string): string {
+export function buildNodePathExpression(rawPath: string, paramNameMap?: Map<string, string>): string {
   const segments = parsePathTemplate(rawPath);
   if (!hasPathParams(segments)) {
     return `'${rawPath}'`;
@@ -23,15 +29,16 @@ export function buildNodePathExpression(rawPath: string): string {
 
   let body = '';
   for (const seg of segments) {
-    body += renderSegment(seg);
+    body += renderSegment(seg, paramNameMap);
   }
   return `\`${body}\``;
 }
 
-function renderSegment(seg: PathSegment): string {
+function renderSegment(seg: PathSegment, paramNameMap?: Map<string, string>): string {
   if (seg.kind === 'literal') {
     // Template-literal-safe escapes: backtick, backslash, ${
     return seg.value.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
   }
-  return `\${encodeURIComponent(${fieldName(seg.name)})}`;
+  const localName = paramNameMap?.get(seg.name) ?? fieldName(seg.name);
+  return `\${encodeURIComponent(${localName})}`;
 }

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -1242,8 +1242,8 @@ function renderOptionsObjectMethod(
   if (!optionParam) return false;
 
   const responseModel = plan.responseModelName ? resolveInterfaceName(plan.responseModelName, ctx) : null;
-  const pathStr = buildPathStr(op);
   const pathBindings = buildOptionsObjectPathBindings(op, optionParam.type, ctx);
+  const pathStr = buildPathStr(op, buildOptionsObjectPathParamMap(op, optionParam.type, ctx));
 
   if (plan.isPaginated && op.pagination && op.httpMethod === 'get') {
     let itemRawName = op.pagination.itemType.kind === 'model' ? op.pagination.itemType.name : null;
@@ -1374,11 +1374,27 @@ function renderOptionsObjectDestructure(lines: string[], pathBindings: string[],
 }
 
 function buildOptionsObjectPathBindings(op: Operation, optionType: string, ctx: EmitterContext): string[] {
-  return op.pathParams.map((param) => {
+  // Return resolved SDK field names directly — the URL template uses these
+  // names too (via the param-name map threaded into buildNodePathExpression),
+  // so the destructure no longer needs `optionField: localName` renames.
+  return op.pathParams.map((param) => resolveOptionsObjectField(fieldName(param.name), optionType, ctx));
+}
+
+/**
+ * Map spec path-param names (e.g. `omId`) to the SDK field name exposed on
+ * the options interface (e.g. `organizationMembershipId`). Empty when every
+ * path param's spec name already matches the SDK field. Consumed by
+ * `buildNodePathExpression` so the URL template binds to the same identifier
+ * the destructure does.
+ */
+function buildOptionsObjectPathParamMap(op: Operation, optionType: string, ctx: EmitterContext): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const param of op.pathParams) {
     const localName = fieldName(param.name);
-    const optionField = resolveOptionsObjectField(localName, optionType, ctx);
-    return optionField === localName ? localName : `${optionField}: ${localName}`;
-  });
+    const sdkField = resolveOptionsObjectField(localName, optionType, ctx);
+    if (sdkField !== localName) map.set(param.name, sdkField);
+  }
+  return map;
 }
 
 function resolveOptionsObjectField(localName: string, optionType: string, ctx: EmitterContext): string {
@@ -1826,8 +1842,8 @@ function renderQueryExpr(queryParams: { name: string; required: boolean }[]): st
   return `options ? { ${parts.join(', ')} } : undefined`;
 }
 
-function buildPathStr(op: Operation): string {
-  return buildNodePathExpression(op.path);
+function buildPathStr(op: Operation, paramNameMap?: Map<string, string>): string {
+  return buildNodePathExpression(op.path, paramNameMap);
 }
 
 function buildPathParams(op: Operation, specEnumNames?: Set<string>): string {

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -110,6 +110,15 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     const propName = mountAccessors.get(mountName) ?? servicePropertyName(mountName);
     if (ctx.apiSurface && baselineWorkOSProps.size > 0 && !baselineWorkOSProps.has(propName)) continue;
 
+    // Skip when the resource class diverges from the mount accessor — this
+    // happens for services with constructor-incompatible baselines (e.g.
+    // hand-written `Webhooks(crypto)` forks the emitted ops onto
+    // `WebhooksEndpoints`). The generated test would do
+    // `workos.<propName>.fooMethod(...)`, but those methods live on a
+    // different class, so the test would fail to compile.
+    const resourceClass = resolveResourceClassName(mergedService, ctx);
+    if (resourceClass !== mountName) continue;
+
     const testService = ops.length < operations.length ? { ...mergedService, operations: ops } : mergedService;
     files.push(generateServiceTest(testService, spec, ctx, modelMap, mountAccessors));
   }
@@ -409,8 +418,12 @@ function renderBodyTest(
   const optionsArg = buildOptionsObjectTestArg(op, plan, baselineMethod, modelMap, ctx);
   const allArgs = optionsArg ?? (pathArgs ? `${pathArgs}, ${payloadArg}` : payloadArg);
 
+  const isArrayResponse = !!plan.isArrayResponse;
+  const fixtureExpr = isArrayResponse ? `[${fixture}]` : fixture;
+  const accessor = isArrayResponse ? 'result[0]' : 'result';
+
   lines.push("    it('sends the correct request and returns result', async () => {");
-  lines.push(`      fetchOnce(${fixture});`);
+  lines.push(`      fetchOnce(${fixtureExpr});`);
   lines.push('');
   lines.push(`      const result = await workos.${serviceProp}.${method}(${allArgs});`);
   lines.push('');
@@ -427,14 +440,18 @@ function renderBodyTest(
     lines.push('      expect(fetchBody()).toBeDefined();');
   }
 
+  if (isArrayResponse) {
+    lines.push('      expect(Array.isArray(result)).toBe(true);');
+  }
+
   // Use entity helper if available, otherwise inline assertions
   const bodyHelperName = ctx ? `expect${resolveInterfaceName(responseModelName, ctx)}` : null;
   if (bodyHelperName && entityHelpers?.has(bodyHelperName)) {
-    lines.push(`      ${bodyHelperName}(result);`);
+    lines.push(`      ${bodyHelperName}(${accessor});`);
   } else {
     const responseModel = modelMap.get(responseModelName);
     if (responseModel) {
-      const assertions = buildFieldAssertions(responseModel, 'result', modelMap);
+      const assertions = buildFieldAssertions(responseModel, accessor, modelMap);
       if (assertions.length > 0) {
         for (const assertion of assertions) {
           lines.push(`      ${assertion}`);
@@ -466,8 +483,12 @@ function renderGetTest(
   const pathArgs = buildTestPathArgs(op);
   const optionsArg = buildOptionsObjectTestArg(op, plan, baselineMethod, modelMap, ctx);
 
+  const isArrayResponse = !!plan.isArrayResponse;
+  const fixtureExpr = isArrayResponse ? `[${fixture}]` : fixture;
+  const accessor = isArrayResponse ? 'result[0]' : 'result';
+
   lines.push("    it('returns the expected result', async () => {");
-  lines.push(`      fetchOnce(${fixture});`);
+  lines.push(`      fetchOnce(${fixtureExpr});`);
   lines.push('');
   lines.push(`      const result = await workos.${serviceProp}.${method}(${optionsArg ?? pathArgs});`);
   lines.push('');
@@ -475,15 +496,18 @@ function renderGetTest(
   // Fix #12: Full URL path assertion instead of toContain()
   const expectedPathGet = buildExpectedPath(op);
   lines.push(`      expect(new URL(String(fetchURL())).pathname).toBe('${expectedPathGet}');`);
+  if (isArrayResponse) {
+    lines.push('      expect(Array.isArray(result)).toBe(true);');
+  }
 
   // Use entity helper if available, otherwise inline assertions
   const helperName = ctx ? `expect${resolveInterfaceName(responseModelName, ctx)}` : null;
   if (helperName && entityHelpers?.has(helperName)) {
-    lines.push(`      ${helperName}(result);`);
+    lines.push(`      ${helperName}(${accessor});`);
   } else {
     const responseModel = modelMap.get(responseModelName);
     if (responseModel) {
-      const assertions = buildFieldAssertions(responseModel, 'result', modelMap);
+      const assertions = buildFieldAssertions(responseModel, accessor, modelMap);
       if (assertions.length > 0) {
         for (const assertion of assertions) {
           lines.push(`      ${assertion}`);
@@ -636,27 +660,37 @@ function generateEntityHelpers(
  * nested models so we still get meaningful assertions instead of a bare
  * `toBeDefined()`.
  */
+function isDateTimeFieldType(type: TypeRef): boolean {
+  if (type.kind === 'primitive') return type.format === 'date-time';
+  if (type.kind === 'nullable') return isDateTimeFieldType(type.inner);
+  return false;
+}
+
 function buildFieldAssertions(model: Model, accessor: string, modelMap?: Map<string, Model>): string[] {
   const assertions: string[] = [];
 
   for (const field of model.fields) {
     if (!field.required) continue;
+    const domainField = fieldName(field.name);
+    // `string` + `format: 'date-time'` is deserialized to `Date` by the
+    // serializer (see `mapPrimitive` in type-map.ts). Asserting against a
+    // string literal would fail Object.is — compare via `.toISOString()`.
+    const isDateTime = isDateTimeFieldType(field.type);
+    const fieldAccessor = isDateTime ? `${accessor}.${domainField}.toISOString()` : `${accessor}.${domainField}`;
     // When a field has an example value, use it as the expected assertion value
     if (field.example !== undefined) {
-      const domainField = fieldName(field.name);
       if (typeof field.example === 'object' && field.example !== null) {
         // Objects and arrays need toEqual with JSON serialization
         assertions.push(`expect(${accessor}.${domainField}).toEqual(${JSON.stringify(field.example)});`);
       } else {
         const exampleLiteral = typeof field.example === 'string' ? `'${field.example}'` : String(field.example);
-        assertions.push(`expect(${accessor}.${domainField}).toBe(${exampleLiteral});`);
+        assertions.push(`expect(${fieldAccessor}).toBe(${exampleLiteral});`);
       }
       continue;
     }
     const value = fixtureValueForType(field.type, field.name, model.name);
     if (value === null) continue;
-    const domainField = fieldName(field.name);
-    assertions.push(`expect(${accessor}.${domainField}).toBe(${value});`);
+    assertions.push(`expect(${fieldAccessor}).toBe(${value});`);
   }
 
   // When no primitive assertions were found (e.g. wrapper types like

--- a/test/node/resources.test.ts
+++ b/test/node/resources.test.ts
@@ -176,6 +176,76 @@ describe('generateResources', () => {
     expect(resourceFile!.content).toContain('async listGroupsForOrganizationMembership');
   });
 
+  it('options-object: URL template binds to the SDK field name, not the spec path-param name', () => {
+    // When the spec uses `omId` as a path-param name but the baseline options
+    // interface exposes `organizationMembershipId`, both the destructure and
+    // the URL template should reference `organizationMembershipId` directly —
+    // no `organizationMembershipId: omId` rename indirection in the body.
+    const operation = {
+      name: 'removeOrganizationMembership',
+      httpMethod: 'delete' as const,
+      path: '/organizations/{organizationId}/groups/{groupId}/organization-memberships/{omId}',
+      pathParams: [
+        { name: 'organizationId', type: { kind: 'primitive' as const, type: 'string' as const }, required: true },
+        { name: 'groupId', type: { kind: 'primitive' as const, type: 'string' as const }, required: true },
+        { name: 'omId', type: { kind: 'primitive' as const, type: 'string' as const }, required: true },
+      ],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'primitive' as const, type: 'unknown' as const },
+      errors: [],
+      injectIdempotencyKey: false,
+    };
+    const service: Service = { name: 'Groups', operations: [operation] };
+    const spec: ApiSpec = { ...emptySpec, services: [service] };
+    const ctxWithBaseline: EmitterContext = {
+      ...ctx,
+      spec,
+      emitterOptions: { ownedServices: ['Groups'] },
+      apiSurface: {
+        classes: {
+          Groups: {
+            constructorParams: [{ name: 'workos', type: 'WorkOS' }],
+            methods: {
+              removeOrganizationMembership: [
+                {
+                  name: 'removeOrganizationMembership',
+                  params: [
+                    {
+                      name: 'options',
+                      type: 'RemoveGroupOrganizationMembershipOptions',
+                      passingStyle: 'options_object',
+                    },
+                  ],
+                  returnType: 'Promise<void>',
+                  async: true,
+                },
+              ],
+            },
+          },
+        },
+        interfaces: {
+          RemoveGroupOrganizationMembershipOptions: {
+            fields: {
+              organizationId: { type: 'string', required: true },
+              groupId: { type: 'string', required: true },
+              organizationMembershipId: { type: 'string', required: true },
+            },
+          },
+        },
+      } as any,
+    };
+
+    const result = generateResources([service], ctxWithBaseline);
+    const resourceFile = result.find((f) => f.path === 'src/groups/groups.ts');
+    expect(resourceFile).toBeDefined();
+    const content = resourceFile!.content;
+    expect(content).toContain('const { organizationId, groupId, organizationMembershipId } = options;');
+    expect(content).toContain('${encodeURIComponent(organizationMembershipId)}');
+    expect(content).not.toContain('organizationMembershipId: omId');
+    expect(content).not.toContain('encodeURIComponent(omId)');
+  });
+
   it('drops brand-new service paths in an existing SDK by default', () => {
     const tmpRoot = createTrackedSdkRoot();
     try {

--- a/test/node/tests.test.ts
+++ b/test/node/tests.test.ts
@@ -116,4 +116,99 @@ describe('node test generation ownership', () => {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it('emits tests and fixtures for adopted services when regenerateOwnedTests is true', () => {
+    // Adopted dirs are created by oagen from scratch — no hand-written content
+    // to preserve, so scaffolding tests/fixtures is safe and useful.
+    const tmpRoot = createTrackedSdkRoot();
+    try {
+      const result = nodeEmitter.generateTests!(spec, {
+        ...ctx,
+        outputDir: tmpRoot,
+        emitterOptions: { adoptMissingServices: true, regenerateOwnedTests: true },
+      } as EmitterContext);
+
+      const testFile = result.find((f) => f.path === 'src/groups/groups.spec.ts');
+      const fixtureFile = result.find((f) => f.path === 'src/groups/fixtures/group.json');
+      expect(testFile).toBeDefined();
+      expect(fixtureFile).toBeDefined();
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('skips tests for adopted services when regenerateOwnedTests is false', () => {
+    const tmpRoot = createTrackedSdkRoot();
+    try {
+      const result = nodeEmitter.generateTests!(spec, {
+        ...ctx,
+        outputDir: tmpRoot,
+        emitterOptions: { adoptMissingServices: true },
+      } as EmitterContext);
+
+      expect(result.some((f) => f.path.startsWith('src/groups/'))).toBe(false);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('skips tests when the resource class diverges from the mount accessor', () => {
+    // Hand-written `Webhooks` has a constructor incompatible with WorkOS,
+    // so the emitter forks endpoint methods onto a `WebhooksEndpoints`
+    // helper class. A generated test would call `workos.webhooks.foo(...)`
+    // — but those methods live on the helper, not the crypto class. Skip
+    // these tests so we don't ship a spec that fails to compile.
+    const webhookOp = {
+      name: 'listWebhookEndpoints',
+      httpMethod: 'get' as const,
+      path: '/webhook_endpoints',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'primitive' as const, type: 'unknown' as const },
+      errors: [],
+      injectIdempotencyKey: false,
+    };
+    const webhookService: Service = { name: 'Webhooks', operations: [webhookOp] };
+    const webhookSpec: ApiSpec = {
+      ...spec,
+      services: [webhookService],
+    };
+
+    const tmpRoot = createTrackedSdkRoot();
+    try {
+      const result = nodeEmitter.generateTests!(webhookSpec, {
+        ...ctx,
+        spec: webhookSpec,
+        outputDir: tmpRoot,
+        emitterOptions: { adoptMissingServices: true, regenerateOwnedTests: true },
+        apiSurface: {
+          classes: {
+            Webhooks: {
+              constructorParams: [{ name: 'crypto', type: 'CryptoProvider' }],
+            },
+            WorkOS: {
+              properties: { webhooks: { type: 'Webhooks' } },
+            },
+          },
+        },
+        resolvedOperations: [
+          {
+            operation: webhookOp,
+            service: webhookService,
+            methodName: 'list_webhook_endpoints',
+            mountOn: 'Webhooks',
+            defaults: {},
+            inferFromClient: [],
+            urlBuilder: false,
+          },
+        ],
+      } as unknown as EmitterContext);
+
+      expect(result.some((f) => f.path === 'src/webhooks/webhooks-endpoints.spec.ts')).toBe(false);
+      expect(result.some((f) => f.path === 'src/webhooks/webhooks.spec.ts')).toBe(false);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Test/fixture scaffolding now emits for adopted-service directories (Connect, Radar, etc.) in addition to `ownedServices`, since adoption means oagen owns the dir from scratch and there is no hand-written content to preserve.
- Fixes several latent emitter bugs that were hidden by the old filter and surfaced when adopted-service tests started landing.
- Cleans up the `options-object` path-expression so the URL template binds to the SDK field name directly, removing the `organizationMembershipId: omId` destructure rename.

## Changes

**Filter (`src/node/index.ts`)** — adopted dirs are treated like owned dirs for test/fixture purposes. Rule (a) still drops files that exist hand-written, so this can't trample anything on disk.

**Model field projection (`src/node/models.ts`, `src/node/naming.ts`)** — `isSupportedFieldType` was dropping fields whose target interface wasn't yet on disk, silently truncating models. Now keeps the field when the target is in `adoptedModelNames` (its interface will land in the same pass). Example: `UserManagementLoginRequest.user` and `.user_consent_options` no longer disappear.

**Array-response tests (`src/node/tests.ts`)** — `renderGetTest` and `renderBodyTest` now wrap the fixture in an array literal and use `result[0]` as the accessor when `plan.isArrayResponse` is true, plus an `expect(Array.isArray(result)).toBe(true)` assertion. Fixes failures on operations like `listApplicationClientSecrets`.

**Date-time assertions (`src/node/tests.ts`)** — `string` + `format: date-time` deserializes to `Date`, but `buildFieldAssertions` was emitting string comparisons. Now compares via `.toISOString()` for date-time fields.

**Split-class skip (`src/node/tests.ts`)** — when the resource class diverges from the mount accessor (e.g. hand-written `Webhooks(crypto)` forks endpoint methods onto `WebhooksEndpoints`), skip the test entirely. The generated test would call `workos.webhooks.foo()` but the methods live on a different class.

**Path-expression cleanup (`src/node/path-expression.ts`, `src/node/resources.ts`)** — `buildNodePathExpression` now accepts an optional `Map<string, string>` mapping spec param names to SDK field names. The options-object code path threads this through, so the URL template renders `${encodeURIComponent(organizationMembershipId)}` directly and the destructure becomes `{ organizationMembershipId }` instead of `{ organizationMembershipId: omId }`.

## Test plan

- [x] `npm test` — 436/436 pass (3 new tests added)
- [x] `npm run typecheck` — clean
- [x] End-to-end: `npm run sdk:generate -- --lang node` against `workos-node` produces `connect.spec.ts`, `radar.spec.ts`, no `webhooks-endpoints.spec.ts`, and full Node CI passes 730 tests (up from 705)

🤖 Generated with [Claude Code](https://claude.com/claude-code)