### PR TITLE
fix(node): stop emitting duplicate Response-suffixed interfaces

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -23,6 +23,7 @@ import {
   setBaselineSerializedNames,
   setBaselineInterfaceNames,
   setAdoptedModelNames,
+  setStructurallyRenamedDomainNames,
   resolveInterfaceName,
 } from './naming.js';
 import { withNodeOperationOverrides } from './node-overrides.js';
@@ -108,6 +109,19 @@ function getSurface(ctx: EmitterContext): LiveSurface {
   // Pass an empty map; type-map will fall back to emitting the symbol name.
   setInlineEnumUnions(new Map());
   setAdoptedModelNames(computeAdoptedModelNames(ctx, surface));
+
+  // Pre-compute which domain names the resolver reaches via structural
+  // rename so `wireInterfaceName` can tell `AuditLogSchemaJson` →
+  // `AuditLogSchemaResponse` (real single-form case) apart from
+  // `CreateDataKeyResponse` → `CreateDataKeyResponse` (fresh IR model whose
+  // own name already ends in `Response`).
+  const renamed = new Set<string>();
+  for (const model of ctx.spec.models) {
+    const resolved = resolveInterfaceName(model.name, ctx);
+    if (resolved !== model.name) renamed.add(resolved);
+  }
+  setStructurallyRenamedDomainNames(renamed);
+
   return surface;
 }
 

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -517,36 +517,43 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
     }
     lines.push('');
 
-    // Wire/response interface
-    const seenWireFields = new Set<string>();
-    if (model.fields.length === 0) {
-      lines.push(`export type ${responseName}${typeParams} = object;`);
-    } else {
-      lines.push(`export interface ${responseName}${typeParams} {`);
-      for (const field of model.fields) {
-        const wireField = wireFieldName(field.name);
-        if (seenWireFields.has(wireField)) continue;
-        seenWireFields.add(wireField);
-        const baselineField = baselineResponse?.fields?.[wireField];
-        if (
-          baselineField &&
-          baselineTypeResolvable(baselineField.type, importableNames) &&
-          baselineFieldCompatible(baselineField, field)
-        ) {
-          const opt = baselineField.optional ? '?' : '';
-          lines.push(`  ${wireField}${opt}: ${baselineField.type};`);
-        } else {
-          const isNewFieldOnExistingModel = baselineResponse && !baselineField;
-          // Same baseline-optional preservation as the domain side. The
-          // wire interface's optional flag drives test-fixture shape, so
-          // flipping it on regen breaks every fixture that omitted the
-          // field assuming it was optional.
-          const baselineSaysOptional = baselineField?.optional === true;
-          const opt = baselineSaysOptional || !field.required || isNewFieldOnExistingModel ? '?' : '';
-          lines.push(`  ${wireField}${opt}: ${mapWireTypeRef(field.type, modelWireTypeRefOpts)};`);
+    // Wire/response interface — skip when the wire name collapsed onto the
+    // domain name (single-form structural-rename case, e.g. IR `Object` →
+    // `ReadObjectResponse`). Emitting the second declaration would either
+    // produce a literal duplicate `export interface ReadObjectResponse`
+    // pair or, after TypeScript's silent declaration merge, leave the
+    // call site with `import type { ReadObjectResponse, ReadObjectResponse }`.
+    if (responseName !== domainName) {
+      const seenWireFields = new Set<string>();
+      if (model.fields.length === 0) {
+        lines.push(`export type ${responseName}${typeParams} = object;`);
+      } else {
+        lines.push(`export interface ${responseName}${typeParams} {`);
+        for (const field of model.fields) {
+          const wireField = wireFieldName(field.name);
+          if (seenWireFields.has(wireField)) continue;
+          seenWireFields.add(wireField);
+          const baselineField = baselineResponse?.fields?.[wireField];
+          if (
+            baselineField &&
+            baselineTypeResolvable(baselineField.type, importableNames) &&
+            baselineFieldCompatible(baselineField, field)
+          ) {
+            const opt = baselineField.optional ? '?' : '';
+            lines.push(`  ${wireField}${opt}: ${baselineField.type};`);
+          } else {
+            const isNewFieldOnExistingModel = baselineResponse && !baselineField;
+            // Same baseline-optional preservation as the domain side. The
+            // wire interface's optional flag drives test-fixture shape, so
+            // flipping it on regen breaks every fixture that omitted the
+            // field assuming it was optional.
+            const baselineSaysOptional = baselineField?.optional === true;
+            const opt = baselineSaysOptional || !field.required || isNewFieldOnExistingModel ? '?' : '';
+            lines.push(`  ${wireField}${opt}: ${mapWireTypeRef(field.type, modelWireTypeRefOpts)};`);
+          }
         }
+        lines.push('}');
       }
-      lines.push('}');
     }
 
     // Preserve inline types from existing file

--- a/src/node/naming.ts
+++ b/src/node/naming.ts
@@ -74,6 +74,23 @@ export function isAdoptedModelName(name: string): boolean {
 }
 
 /**
+ * Domain names that `resolveInterfaceName` reached via a structural rename
+ * — the resolved name differs from the IR model's own name. `wireInterfaceName`
+ * consults this set to decide whether to fire the "single-form wire" case:
+ * that case is *only* meant for structurally-renamed models, where the
+ * baseline owns a `*Response` interface representing the wire shape with no
+ * separate `*Wire` companion. Without this signal, a freshly-emitted model
+ * whose IR name already ends in `Response` (e.g. `CreateDataKeyResponse`)
+ * would land in the same case as soon as a prior buggy regen wrote the
+ * baseline — producing two `export interface CreateDataKeyResponse { ... }`
+ * declarations in the same file.
+ */
+let structurallyRenamedDomainNames: Set<string> = new Set();
+export function setStructurallyRenamedDomainNames(names: Set<string>): void {
+  structurallyRenamedDomainNames = names;
+}
+
+/**
  * Wire/response interface name.
  *
  * Resolution order:
@@ -97,7 +114,14 @@ export function wireInterfaceName(domainName: string): string {
   if (domainName.endsWith('Response')) {
     const wireForm = `${domainName}Wire`;
     if (baselineInterfaceNames.has(wireForm)) return wireForm;
-    if (baselineInterfaceNames.has(domainName)) return domainName;
+    // Single-form case (#3 in the docstring): only fire when the resolver
+    // structurally renamed an IR model to this baseline name. Otherwise a
+    // fresh `CreateDataKeyResponse`-style IR model would collapse onto its
+    // own name as soon as one buggy regen wrote `CreateDataKeyResponse` to
+    // the baseline, perpetuating the duplicate-interface emission.
+    if (structurallyRenamedDomainNames.has(domainName) && baselineInterfaceNames.has(domainName)) {
+      return domainName;
+    }
     return wireForm;
   }
   return `${domainName}Response`;

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -698,7 +698,15 @@ function generateResourceClass(service: Service, ctx: EmitterContext): Generated
         ? `./interfaces/${fileName(name)}.interface`
         : `../${modelServiceDir}/interfaces/${fileName(name)}.interface`;
     if (usedWireTypes.has(resolved)) {
-      lines.push(`import type { ${resolved}, ${wireInterfaceName(resolved)} } from '${relPath}';`);
+      const wireName = wireInterfaceName(resolved);
+      // When the wire name collapsed onto the domain name (single-form
+      // structural-rename emission), import once — otherwise we ship
+      // `import type { ReadObjectResponse, ReadObjectResponse }`.
+      if (wireName === resolved) {
+        lines.push(`import type { ${resolved} } from '${relPath}';`);
+      } else {
+        lines.push(`import type { ${resolved}, ${wireName} } from '${relPath}';`);
+      }
     } else {
       lines.push(`import type { ${resolved} } from '${relPath}';`);
     }

--- a/test/node/naming.test.ts
+++ b/test/node/naming.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import type { EmitterContext } from '@workos/oagen';
 import { defaultSdkBehavior } from '@workos/oagen';
-import { resolveInterfaceName, setAdoptedModelNames } from '../../src/node/naming.js';
+import {
+  resolveInterfaceName,
+  setAdoptedModelNames,
+  setBaselineInterfaceNames,
+  setStructurallyRenamedDomainNames,
+  wireInterfaceName,
+} from '../../src/node/naming.js';
 
 const ctx: EmitterContext = {
   namespace: 'workos',
@@ -19,6 +25,8 @@ const ctx: EmitterContext = {
 
 afterEach(() => {
   setAdoptedModelNames(new Set());
+  setBaselineInterfaceNames(new Set());
+  setStructurallyRenamedDomainNames(new Set());
 });
 
 describe('resolveInterfaceName', () => {
@@ -73,5 +81,41 @@ describe('resolveInterfaceName', () => {
     });
 
     expect(result).toBe('CreateM2MApplication');
+  });
+});
+
+describe('wireInterfaceName', () => {
+  it('emits *Wire for a fresh `*Response`-named IR model with an empty baseline', () => {
+    expect(wireInterfaceName('CreateDataKeyResponse')).toBe('CreateDataKeyResponseWire');
+  });
+
+  it('returns *Wire even when a prior buggy regen poisoned the baseline with the bare name', () => {
+    // Reproduces the vault regression: `CreateDataKeyResponse` is its own IR
+    // name (no structural rename), so the resolver does not flag it. A prior
+    // broken emission wrote `export interface CreateDataKeyResponse { ... }`
+    // twice into the file, and the baseline now contains the bare name.
+    // Without the rename signal, `wireInterfaceName` must still pick `*Wire`
+    // — otherwise the duplicate emission perpetuates across regens.
+    setBaselineInterfaceNames(new Set(['CreateDataKeyResponse']));
+    expect(wireInterfaceName('CreateDataKeyResponse')).toBe('CreateDataKeyResponseWire');
+  });
+
+  it('uses *Wire when baseline already has a separate `*Wire` companion', () => {
+    setBaselineInterfaceNames(new Set(['DecryptResponse', 'DecryptResponseWire']));
+    expect(wireInterfaceName('DecryptResponse')).toBe('DecryptResponseWire');
+  });
+
+  it('returns the bare name when a structural rename mapped a differently-named IR model onto a baseline `*Response`', () => {
+    // The legitimate single-form case the heuristic was designed for:
+    // `AuditLogSchemaJson` → `AuditLogSchemaResponse` via structural match,
+    // and the baseline owns just the one `AuditLogSchemaResponse` interface
+    // representing the wire shape.
+    setBaselineInterfaceNames(new Set(['AuditLogSchemaResponse']));
+    setStructurallyRenamedDomainNames(new Set(['AuditLogSchemaResponse']));
+    expect(wireInterfaceName('AuditLogSchemaResponse')).toBe('AuditLogSchemaResponse');
+  });
+
+  it('falls back to `${name}Response` for non-`*Response` IR names', () => {
+    expect(wireInterfaceName('Organization')).toBe('OrganizationResponse');
   });
 });


### PR DESCRIPTION
## Summary

`wireInterfaceName` fell back to the bare domain name for any `*Response`-suffixed model that already existed in the baseline, even when the IR owned that name directly (no structural rename). The result:

```ts
// vault/interfaces/create-data-key-response.interface.ts (before)
export interface CreateDataKeyResponse {
  context: Record<string, string>;
  dataKey: string;          // camelCase domain
  encryptedKeys: string;
  ...
}
export interface CreateDataKeyResponse {  // ← same name, snake_case wire
  context: Record<string, string>;
  data_key: string;
  encrypted_keys: string;
  ...
}
```

```ts
// vault/vault.ts (before)
import type {
  CreateDataKeyResponse,
  CreateDataKeyResponse,  // ← duplicate identifier; TS2300
} from './interfaces/create-data-key-response.interface';
```

The single-form heuristic (case #3 in the `wireInterfaceName` docstring) was *intended* for structural renames where the resolver maps a differently-named IR model onto a baseline `*Response` interface (`AuditLogSchemaJson` → `AuditLogSchemaResponse`, where the baseline only has the wire shape). Without an explicit signal it also fired for fresh `*Response`-named IR models, and once one buggy regen wrote the duplicated baseline, every subsequent regen perpetuated it.

## Fix

- New `structurallyRenamedDomainNames` set in `naming.ts`, populated once per generation from the resolver's `model.name !== resolveInterfaceName(model.name)` decisions.
- `wireInterfaceName` now gates case #3 on this signal. A fresh `CreateDataKeyResponse`-named IR model gets `${name}Wire` for its wire interface; the AuditLog structural-rename case still produces the single-form name.
- The two emission sites that produced the duplicate output when the wire name *legitimately* collapses (`Object` → `ReadObjectResponse` — the IR model `Object` matched onto a baseline `ReadObjectResponse` with no `ReadObject` sibling) are deduped:
  - `models.ts` skips the second `export interface ${responseName}` declaration.
  - `resources.ts` collapses `import type { X, X }` to `import type { X }`.

## Test plan

- [x] `npm test` — 54 files, 444 tests passing (5 new in `naming.test.ts` covering all four `wireInterfaceName` branches plus the duplicate-baseline poisoning case)
- [x] Regenerated `workos-node` against the WorkOS spec — `vault/interfaces/create-data-key-response.interface.ts` now correctly emits `CreateDataKeyResponseWire` for the wire shape, and `vault/interfaces/object.interface.ts` emits a single `ReadObjectResponse` (the legitimate single-form case).
- [x] Resource consumer `vault.ts` now imports `import type { CreateDataKeyResponse, CreateDataKeyResponseWire }` and `import type { ReadObjectResponse }` (single).

🤖 Generated with [Claude Code](https://claude.com/claude-code)