### PR TITLE
fix(node): skip dead deserializers and strengthen all-optional body tests

### DIFF
--- a/src/node/field-plan.ts
+++ b/src/node/field-plan.ts
@@ -666,6 +666,10 @@ interface SerializerContext {
   resolveDir: (irService: string | undefined) => string;
   dedup: Map<string, string>;
   skippedSerializeModels: Set<string>;
+  /** Models reachable from any response — anything outside this set is
+   *  request-only and won't have a `deserialize<X>` emitted. `undefined`
+   *  means "no usage info available, assume deserialize exists". */
+  responseReachableModels: Set<string> | undefined;
   ctx: EmitterContext;
 }
 
@@ -723,6 +727,10 @@ export function buildSerializerImports(
     const canon = sctx.dedup.get(dep);
     const depSkipSerialize =
       sctx.skippedSerializeModels.has(dep) || (canon != null && sctx.skippedSerializeModels.has(canon));
+    const depSkipDeserialize =
+      sctx.responseReachableModels !== undefined &&
+      !sctx.responseReachableModels.has(dep) &&
+      (canon == null || !sctx.responseReachableModels.has(canon));
 
     // Decide whether this serializer is reachable at runtime:
     //   - file on disk → honor what it exports (hasDeser/hasSer)
@@ -759,8 +767,11 @@ export function buildSerializerImports(
       continue;
     }
 
+    if (depSkipSerialize && depSkipDeserialize) continue;
     if (depSkipSerialize) {
       lines.push(`import { deserialize${depName} } from '${rel}';`);
+    } else if (depSkipDeserialize) {
+      lines.push(`import { serialize${depName} } from '${rel}';`);
     } else {
       lines.push(`import { deserialize${depName}, serialize${depName} } from '${rel}';`);
     }
@@ -821,27 +832,30 @@ export function emitSerializerBody(
   baselineResponse: BaselineInterface | undefined,
   skipFormatFields: Set<string>,
   shouldSkipSerialize: boolean,
+  shouldSkipDeserialize: boolean,
   ctx: EmitterContext,
 ): string[] {
   const lines: string[] = [];
 
-  const seenDeserFields = new Set<string>();
-  const deserParamPrefix = model.fields.length === 0 ? '_' : '';
-  lines.push(`export const deserialize${domainName} = ${typeParams.decl}(`);
-  lines.push(`  ${deserParamPrefix}response: ${responseName}${typeParams.usage},`);
-  lines.push(`): ${domainName}${typeParams.usage} => ({`);
-  for (const field of model.fields) {
-    const domain = fieldName(field.name);
-    if (seenDeserFields.has(domain)) continue;
-    seenDeserFields.add(domain);
-    const plan = planDeserializeField(field, baselineDomain, baselineResponse, skipFormatFields, ctx);
-    if (!plan.skip) lines.push(plan.line);
+  if (!shouldSkipDeserialize) {
+    const seenDeserFields = new Set<string>();
+    const deserParamPrefix = model.fields.length === 0 ? '_' : '';
+    lines.push(`export const deserialize${domainName} = ${typeParams.decl}(`);
+    lines.push(`  ${deserParamPrefix}response: ${responseName}${typeParams.usage},`);
+    lines.push(`): ${domainName}${typeParams.usage} => ({`);
+    for (const field of model.fields) {
+      const domain = fieldName(field.name);
+      if (seenDeserFields.has(domain)) continue;
+      seenDeserFields.add(domain);
+      const plan = planDeserializeField(field, baselineDomain, baselineResponse, skipFormatFields, ctx);
+      if (!plan.skip) lines.push(plan.line);
+    }
+    lines.push('});');
   }
-  lines.push('});');
 
   if (!shouldSkipSerialize) {
+    if (!shouldSkipDeserialize) lines.push('');
     const serParamPrefix = model.fields.length === 0 ? '_' : '';
-    lines.push('');
     lines.push(`export const serialize${domainName} = ${typeParams.decl}(`);
     lines.push(`  ${serParamPrefix}model: ${domainName}${typeParams.usage},`);
     lines.push(`): ${responseName}${typeParams.usage} => ({`);

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -61,6 +61,10 @@ interface SharedModelContext {
 interface GeneratedResourceModelUsage {
   interfaceRoots: Set<string>;
   serializerRoots: Set<string>;
+  /** Models that are directly used as a request body. Drive `serialize<X>`. */
+  requestRoots: Set<string>;
+  /** Models that are directly used as a response body. Drive `deserialize<X>`. */
+  responseRoots: Set<string>;
 }
 
 function buildSharedContext(models: Model[], ctx: EmitterContext): SharedModelContext {
@@ -655,6 +659,14 @@ export function generateSerializers(
   const serializerEligibleModels = resourceUsage
     ? expandModelRoots(resourceUsage.serializerRoots, projectedByName)
     : undefined;
+  // Models reachable from any response — only these need a `deserialize<X>`.
+  // A model used solely as a request body (e.g. `CreateWebhookEndpoint`)
+  // would otherwise emit a deserializer with a partial response shape that
+  // silently misbehaves if called. Undefined means "no resource usage info,
+  // emit both halves" (standalone generation, smoke tests).
+  const responseReachableModels = resourceUsage
+    ? expandModelRoots(resourceUsage.responseRoots, projectedByName)
+    : undefined;
 
   const serializerReachable = computeNonEventReachable(ctx.spec.services, models);
 
@@ -765,9 +777,19 @@ export function generateSerializers(
       if (domainName === canonDomainName) continue;
       const rel = relativeImport(serializerPath, canonSerializerPath);
       const canonSkipSerialize = skippedSerializeModels.has(canonicalName) || skippedSerializeModels.has(model.name);
-      const reexportContent = canonSkipSerialize
-        ? `export { deserialize${canonDomainName} as deserialize${domainName} } from '${rel}';`
-        : `export { deserialize${canonDomainName} as deserialize${domainName}, serialize${canonDomainName} as serialize${domainName} } from '${rel}';`;
+      const canonSkipDeserialize =
+        responseReachableModels !== undefined &&
+        !responseReachableModels.has(canonicalName) &&
+        !responseReachableModels.has(model.name);
+      if (canonSkipSerialize && canonSkipDeserialize) continue;
+      const parts: string[] = [];
+      if (!canonSkipDeserialize) {
+        parts.push(`deserialize${canonDomainName} as deserialize${domainName}`);
+      }
+      if (!canonSkipSerialize) {
+        parts.push(`serialize${canonDomainName} as serialize${domainName}`);
+      }
+      const reexportContent = `export { ${parts.join(', ')} } from '${rel}';`;
       files.push({
         path: serializerPath,
         content: reexportContent,
@@ -787,8 +809,21 @@ export function generateSerializers(
 
     const skipFormatFields = buildSkipFormatFields(model, baselineDomain);
     const shouldSkipSerialize = skippedSerializeModels.has(model.name);
+    // Skip `deserialize<X>` when the model never appears as a response (and
+    // we have usage info to verify that — `undefined` means "emit both halves
+    // conservatively"). Cuts unused, partially-typed deserializers like
+    // `deserializeCreateWebhookEndpoint` from request-body-only models.
+    const shouldSkipDeserialize = responseReachableModels !== undefined && !responseReachableModels.has(model.name);
+    if (shouldSkipSerialize && shouldSkipDeserialize) continue;
 
-    const sctx = { modelToService, resolveDir, dedup, skippedSerializeModels, ctx };
+    const sctx = {
+      modelToService,
+      resolveDir,
+      dedup,
+      skippedSerializeModels,
+      responseReachableModels,
+      ctx,
+    };
     const lines = [
       ...buildSerializerImports(model, serializerPath, dirName, domainName, responseName, sctx),
       ...emitSerializerBody(
@@ -800,6 +835,7 @@ export function generateSerializers(
         baselineResponse,
         skipFormatFields,
         shouldSkipSerialize,
+        shouldSkipDeserialize,
         ctx,
       ),
     ];
@@ -812,6 +848,10 @@ export function generateSerializers(
   }
 
   (ctx as any)._skippedSerializeModels = skippedSerializeModels;
+  // Surface the response-reachable set so the serializer-roundtrip test
+  // generator can fall back to a deserialize-skipped path for request-only
+  // models (where `deserialize<X>` was deliberately not emitted).
+  (ctx as any)._responseReachableModels = responseReachableModels;
 
   // Emit a `serializers/index.ts` barrel per directory that received serializer
   // files in this pass. Mirrors the per-service `interfaces/index.ts` barrel so
@@ -882,6 +922,8 @@ function buildGeneratedResourceModelUsage(
   const modelMap = new Map(models.map((model) => [model.name, model]));
   const interfaceRoots = new Set<string>();
   const serializerRoots = new Set<string>();
+  const requestRoots = new Set<string>();
+  const responseRoots = new Set<string>();
   const resolvedLookup = buildResolvedLookup(ctx);
   const mountGroups = groupByMount(ctx);
   const services: Service[] =
@@ -924,16 +966,19 @@ function buildGeneratedResourceModelUsage(
           if (unwrapped) itemName = unwrapped.name;
           interfaceRoots.add(itemName);
           serializerRoots.add(itemName);
+          responseRoots.add(itemName);
         }
       } else if (plan.responseModelName) {
         interfaceRoots.add(plan.responseModelName);
         serializerRoots.add(plan.responseModelName);
+        responseRoots.add(plan.responseModelName);
       }
 
       const bodyInfo = extractRequestBodyModels(op, ctx);
       for (const name of bodyInfo) {
         interfaceRoots.add(name);
         serializerRoots.add(name);
+        requestRoots.add(name);
       }
 
       for (const param of [...op.pathParams, ...op.queryParams, ...op.headerParams]) {
@@ -945,6 +990,7 @@ function buildGeneratedResourceModelUsage(
         for (const name of collectWrapperResponseModels(resolved)) {
           interfaceRoots.add(name);
           serializerRoots.add(name);
+          responseRoots.add(name);
         }
         for (const wrapper of resolved.wrappers ?? []) {
           for (const { field } of resolveWrapperParams(wrapper, ctx)) {
@@ -955,7 +1001,7 @@ function buildGeneratedResourceModelUsage(
     }
   }
 
-  return { interfaceRoots, serializerRoots };
+  return { interfaceRoots, serializerRoots, requestRoots, responseRoots };
 }
 
 function extractRequestBodyModels(op: Operation, ctx: EmitterContext): string[] {

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -838,18 +838,33 @@ function buildTestPayload(
   }
   if (!model) return null;
 
-  const fields = model.fields.filter((f) => f.required);
+  const requiredFields = model.fields.filter((f) => f.required);
   // Only use fields that we can generate deterministic values for (primitives, enums, and nested models)
-  const usableFields = fields.filter((f) => fixtureValueForType(f.type, f.name, model.name, modelMap) !== null);
+  const usableRequired = requiredFields.filter(
+    (f) => fixtureValueForType(f.type, f.name, model.name, modelMap) !== null,
+  );
 
-  // Only generate a typed payload when ALL required fields have fixture values.
-  // A partial payload missing required fields would fail TypeScript type checking.
-  if (usableFields.length === 0 || usableFields.length < fields.length) return null;
+  let chosenFields: typeof model.fields;
+  if (requiredFields.length > 0) {
+    // Only generate a typed payload when ALL required fields have fixture values.
+    // A partial payload missing required fields would fail TypeScript type checking.
+    if (usableRequired.length < requiredFields.length) return null;
+    chosenFields = usableRequired;
+  } else {
+    // All-optional model (e.g. PATCH `Update<X>` bodies). Pick the first few
+    // optional fields with available fixture values so the test asserts the
+    // wire format instead of falling back to `expect(fetchBody()).toBeDefined()`.
+    const usableOptional = model.fields.filter(
+      (f) => !f.required && fixtureValueForType(f.type, f.name, model.name, modelMap) !== null,
+    );
+    if (usableOptional.length === 0) return null;
+    chosenFields = usableOptional.slice(0, 2);
+  }
 
   const camelEntries: string[] = [];
   const snakeEntries: string[] = [];
 
-  for (const field of usableFields) {
+  for (const field of chosenFields) {
     const camelValue = fixtureValueForType(field.type, field.name, model.name, modelMap)!;
     const wireValue = fixtureValueForType(field.type, field.name, model.name, modelMap, true)!;
     const camelKey = fieldName(field.name);
@@ -935,6 +950,10 @@ function generateSerializerTests(spec: ApiSpec, ctx: EmitterContext): GeneratedF
   // Use the skipped-serialize set computed by the serializer generator.
   // It's stashed on the context during generateSerializers.
   const serializeSkipped: Set<string> = (ctx as any)._skippedSerializeModels ?? new Set<string>();
+  // Response-reachable models — anything outside this set is request-only
+  // and has no `deserialize<X>` to test. `undefined` means "no usage info,
+  // assume deserialize exists" (standalone generation, smoke tests).
+  const responseReachableModels: Set<string> | undefined = (ctx as any)._responseReachableModels;
 
   // Group eligible models by service directory for one test file per service
   const modelsByDir = new Map<string, Model[]>();
@@ -958,6 +977,7 @@ function generateSerializerTests(spec: ApiSpec, ctx: EmitterContext): GeneratedF
     const interfaceImports: string[] = [];
     const fixtureImports: string[] = [];
     const deserializeOnlyModels = new Set<string>();
+    const serializeOnlyModels = new Set<string>();
 
     for (const model of models) {
       const domainName = resolveInterfaceName(model.name, ctx);
@@ -966,13 +986,24 @@ function generateSerializerTests(spec: ApiSpec, ctx: EmitterContext): GeneratedF
       const serializerPath = `src/${modelDir}/serializers/${fileName(model.name)}.serializer.ts`;
       const interfacePath = `src/${modelDir}/interfaces/${fileName(model.name)}.interface.ts`;
       const fixturePath = `src/${modelDir}/fixtures/${fileName(model.name)}.json`;
-      const deserializeOnly = serializeSkipped.has(model.name) || fixtureIsHandOwned(fixturePath, ctx);
+      // Request-only models (e.g. `CreateWebhookEndpoint`) have no
+      // `deserialize<X>` emitted, so they can only be tested via serialize.
+      // This check has to come first: a hand-owned fixture would otherwise
+      // route through the deserialize-only branch, which then imports a
+      // function that doesn't exist.
+      const isRequestOnly = responseReachableModels !== undefined && !responseReachableModels.has(model.name);
+      const deserializeOnly =
+        !isRequestOnly && (serializeSkipped.has(model.name) || fixtureIsHandOwned(fixturePath, ctx));
+      const serializeOnly = isRequestOnly;
       if (deserializeOnly) deserializeOnlyModels.add(model.name);
+      if (serializeOnly) serializeOnlyModels.add(model.name);
 
       if (deserializeOnly) {
         serializerImports.push(
           `import { deserialize${domainName} } from '${relativeImport(testPath, serializerPath)}';`,
         );
+      } else if (serializeOnly) {
+        serializerImports.push(`import { serialize${domainName} } from '${relativeImport(testPath, serializerPath)}';`);
       } else {
         serializerImports.push(
           `import { deserialize${domainName}, serialize${domainName} } from '${relativeImport(testPath, serializerPath)}';`,
@@ -1007,6 +1038,15 @@ function generateSerializerTests(spec: ApiSpec, ctx: EmitterContext): GeneratedF
         lines.push(`    const fixture = ${fixtureName} as ${wireName};`);
         lines.push(`    const deserialized = deserialize${domainName}(fixture);`);
         lines.push('    expect(deserialized).toBeDefined();');
+        lines.push('  });');
+        lines.push('});');
+      } else if (serializeOnlyModels.has(model.name)) {
+        // Serialize-only test for request-body-only models without a deserializer.
+        lines.push(`describe('${domainName}Serializer', () => {`);
+        lines.push("  it('serializes correctly', () => {");
+        lines.push(`    const fixture = ${fixtureName} as ${wireName};`);
+        lines.push(`    const serialized = serialize${domainName}(fixture as any);`);
+        lines.push('    expect(serialized).toBeDefined();');
         lines.push('  });');
         lines.push('});');
       } else {

--- a/test/node/models.test.ts
+++ b/test/node/models.test.ts
@@ -590,4 +590,60 @@ describe('generateSerializers', () => {
       expect(barrel!.overwriteExisting).toBe(true);
     }
   });
+
+  it('omits deserialize half for request-body-only models', () => {
+    // `CreateOrganization` is sent as a POST body but the operation responds
+    // with a separate `Organization` model. The deserializer for the request
+    // model would be dead code AND would silently misbehave if called (the
+    // response wire shape doesn't match), so it shouldn't be emitted.
+    const models: Model[] = [
+      {
+        name: 'Organization',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'CreateOrganization',
+        fields: [{ name: 'name', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    const spec: ApiSpec = {
+      ...emptySpec,
+      models,
+      services: [
+        {
+          name: 'Organizations',
+          operations: [
+            {
+              name: 'createOrganization',
+              httpMethod: 'post',
+              path: '/organizations',
+              pathParams: [],
+              queryParams: [],
+              headerParams: [],
+              response: { kind: 'model', name: 'Organization' },
+              requestBody: { kind: 'model', name: 'CreateOrganization' },
+              errors: [],
+              injectIdempotencyKey: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    const ctxWithModels: EmitterContext = { ...ctx, spec };
+    const result = generateSerializers(models, ctxWithModels);
+
+    const createSerializer = result.find((f) => f.path.endsWith('create-organization.serializer.ts'));
+    expect(createSerializer).toBeDefined();
+    expect(createSerializer!.content).toContain('export const serializeCreateOrganization');
+    expect(createSerializer!.content).not.toContain('export const deserializeCreateOrganization');
+
+    // Response-side model still gets both halves.
+    const orgSerializer = result.find(
+      (f) => f.path.endsWith('organization.serializer.ts') && !f.path.includes('create'),
+    );
+    expect(orgSerializer).toBeDefined();
+    expect(orgSerializer!.content).toContain('export const deserializeOrganization');
+  });
 });

--- a/test/node/tests.test.ts
+++ b/test/node/tests.test.ts
@@ -211,4 +211,61 @@ describe('node test generation ownership', () => {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it('asserts wire format on all-optional request bodies instead of toBeDefined()', () => {
+    // For PATCH/Update bodies where every field is optional, the test
+    // emitter previously fell back to `expect(fetchBody()).toBeDefined()`,
+    // which passes even if the serializer writes the wrong keys. Picking a
+    // couple of optional fields with deterministic fixture values makes the
+    // test actually validate snake_case conversion on the wire.
+    const updateModel: Model = {
+      name: 'UpdateGroup',
+      fields: [
+        { name: 'name', type: { kind: 'primitive', type: 'string' }, required: false },
+        { name: 'description', type: { kind: 'primitive', type: 'string' }, required: false },
+      ],
+    };
+
+    const updateOp = {
+      name: 'updateGroup',
+      httpMethod: 'patch' as const,
+      path: '/organizations/{organizationId}/groups/{id}',
+      pathParams: [
+        { name: 'organizationId', type: { kind: 'primitive' as const, type: 'string' as const }, required: true },
+        { name: 'id', type: { kind: 'primitive' as const, type: 'string' as const }, required: true },
+      ],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model' as const, name: 'Group' },
+      requestBody: { kind: 'model' as const, name: 'UpdateGroup' },
+      errors: [],
+      injectIdempotencyKey: false,
+    };
+
+    const updateService: Service = { name: 'Groups', operations: [updateOp] };
+    const updateSpec: ApiSpec = {
+      ...spec,
+      models: [groupModel, updateModel],
+      services: [updateService],
+    };
+    const tmpRoot = createTrackedSdkRoot();
+    try {
+      const result = nodeEmitter.generateTests!(updateSpec, {
+        ...ctx,
+        spec: updateSpec,
+        outputDir: tmpRoot,
+        emitterOptions: { ownedServices: ['Groups'], regenerateOwnedTests: true },
+      } as EmitterContext);
+
+      const testFile = result.find((f) => f.path === 'src/groups/groups.spec.ts');
+      expect(testFile).toBeDefined();
+      const content = testFile!.content;
+      // The body assertion picks at least one optional field and checks its
+      // snake_case wire format — not just `.toBeDefined()`.
+      expect(content).toContain('expect(fetchBody()).toEqual(');
+      expect(content).toMatch(/expect\.objectContaining\(\{[^}]*\bname\b/);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Two related quality improvements to the Node emitter, both surfaced by review of the generated webhook-endpoint surface in workos-node PR #1592.

### 1. Skip dead `deserialize<X>` halves on request-only models

`generateSerializers` previously emitted both `serialize<X>` and `deserialize<X>` for every reachable model. For models that only ever appear as request bodies (`CreateWebhookEndpoint`, `UpdateWebhookEndpoint`, etc.) the deserializer is never called by the SDK AND is shaped against the *request* wire — a consumer importing it via the serializers barrel and calling it on the actual API response would silently get an object missing every response-only field.

Track request vs response usage separately in `GeneratedResourceModelUsage`, walk responses transitively via `expandModelRoots`, and skip the `deserialize<X>` half when the model isn't response-reachable.

Affected sites threaded with the new info:
- `emitSerializerBody` — gains a `shouldSkipDeserialize` parameter.
- `buildSerializerImports` — parallel `depSkipDeserialize` so nested cross-file imports don't reference symbols that no longer exist.
- Dedup re-export path in `generateSerializers` — selective `export { … }` instead of always-both.
- `generateSerializerTests` — new serialize-only branch (mirrors the existing deserialize-only branch). Checks request-only FIRST so a hand-owned fixture doesn't route into a deserialize path for a model that has no deserializer.

### 2. Strengthen `Update<X>` body assertions

`buildTestPayload` returned null when the request model had zero required fields, falling back to `{} as any` + `expect(fetchBody()).toBeDefined()` — passes even if the serializer writes wrong keys. Now: when no required fields exist (`Update<X>` style), pick up to two optional fields with deterministic fixture values and assert the snake_case wire format the same way the `Create<X>` test path does.

### Test plan

- [x] `npm test` — 439/439 pass; two new tests added (`emits a serializers/index.ts barrel listing every emitted serializer` was already there; new: `omits deserialize half for request-body-only models` in `models.test.ts`, `asserts wire format on all-optional request bodies instead of toBeDefined()` in `tests.test.ts`)
- [x] `npm run typecheck` — clean
- [x] End-to-end against workos-node:
  - `src/webhooks/serializers/create-webhook-endpoint.serializer.ts` now exports only `serializeCreateWebhookEndpoint`; ditto `update-webhook-endpoint`.
  - `src/webhooks/serializers.spec.ts` uses the new serialize-only branch (imports `serialize<X>`, calls it, asserts defined).
  - `src/webhooks/webhooks.spec.ts`'s `updateWebhookEndpoint` test now passes `{ endpointUrl, status }` and asserts `endpoint_url`/`status` on the wire instead of `toBeDefined()`.
  - Cross-file dedup re-export (`radar-standalone-delete-radar-list-entry-request.serializer.ts`) now correctly omits the missing `deserialize<X>` alias.
  - Node CI: 716/728 tests pass (12 skipped, expected), 39/40 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)