### PR TITLE
fix(shared): prevent synthetic-enum collision with IR enums

### DIFF
--- a/src/ruby/index.ts
+++ b/src/ruby/index.ts
@@ -36,8 +36,8 @@ function ensureTrailingNewlines(files: GeneratedFile[]): GeneratedFile[] {
  * has its original fields restored — otherwise `ConnectApplication`-style
  * bases would silently lose every variant field they had previously.
  */
-function enrichModelsForRuby(models: Model[]): Model[] {
-  const enriched = enrichModelsFromSpec(models);
+function enrichModelsForRuby(models: Model[], enums: Enum[]): Model[] {
+  const enriched = enrichModelsFromSpec(models, enums);
   const originalByName = new Map(models.map((m) => [m.name, m]));
   return enriched.map((m) => {
     if ((m as { discriminator?: unknown }).discriminator && m.fields.length === 0) {
@@ -54,7 +54,7 @@ export const rubyEmitter: Emitter = {
   language: 'ruby',
 
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
-    const modelFiles = generateModels(enrichModelsForRuby(models), ctx);
+    const modelFiles = generateModels(enrichModelsForRuby(models, ctx.spec.enums), ctx);
     return ensureTrailingNewlines(modelFiles);
   },
 

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -503,7 +503,7 @@ export function detectDiscriminators(models: Model[]): Model[] {
  * Returns a new array of enriched models (original models are not mutated).
  * Synthetic enums are stored internally; retrieve them via `getSyntheticEnums()`.
  */
-export function enrichModelsFromSpec(models: Model[]): Model[] {
+export function enrichModelsFromSpec(models: Model[], enums: Enum[] = []): Model[] {
   const spec = loadRawSpec();
   if (!spec) {
     _lastSyntheticEnums = [];
@@ -517,6 +517,17 @@ export function enrichModelsFromSpec(models: Model[]): Model[] {
   for (const m of models) {
     collector.usedNames.add(m.name);
     collector.usedNames.add(toSnakeCase(m.name));
+  }
+  // Seed existing IR enum names too. The parser already emits inline enums
+  // like `DataIntegrationAccessTokenResponseError` (PascalCase); without this
+  // seed, the synthetic path would emit a sibling enum named
+  // `DataIntegrationAccessTokenResponse_error`, and language emitters that
+  // PascalCase-normalize identifiers (Ruby, Go, PHP, Python) would collapse
+  // both onto the same class/file path — the second overwrites the first
+  // with a `X = X` self-alias.
+  for (const e of enums) {
+    collector.usedNames.add(e.name);
+    collector.usedNames.add(toSnakeCase(e.name));
   }
 
   const enriched = models.map((model) => {


### PR DESCRIPTION
## Summary

- `enrichModelsFromSpec` was emitting a synthetic enum (e.g. `DataIntegrationAccessTokenResponse_error`) alongside the parser's existing IR enum (`DataIntegrationAccessTokenResponseError`). The two names differ as strings but collapse to the same identifier in PascalCase-normalizing emitters (Ruby, Go, PHP, Python), so both wrote to the same file path — the second overwrote the first with a `X = X` self-alias.
- In the Ruby SDK this surfaced as `script/ci` failing on `Lint/SelfAssignment` in `lib/workos/types/data_integration_access_token_response_error.rb`.
- Fix: thread the IR enum list into `enrichModelsFromSpec` and seed `collector.usedNames` with both PascalCase and snake_case forms so the synthetic path skips names the parser already produced. Wired through the Ruby emitter via `ctx.spec.enums`; other languages stay on the default `[]` until they opt in.

## Test plan

- [x] `npm test` (54 files, 439 tests passing)
- [x] Manual repro: re-ran `generateAllFiles` against the WorkOS spec — no duplicate paths, and `lib/workos/types/data_integration_access_token_response_error.rb` now contains the full enum class body instead of `DataIntegrationAccessTokenResponseError = DataIntegrationAccessTokenResponseError`.
- [ ] After this lands and openapi-spec bumps the dep, `script/ci` in workos-ruby should pass (note: a separate hand-maintained duplicate `def vault` in `workos-ruby/lib/workos/client.rb` still needs removal — tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)