### PR TITLE
fix(node): emit serializers/index.ts barrel for owned and adopted services

### DIFF
--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -813,6 +813,41 @@ export function generateSerializers(
 
   (ctx as any)._skippedSerializeModels = skippedSerializeModels;
 
+  // Emit a `serializers/index.ts` barrel per directory that received serializer
+  // files in this pass. Mirrors the per-service `interfaces/index.ts` barrel so
+  // consumers can `import { ... } from './serializers'` rather than reaching
+  // into individual `.serializer.ts` files. Also includes any pre-existing
+  // `*.serializer.ts` files in the same directory (e.g. hand-written option
+  // serializers in an owned service) so we don't strand them from the barrel.
+  const serializersByDir = new Map<string, Set<string>>();
+  for (const f of files) {
+    const match = f.path.match(/^src\/([^/]+)\/serializers\/(.+)\.serializer\.ts$/);
+    if (!match) continue;
+    const [, dir, stem] = match;
+    if (!serializersByDir.has(dir)) serializersByDir.set(dir, new Set());
+    serializersByDir.get(dir)!.add(stem);
+  }
+  const liveRootForBarrel = ctx.outputDir ?? ctx.targetDir;
+  for (const [dir, stems] of serializersByDir) {
+    if (liveRootForBarrel) {
+      const serializersDir = path.join(liveRootForBarrel, 'src', dir, 'serializers');
+      try {
+        for (const entry of fs.readdirSync(serializersDir)) {
+          if (!entry.endsWith('.serializer.ts')) continue;
+          stems.add(entry.replace(/\.serializer\.ts$/, ''));
+        }
+      } catch {
+        // Directory doesn't exist yet — only this-pass serializers will appear.
+      }
+    }
+    const lines = [...stems].sort().map((stem) => `export * from './${stem}.serializer';`);
+    files.push({
+      path: `src/${dir}/serializers/index.ts`,
+      content: lines.join('\n') + '\n',
+      overwriteExisting: true,
+    });
+  }
+
   return files;
 }
 

--- a/test/node/models.test.ts
+++ b/test/node/models.test.ts
@@ -558,4 +558,36 @@ describe('generateSerializers', () => {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it('emits a serializers/index.ts barrel listing every emitted serializer', () => {
+    const models: Model[] = [
+      {
+        name: 'Organization',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'OrganizationMember',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    const spec = makeSpec(models);
+    const ctxWithModels: EmitterContext = { ...ctx, spec };
+    const result = generateSerializers(models, ctxWithModels);
+
+    const serializerFiles = result.filter((f) => f.path.endsWith('.serializer.ts'));
+    expect(serializerFiles.length).toBeGreaterThan(0);
+
+    // Every emitted serializer file should appear in a barrel at the same
+    // directory's `serializers/index.ts`.
+    for (const sf of serializerFiles) {
+      const match = sf.path.match(/^src\/([^/]+)\/serializers\/(.+)\.serializer\.ts$/);
+      expect(match).not.toBeNull();
+      const [, dir, stem] = match!;
+      const barrel = result.find((f) => f.path === `src/${dir}/serializers/index.ts`);
+      expect(barrel, `expected barrel for ${dir}`).toBeDefined();
+      expect(barrel!.content).toContain(`export * from './${stem}.serializer';`);
+      expect(barrel!.overwriteExisting).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

The Node emitter generates an `interfaces/index.ts` barrel per service directory but never emitted a parallel `serializers/index.ts`. Every owned/adopted service consequently shipped without one, leaving consumers to reach into individual `*.serializer.ts` files. Hand-written services (api-keys, etc.) still have their barrels because those weren't touched by oagen; the inconsistency only appeared on services the emitter manages.

## Changes

- `src/node/models.ts::generateSerializers` — after the main loop, group emitted serializer files by directory and write a barrel listing all of them.
- Also scans the existing `serializers/` directory on disk so hand-written option serializers in a partially-owned service (e.g. Groups' `create-group-options.serializer.ts`) stay in the barrel after regen.

## Test plan

- [x] `npm test` — 437/437 pass; new `emits a serializers/index.ts barrel listing every emitted serializer` test in `test/node/models.test.ts`
- [x] `npm run typecheck` — clean
- [x] End-to-end against `workos-node`:
  - `src/webhooks/serializers/index.ts` now lists the 3 endpoint serializers.
  - `src/groups/serializers/index.ts` now lists all 7 serializers (3 new spec-model + 4 pre-existing hand-written options).
  - `src/connect/serializers/index.ts` and `src/radar/serializers/index.ts` similarly emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)