### PR TITLE
fix(node): use toBeNull() when example is null on date-time fields

### DIFF
--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -682,7 +682,14 @@ function buildFieldAssertions(model: Model, accessor: string, modelMap?: Map<str
     const fieldAccessor = isDateTime ? `${accessor}.${domainField}.toISOString()` : `${accessor}.${domainField}`;
     // When a field has an example value, use it as the expected assertion value
     if (field.example !== undefined) {
-      if (typeof field.example === 'object' && field.example !== null) {
+      // A null example on a nullable field must assert `toBeNull()` on the
+      // raw value — calling `.toISOString()` on null throws at runtime, and
+      // `.toBe(null)` against any non-null value never matches.
+      if (field.example === null) {
+        assertions.push(`expect(${accessor}.${domainField}).toBeNull();`);
+        continue;
+      }
+      if (typeof field.example === 'object') {
         // Objects and arrays need toEqual with JSON serialization
         assertions.push(`expect(${accessor}.${domainField}).toEqual(${JSON.stringify(field.example)});`);
       } else {

--- a/test/node/tests.test.ts
+++ b/test/node/tests.test.ts
@@ -268,4 +268,73 @@ describe('node test generation ownership', () => {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it('asserts toBeNull() for nullable fields whose example is null', () => {
+    // When the spec gives `example: null` on a nullable field — common for
+    // optional date-times like `last_used_at` — the previous emitter would
+    // emit `expect(x.toISOString()).toBe(null)`, which both blows up at
+    // runtime on a null `x` and never matches when `x` is a Date.
+    const secretModel: Model = {
+      name: 'Secret',
+      fields: [
+        { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true, example: 'sec_1' },
+        {
+          name: 'last_used_at',
+          type: {
+            kind: 'nullable',
+            inner: { kind: 'primitive', type: 'string', format: 'date-time' },
+          },
+          required: true,
+          example: null,
+        },
+        {
+          name: 'created_at',
+          type: { kind: 'primitive', type: 'string', format: 'date-time' },
+          required: true,
+          example: '2026-01-15T12:00:00.000Z',
+        },
+      ],
+    };
+
+    const showOp = {
+      name: 'showSecret',
+      httpMethod: 'get' as const,
+      path: '/secrets/{id}',
+      pathParams: [{ name: 'id', type: { kind: 'primitive' as const, type: 'string' as const }, required: true }],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model' as const, name: 'Secret' },
+      errors: [],
+      injectIdempotencyKey: false,
+    };
+    const secretService: Service = { name: 'Secrets', operations: [showOp] };
+    const secretSpec: ApiSpec = {
+      ...spec,
+      models: [secretModel],
+      services: [secretService],
+    };
+    const tmpRoot = createTrackedSdkRoot();
+    try {
+      fs.mkdirSync(path.join(tmpRoot, 'src', 'secrets', 'fixtures'), { recursive: true });
+      execFileSync('git', ['add', 'src'], { cwd: tmpRoot, stdio: 'ignore' });
+
+      const result = nodeEmitter.generateTests!(secretSpec, {
+        ...ctx,
+        spec: secretSpec,
+        outputDir: tmpRoot,
+        emitterOptions: { ownedServices: ['Secrets'], regenerateOwnedTests: true },
+      } as EmitterContext);
+
+      const testFile = result.find((f) => f.path === 'src/secrets/secrets.spec.ts');
+      expect(testFile).toBeDefined();
+      const content = testFile!.content;
+      // Null example on a nullable date-time → toBeNull(), not `.toISOString().toBe(null)`.
+      expect(content).toContain('expect(result.lastUsedAt).toBeNull();');
+      expect(content).not.toContain('lastUsedAt.toISOString()).toBe(null)');
+      // Non-null date-time examples still go through `.toISOString()`.
+      expect(content).toContain("expect(result.createdAt.toISOString()).toBe('2026-01-15T12:00:00.000Z');");
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

The Node test emitter unconditionally appended `.toISOString()` to date-time field accessors and then asserted `.toBe(<exampleLiteral>)`. When the spec gave `example: null` on a nullable date-time (e.g. `last_used_at` on a connect application secret), this produced:

```ts
expect(result[0].lastUsedAt.toISOString()).toBe(null);
```

Two problems with that:

1. **Runtime:** if `lastUsedAt` is `null`, the assertion throws — `null.toISOString()` is a TypeError.
2. **TypeScript:** with the type emitter now correctly producing `Date | null`, `null.toISOString()` doesn't typecheck, and `toBe(null)` against a string never matches anyway.

The fix is a one-liner short-circuit: when the example is `null`, emit `expect(accessor).toBeNull();` and skip the date-time branch.

## Where this showed up

Generated `workos-node/src/connect/connect.spec.ts` (`listApplicationClientSecrets` and `createApplicationClientSecret` tests) — `script/ci` failed at typecheck with:

```
src/connect/connect.spec.ts(162,14): error TS2531: Object is possibly 'null'.
src/connect/connect.spec.ts(162,35): error TS2551: Property 'toISOString' does not exist on type 'string'.
```

After this PR + regen, those assertions become:

```ts
expect(result[0].lastUsedAt).toBeNull();
```

## Test plan

- [x] `npm test` — 54 files, 440 tests passing (1 new test added covering null-example on a nullable date-time)
- [x] Linked locally and regenerated workos-node — the failing `.toISOString().toBe(null)` lines became `.toBeNull()` as expected; non-null `createdAt`/`updatedAt` assertions still use `.toISOString()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)