### PR TITLE
fix: emit non-paginated list wrappers, dotnet member/class collisions, rust glob ambiguity

### DIFF
--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -20,7 +20,11 @@ import {
 } from './naming.js';
 
 // Import and re-export shared model detection utilities
-import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
+import {
+  isListWrapperModel,
+  isListMetadataModel,
+  collectNonPaginatedResponseModelNames,
+} from '../shared/model-utils.js';
 export { isListWrapperModel, isListMetadataModel };
 
 /**
@@ -74,6 +78,11 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
   // (see workos-dotnet#248 with `CreateUserApiKey` /
   // `UserManagementCreateApiKeyOptions`). Skip emission for those.
   const requestBodyOnlyNames = collectRequestBodyOnlyModelNames(ctx.spec.services, models);
+  // Wrappers referenced as a non-paginated response (e.g. `VersionListResponse`
+  // for `GET /vault/v1/kv/{id}/versions`) must still be emitted — the resource
+  // code references them by name and the pagination iterator doesn't unwrap them.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+  const skipAsListWrapper = (m: Model): boolean => isListWrapperModel(m) && !nonPaginatedRefs.has(m.name);
 
   // Build a lookup of base model field C# names → C# types for inheritance.
   // Variant models skip inherited fields and use `new` for type-divergent ones.
@@ -81,9 +90,12 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
   if (discCtx) {
     for (const model of models) {
       if (discCtx.discriminatorBases.has(model.name)) {
+        const baseClassName = modelClassName(model.name);
         const fieldMap = new Map<string, string>();
         for (const field of model.fields) {
-          fieldMap.set(fieldName(field.name), mapTypeRef(field.type));
+          let csName = fieldName(field.name);
+          if (csName === baseClassName) csName = `${csName}Value`;
+          fieldMap.set(csName, mapTypeRef(field.type));
         }
         baseFieldLookup.set(model.name, fieldMap);
       }
@@ -91,7 +103,7 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
   }
 
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
     if (requestBodyOnlyNames.has(model.name)) continue;
 
     const csClassName = modelClassName(model.name);
@@ -104,7 +116,11 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
     const fieldTypes = model.fields.map((f) => mapTypeRef(f.type));
     const needsCollections = fieldTypes.some((t) => t.startsWith('List<') || t.startsWith('Dictionary<'));
     const needsSystem = fieldTypes.some((t) => t.includes('DateTimeOffset'));
-    const needsJsonAttrs = model.fields.some((f) => f.required && isEnumRef(f.type));
+    // Required enums need JsonProperty / STJS; a field whose PascalCase name
+    // collides with the enclosing class needs the same imports for the wire-
+    // name override emitted below.
+    const hasClassNameCollision = model.fields.some((f) => fieldName(f.name) === csClassName);
+    const needsJsonAttrs = hasClassNameCollision || model.fields.some((f) => f.required && isEnumRef(f.type));
 
     lines.push(`namespace ${ctx.namespacePascal}`);
     lines.push('{');
@@ -154,7 +170,14 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
     // Deduplicate fields by C# property name
     const seenFieldNames = new Set<string>();
     for (const field of model.fields) {
-      const csFieldName = fieldName(field.name);
+      // CS0542: a property can't share its enclosing class's name. Spec schemas
+      // like `Error.error` PascalCase into `Error.Error`, so suffix with `Value`
+      // when that happens. Track the rename so we emit an explicit
+      // `[JsonProperty]` attribute below — the SnakeCaseLower naming policy
+      // would otherwise serialize `ErrorValue` as `error_value`, not `error`.
+      let csFieldName = fieldName(field.name);
+      const collidesWithClassName = csFieldName === csClassName;
+      if (collidesWithClassName) csFieldName = `${csFieldName}Value`;
       if (seenFieldNames.has(csFieldName)) continue;
       seenFieldNames.add(csFieldName);
 
@@ -234,7 +257,9 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
       }
 
       const isRequiredEnum = field.required && isEnumRef(field.type) && constInit === null;
-      lines.push(...emitJsonPropertyAttributes(field.name, { isRequiredEnum }));
+      lines.push(
+        ...emitJsonPropertyAttributes(field.name, { isRequiredEnum, explicitWireName: collidesWithClassName }),
+      );
       // Discriminated-union-typed field: attach the variant-dispatching converter
       // so Newtonsoft picks the right subtype on deserialization. The converter
       // name is keyed off the first IR variant model name (matches how

--- a/src/dotnet/type-map.ts
+++ b/src/dotnet/type-map.ts
@@ -156,7 +156,24 @@ export function isEnumRef(ref: TypeRef): boolean {
  * omission so the API returns a clear `missing required field` error instead
  * of a confusing 422.
  */
-export function emitJsonPropertyAttributes(_wireName: string, options: { isRequiredEnum?: boolean } = {}): string[] {
+export function emitJsonPropertyAttributes(
+  wireName: string,
+  options: { isRequiredEnum?: boolean; explicitWireName?: boolean } = {},
+): string[] {
+  // When the C# property name doesn't naturally map back to the wire name via
+  // the SnakeCaseLower naming policy (e.g. we suffixed the property to avoid a
+  // CS0542 class/member collision like `Error.Error` → `Error.ErrorValue`), the
+  // caller pins the wire name explicitly so JSON round-trip still works.
+  if (options.explicitWireName) {
+    if (options.isRequiredEnum) {
+      return [
+        `        [JsonProperty("${wireName}", DefaultValueHandling = DefaultValueHandling.Ignore)]`,
+        `        [STJS.JsonIgnore(Condition = STJS.JsonIgnoreCondition.WhenWritingDefault)]`,
+        `        [STJS.JsonPropertyName("${wireName}")]`,
+      ];
+    }
+    return [`        [JsonProperty("${wireName}")]`, `        [STJS.JsonPropertyName("${wireName}")]`];
+  }
   if (options.isRequiredEnum) {
     return [
       `        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]`,

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -5,7 +5,11 @@ import { className, fieldName } from './naming.js';
 import { lowerFirstForDoc, fieldDocComment, articleFor } from '../shared/naming-utils.js';
 
 // Import and re-export shared model detection utilities
-import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
+import {
+  isListWrapperModel,
+  isListMetadataModel,
+  collectNonPaginatedResponseModelNames,
+} from '../shared/model-utils.js';
 export { isListWrapperModel, isListMetadataModel };
 
 /**
@@ -83,12 +87,17 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   lines.push('');
 
   const requestBodyOnly = collectRequestBodyOnlyModelNames(ctx.spec.services, models);
+  // Wrappers referenced as a non-paginated response (e.g. `VersionListResponse`
+  // for `GET /vault/v1/kv/{id}/versions`) must still be emitted — the resource
+  // code references them by name and the pagination iterator doesn't unwrap them.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+  const skipAsListWrapper = (m: Model): boolean => isListWrapperModel(m) && !nonPaginatedRefs.has(m.name);
 
   // Build structural hash for deduplication
   const modelHashMap = new Map<string, string>();
   const hashGroups = new Map<string, string[]>();
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
     if (requestBodyOnly.has(model.name)) continue;
     const hash = structuralHash(model);
     modelHashMap.set(model.name, hash);
@@ -112,7 +121,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
   const batchedAliases = new Set<string>();
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
     if (requestBodyOnly.has(model.name)) continue;
 
     const structName = className(model.name);

--- a/src/kotlin/models.ts
+++ b/src/kotlin/models.ts
@@ -2,7 +2,11 @@ import type { Model, EmitterContext, GeneratedFile, TypeRef, Field } from '@work
 import { mapTypeRef, discriminatedUnions } from './type-map.js';
 import { className, propertyName, ktStringLiteral, humanize } from './naming.js';
 import { enumCanonicalMap } from './enums.js';
-import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
+import {
+  isListWrapperModel,
+  isListMetadataModel,
+  collectNonPaginatedResponseModelNames,
+} from '../shared/model-utils.js';
 
 const KOTLIN_SRC_PREFIX = 'src/main/kotlin/';
 const MODELS_PACKAGE = 'com.workos.models';
@@ -47,7 +51,7 @@ function promoteFieldType(f: Field): Field {
  * List wrappers (`{ data, list_metadata }`) and the shared `ListMetadata`
  * model are skipped — the hand-maintained runtime provides [Page]/[ListMetadata].
  */
-export function generateModels(models: Model[], _ctx: EmitterContext): GeneratedFile[] {
+export function generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
   if (models.length === 0) return [];
 
   // First pass: call mapTypeRef on every model field so discriminator info is
@@ -58,12 +62,18 @@ export function generateModels(models: Model[], _ctx: EmitterContext): Generated
 
   const files: GeneratedFile[] = [];
 
+  // Wrappers referenced as a non-paginated response (e.g. `VersionListResponse`
+  // for `GET /vault/v1/kv/{id}/versions`) must still be emitted — the resource
+  // code references them by name and pagination iterators don't unwrap them.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+  const skipAsListWrapper = (m: Model): boolean => isListWrapperModel(m) && !nonPaginatedRefs.has(m.name);
+
   // Deduplication: identical structures become typealiases.
   // Pass 1: hash without nested-alias resolution.
   modelAliasMap = null;
   const hashGroupsPass1 = new Map<string, string[]>();
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
     if (model.fields.length === 0 && discriminatedUnions.has(className(model.name))) continue;
     const hash = structuralHash(model);
     if (!hashGroupsPass1.has(hash)) hashGroupsPass1.set(hash, []);
@@ -86,7 +96,7 @@ export function generateModels(models: Model[], _ctx: EmitterContext): Generated
   modelAliasMap = aliasOf;
   const hashGroupsPass2 = new Map<string, string[]>();
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
     if (model.fields.length === 0 && discriminatedUnions.has(className(model.name))) continue;
     if (aliasOf.has(model.name)) continue; // already aliased in pass 1
     const hash = structuralHash(model);
@@ -105,7 +115,7 @@ export function generateModels(models: Model[], _ctx: EmitterContext): Generated
   }
 
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
     const typeName = className(model.name);
 
     // Parent of a discriminated union: emit a sealed class.
@@ -142,7 +152,7 @@ export function generateModels(models: Model[], _ctx: EmitterContext): Generated
   // mapping so Jackson can deserialize directly to the correct concrete type.
   const eventMapping: Array<{ wireValue: string; modelName: string }> = [];
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
     if (aliasOf.has(model.name)) continue;
     if (!isEventEnvelopeModel(model)) continue;
     const eventField = model.fields.find((f) => f.name === 'event');

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -23,6 +23,7 @@ import {
   createServiceDirResolver,
   isListMetadataModel,
   isListWrapperModel,
+  collectNonPaginatedResponseModelNames,
   buildDeduplicationMap,
   relativeImport,
   modelHasNewFields,
@@ -209,12 +210,16 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
   }
 
   const discriminatedSkip = (ctx as { _discriminatedModelNames?: Set<string> })._discriminatedModelNames;
+  // Wrappers referenced as a non-paginated response (e.g. `VersionListResponse`
+  // for `GET /vault/v1/kv/{id}/versions`) must still be emitted — the resource
+  // code references them by name and pagination iterators don't unwrap them.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
   for (const originalModel of models) {
     const model = projectedByName.get(originalModel.name) ?? originalModel;
     if (!reachableModels.has(model.name)) continue;
     if (interfaceEligibleModels && !interfaceEligibleModels.has(model.name)) continue;
     if (isListMetadataModel(model)) continue;
-    if (isListWrapperModel(model)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     if (discriminatedSkip?.has(model.name)) continue;
     const service = modelToService.get(model.name);
     const isOwnedModel = isNodeOwnedService(ctx, service);
@@ -733,13 +738,14 @@ export function generateSerializers(
   }
 
   const discriminatedSerializerSkip = (ctx as { _discriminatedModelNames?: Set<string> })._discriminatedModelNames;
+  const serializerNonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
   const eligibleModels: Model[] = [];
   for (const originalModel of models) {
     const model = projectedByName.get(originalModel.name) ?? originalModel;
     if (!serializerReachable.has(model.name)) continue;
     if (serializerEligibleModels && !serializerEligibleModels.has(model.name)) continue;
     if (isListMetadataModel(model)) continue;
-    if (isListWrapperModel(model)) continue;
+    if (isListWrapperModel(model) && !serializerNonPaginatedRefs.has(model.name)) continue;
     if (discriminatedSerializerSkip?.has(model.name)) continue;
     const service = modelToService.get(model.name);
     const isOwnedModel = isNodeOwnedService(ctx, service);

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -277,7 +277,11 @@ export function isBaselineGeneric(fields: Record<string, unknown>, knownNames: S
   return false;
 }
 
-export { isListMetadataModel, isListWrapperModel } from '../shared/model-utils.js';
+export {
+  isListMetadataModel,
+  isListWrapperModel,
+  collectNonPaginatedResponseModelNames,
+} from '../shared/model-utils.js';
 
 function modelFingerprint(model: Model): string {
   const fields = model.fields.map((f) => `${f.name}:${JSON.stringify(f.type)}:${f.required}`).sort();

--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -4,7 +4,11 @@ import { className, enumClassName, fieldName } from './naming.js';
 import { phpDocComment } from './utils.js';
 
 // Import and re-export shared model detection utilities
-import { isListMetadataModel, isListWrapperModel } from '../shared/model-utils.js';
+import {
+  isListMetadataModel,
+  isListWrapperModel,
+  collectNonPaginatedResponseModelNames,
+} from '../shared/model-utils.js';
 export { isListMetadataModel, isListWrapperModel };
 
 /**
@@ -32,9 +36,14 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     overwriteExisting: true,
   });
 
+  // Wrappers referenced as a non-paginated response (e.g. `VersionListResponse`
+  // for `GET /vault/v1/kv/{id}/versions`) must still be emitted — the resource
+  // code references them by name and the pagination iterator doesn't unwrap them.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+
   for (const model of models) {
     if (isListMetadataModel(model)) continue;
-    if (isListWrapperModel(model)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     const name = className(model.name);
     const lines: string[] = [];
 

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -41,9 +41,15 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // oneOf enrichment collide with existing IR models in snake_case.
   const emittedFilePaths = new Set<string>();
 
+  // Wrappers referenced as a non-paginated operation response (e.g.
+  // `VersionListResponse` for `GET /vault/v1/kv/{id}/versions`) must still be
+  // emitted — the resource code references them by name and SyncPage doesn't
+  // wrap them.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+
   for (const model of models) {
     // Skip list wrapper models (e.g., OrganizationList) — SyncPage handles envelopes
-    if (isListWrapperModel(model)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     // Skip all list metadata models (e.g., ListMetadata, FooListListMetadata)
     if (isListMetadataModel(model)) continue;
 
@@ -865,5 +871,9 @@ function serializeField(ref: any, accessor: string): string {
 }
 
 // Import and re-export shared model detection utilities
-import { isListMetadataModel, isListWrapperModel } from '../shared/model-utils.js';
+import {
+  isListMetadataModel,
+  isListWrapperModel,
+  collectNonPaginatedResponseModelNames,
+} from '../shared/model-utils.js';
 export { isListMetadataModel, isListWrapperModel };

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -1053,8 +1053,14 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
 
     for (const op of allOperations) {
       const plan = planOperation(op);
-      if (plan.responseModelName && !listWrapperNames.has(plan.responseModelName)) {
-        modelImports.add(plan.responseModelName);
+      if (plan.responseModelName) {
+        // List-wrapper responses are normally replaced by SyncPage on paginated
+        // ops, so the wrapper itself is never referenced. On non-paginated ops
+        // (e.g. `GET /vault/v1/kv/{id}/versions` → `VersionListResponse`) the
+        // resource method still returns the wrapper by name and must import it.
+        if (!listWrapperNames.has(plan.responseModelName) || !plan.isPaginated) {
+          modelImports.add(plan.responseModelName);
+        }
       }
       if (op.requestBody?.kind === 'model') {
         const requestBodyRef = op.requestBody;

--- a/src/ruby/models.ts
+++ b/src/ruby/models.ts
@@ -1,7 +1,11 @@
 import type { Model, EmitterContext, GeneratedFile, TypeRef, Field } from '@workos/oagen';
 import { walkTypeRef, assignModelsToServices } from '@workos/oagen';
 import { className, fieldName, fileName, buildMountDirMap } from './naming.js';
-import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
+import {
+  isListWrapperModel,
+  isListMetadataModel,
+  collectNonPaginatedResponseModelNames,
+} from '../shared/model-utils.js';
 
 /** Folder under lib/workos/ for models not owned by any service. */
 export const SHARED_MODEL_DIR = 'shared';
@@ -77,11 +81,17 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
   const files: GeneratedFile[] = [];
 
+  // Wrappers referenced as a non-paginated response (e.g. `VersionListResponse`
+  // for `GET /vault/v1/kv/{id}/versions`) must still be emitted — the resource
+  // code references them by name and the pagination iterator doesn't unwrap them.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+  const skipAsListWrapper = (m: Model): boolean => isListWrapperModel(m) && !nonPaginatedRefs.has(m.name);
+
   // Dedup identical models (by recursive structural hash).
   const recursiveHashes = buildRecursiveHashMap(models, enumNames);
   const hashGroups = new Map<string, string[]>();
   for (const m of models) {
-    if (isListWrapperModel(m) || isListMetadataModel(m)) continue;
+    if (skipAsListWrapper(m) || isListMetadataModel(m)) continue;
     const h = recursiveHashes.get(m.name) ?? '';
     if (!hashGroups.has(h)) hashGroups.set(h, []);
     hashGroups.get(h)!.push(m.name);
@@ -95,7 +105,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   }
 
   for (const model of models) {
-    if (isListWrapperModel(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
 
     const cls = className(model.name);
     const file = fileName(model.name);

--- a/src/rust/models.ts
+++ b/src/rust/models.ts
@@ -140,7 +140,11 @@ function renderField(field: Field, rustField: string, modelName: string, registr
 function renderModelsBarrel(modules: string[]): string {
   const sorted = [...new Set(modules)].sort();
   const lines: string[] = [];
-  for (const m of sorted) lines.push(`pub mod ${m};`);
+  // Declare the modules privately so `pub use crate::models::*` in lib.rs only
+  // re-exports the struct names, not the module names themselves. Otherwise a
+  // module like `models::organization_membership` collides with the same-named
+  // `resources::organization_membership` when both barrels are glob-re-exported.
+  for (const m of sorted) lines.push(`mod ${m};`);
   lines.push('');
   for (const m of sorted) lines.push(`pub use ${m}::*;`);
   return lines.join('\n') + '\n';

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -1317,7 +1317,10 @@ function renderResourcesBarrel(exports: { module: string; struct: string }[]): s
   unique.sort((a, b) => a.module.localeCompare(b.module));
 
   const lines: string[] = [];
-  for (const { module } of unique) lines.push(`pub mod ${module};`);
+  // Declare modules privately — see the matching comment in `models.ts`.
+  // `pub mod resources::organization_membership` would collide with the
+  // same-named module re-exported via `pub use models::*` in lib.rs.
+  for (const { module } of unique) lines.push(`mod ${module};`);
   lines.push('');
   for (const { module, struct } of unique) lines.push(`pub use ${module}::${struct};`);
   return lines.join('\n') + '\n';

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -1,9 +1,30 @@
-import type { Model, Field, TypeRef, Enum } from '@workos/oagen';
-import { toSnakeCase, toUpperSnakeCase } from '@workos/oagen';
+import type { Model, Field, TypeRef, Enum, Service } from '@workos/oagen';
+import { toSnakeCase, toUpperSnakeCase, walkTypeRef } from '@workos/oagen';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 // @ts-ignore -- js-yaml has no type declarations in this project
 import { load as yamlLoad } from 'js-yaml';
+
+/**
+ * Collect model names referenced as the return type of any non-paginated
+ * operation. The list-wrapper skip rule below assumes a wrapper is always
+ * replaced by the SDK's pagination machinery — but a few endpoints
+ * (e.g. `GET /vault/v1/kv/{id}/versions`) have a list-envelope response
+ * shape with no pagination params, so the parser leaves them as a plain
+ * model reference. We must still emit those wrappers as regular models;
+ * otherwise the generated resource code references an undefined name.
+ */
+export function collectNonPaginatedResponseModelNames(services: Service[]): Set<string> {
+  const names = new Set<string>();
+  for (const service of services) {
+    for (const op of service.operations) {
+      if (op.pagination) continue;
+      walkTypeRef(op.response, { model: (r) => names.add(r.name) });
+      for (const sr of op.successResponses ?? []) walkTypeRef(sr.type, { model: (r) => names.add(r.name) });
+    }
+  }
+  return names;
+}
 
 /**
  * Detect whether a model is a list wrapper -- the standard paginated

--- a/test/rust/models.test.ts
+++ b/test/rust/models.test.ts
@@ -110,7 +110,7 @@ describe('rust/models', () => {
     const event = files.find((f) => f.path === 'src/models/event.rs')!;
     expect(event.content).toContain('pub payload: EventPayloadOneOf,');
     const barrel = files.find((f) => f.path === 'src/models/mod.rs')!;
-    expect(barrel.content).toContain('pub mod _unions;');
+    expect(barrel.content).toContain('mod _unions;');
     // The _unions.rs file is rendered by generateClient (the final structural
     // pass) so resource-side body unions can join the same registry.
     const clientFiles = generateClient(emptySpec, ctx, registry);
@@ -170,8 +170,8 @@ describe('rust/models', () => {
     ];
     const files = generateModels(models, ctx, new UnionRegistry());
     const barrel = files.find((f) => f.path === 'src/models/mod.rs')!;
-    expect(barrel.content).toContain('pub mod alpha;');
-    expect(barrel.content).toContain('pub mod beta;');
+    expect(barrel.content).toContain('mod alpha;');
+    expect(barrel.content).toContain('mod beta;');
     expect(barrel.content).toContain('pub use alpha::*;');
   });
 });


### PR DESCRIPTION
## Summary

Three independent SDK-generation bugs that surfaced running `script/ci` across all six target SDKs against the WorkOS spec. Each is in its own commit-worth of change, bundled because the user reported them as one batch and they're cheap to ship together.

### 1. Non-paginated list wrappers are dropped

`isListWrapperModel` is structural: any `{data: array, list_metadata}` schema is treated as a paginated envelope the SDK runtime will replace. But the parser only sets `op.pagination` when the operation has cursor/limit params, so endpoints like `GET /vault/v1/kv/{id}/versions` end up with a wrapper-shaped response (`VersionListResponse`) and **no** pagination metadata. The resource emitter still references the wrapper by name, but the model emitter has already skipped the type, producing "undefined `VersionListResponse`" errors in Python, Go, and PHP.

Added a shared `collectNonPaginatedResponseModelNames(services)` helper and gated the list-wrapper skip on it in every model emitter (Python, Go, PHP, dotnet, Ruby, Kotlin, Node). Python's resource needed the same gate on its import collector so the wrapper actually gets imported.

### 2. dotnet `Error.Error` member-name collision

The spec's `Error.error` field generated `public string Error { get; set; }` inside `public class Error` — C# CS0542. Suffix the colliding property with `Value` (`ErrorValue`) and emit explicit `[JsonProperty("error")] + [STJS.JsonPropertyName("error")]` so the wire name still round-trips (`SnakeCaseLower` naming policy would otherwise serialize `ErrorValue` as `error_value`). Add the matching `using` directives whenever a model triggers the rename.

### 3. Rust `pub mod` glob ambiguity

`pub mod organization_membership;` was emitted in both `src/models/mod.rs` and `src/resources/mod.rs`. `lib.rs` does `pub use models::*; pub use resources::*;`, so both `pub mod`s ended up in the type namespace at the crate root and the compiler emitted ambiguous-glob warnings. Switched the barrels to private `mod foo;` — the companion `pub use foo::*` / `pub use foo::Struct;` lines still re-export struct contents, and external code that goes through the barrel keeps working.

## Test plan

- [x] `npm test` (54 files, 439 tests passing — incl. updated rust barrel assertions)
- [x] Regenerated each SDK against the WorkOS spec:
  - Python: `vault/models/version_list_response.py` is emitted; `vault/_resource.py` imports it.
  - Go: `models.go` contains `VersionListResponse`; `vault.go` references resolve.
  - PHP: `Resource/VersionListResponse.php` exists; `Service/Vault.php` uses it.
  - dotnet: `Error.cs` now declares `public string ErrorValue { get; set; }` with `[JsonProperty("error")]` + `[STJS.JsonPropertyName("error")]`; previous CS0542 is gone.
  - Rust: `cargo build` no longer warns on `organization_membership` ambiguous-glob. Only vault-hand-code collisions remain (tracked separately).
- [ ] CI on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)