### PR TITLE
fix: emit ListMetadata-shape models referenced by surviving wrappers

### DIFF
--- a/src/go/fixtures.ts
+++ b/src/go/fixtures.ts
@@ -1,6 +1,7 @@
 import type { Model, TypeRef, Enum } from '@workos/oagen';
 import { fileName, fieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
+import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
 
 /**
  * Prefix mapping for generating realistic ID fixture values.
@@ -34,9 +35,12 @@ export function generateFixtures(spec: { models: Model[]; enums: Enum[]; service
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
   const files: { path: string; content: string }[] = [];
 
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(spec.services);
+  const listMetadataNeeded = collectReferencedListMetadataModels(spec.models, nonPaginatedRefs);
+
   for (const model of spec.models) {
-    if (isListMetadataModel(model)) continue;
-    if (isListWrapperModel(model)) continue;
+    if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
 
     const fixture = model.fields.length === 0 ? {} : generateModelFixture(model, modelMap, enumMap);
 

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -9,6 +9,7 @@ import {
   isListWrapperModel,
   isListMetadataModel,
   collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
 export { isListWrapperModel, isListMetadataModel };
 
@@ -92,12 +93,17 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // code references them by name and the pagination iterator doesn't unwrap them.
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
   const skipAsListWrapper = (m: Model): boolean => isListWrapperModel(m) && !nonPaginatedRefs.has(m.name);
+  // A `ListMetadata`-shape model referenced by a surviving non-paginated
+  // wrapper (e.g. vault's `VersionListResponse`) must still be emitted —
+  // otherwise the wrapper's struct references a type that was never declared.
+  const listMetadataNeeded = collectReferencedListMetadataModels(models, nonPaginatedRefs);
+  const skipAsListMetadata = (m: Model): boolean => isListMetadataModel(m) && !listMetadataNeeded.has(m.name);
 
   // Build structural hash for deduplication
   const modelHashMap = new Map<string, string>();
   const hashGroups = new Map<string, string[]>();
   for (const model of models) {
-    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     if (requestBodyOnly.has(model.name)) continue;
     const hash = structuralHash(model);
     modelHashMap.set(model.name, hash);
@@ -121,7 +127,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
   const batchedAliases = new Set<string>();
   for (const model of models) {
-    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     if (requestBodyOnly.has(model.name)) continue;
 
     const structName = className(model.name);

--- a/src/kotlin/models.ts
+++ b/src/kotlin/models.ts
@@ -6,6 +6,7 @@ import {
   isListWrapperModel,
   isListMetadataModel,
   collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
 
 const KOTLIN_SRC_PREFIX = 'src/main/kotlin/';
@@ -67,13 +68,18 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // code references them by name and pagination iterators don't unwrap them.
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
   const skipAsListWrapper = (m: Model): boolean => isListWrapperModel(m) && !nonPaginatedRefs.has(m.name);
+  // A `ListMetadata`-shape model referenced by a surviving non-paginated
+  // wrapper (e.g. vault's `VersionListResponse`) must still emit a data class
+  // — otherwise the wrapper's class references a type that was never declared.
+  const listMetadataNeeded = collectReferencedListMetadataModels(models, nonPaginatedRefs);
+  const skipAsListMetadata = (m: Model): boolean => isListMetadataModel(m) && !listMetadataNeeded.has(m.name);
 
   // Deduplication: identical structures become typealiases.
   // Pass 1: hash without nested-alias resolution.
   modelAliasMap = null;
   const hashGroupsPass1 = new Map<string, string[]>();
   for (const model of models) {
-    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     if (model.fields.length === 0 && discriminatedUnions.has(className(model.name))) continue;
     const hash = structuralHash(model);
     if (!hashGroupsPass1.has(hash)) hashGroupsPass1.set(hash, []);
@@ -96,7 +102,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   modelAliasMap = aliasOf;
   const hashGroupsPass2 = new Map<string, string[]>();
   for (const model of models) {
-    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     if (model.fields.length === 0 && discriminatedUnions.has(className(model.name))) continue;
     if (aliasOf.has(model.name)) continue; // already aliased in pass 1
     const hash = structuralHash(model);
@@ -115,7 +121,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   }
 
   for (const model of models) {
-    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     const typeName = className(model.name);
 
     // Parent of a discriminated union: emit a sealed class.
@@ -152,7 +158,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // mapping so Jackson can deserialize directly to the correct concrete type.
   const eventMapping: Array<{ wireValue: string; modelName: string }> = [];
   for (const model of models) {
-    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     if (aliasOf.has(model.name)) continue;
     if (!isEventEnvelopeModel(model)) continue;
     const eventField = model.fields.find((f) => f.name === 'event');

--- a/src/kotlin/resources.ts
+++ b/src/kotlin/resources.ts
@@ -11,7 +11,12 @@ import type {
 } from '@workos/oagen';
 import { planOperation } from '@workos/oagen';
 import { mapTypeRef, mapTypeRefOptional, implicitImportsFor } from './type-map.js';
-import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
+import {
+  isListWrapperModel,
+  isListMetadataModel,
+  collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
+} from '../shared/model-utils.js';
 import { enumCanonicalMap } from './enums.js';
 import {
   className,
@@ -1124,6 +1129,12 @@ function registerTypeImports(ref: TypeRef, imports: Set<string>, ctx: EmitterCon
   const mapped = mapTypeRef(ref);
   for (const imp of implicitImportsFor(mapped)) imports.add(imp);
 
+  // Match the model-emission gate: a `ListMetadata`-shape model that survives
+  // emission (because a non-paginated wrapper still references it) needs its
+  // import here too.
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+  const listMetadataNeeded = collectReferencedListMetadataModels(ctx.spec.models, nonPaginatedRefs);
+
   walk(ref, (r) => {
     if (r.kind === 'enum') {
       // When an enum is aliased, import the canonical class instead of the alias.
@@ -1132,7 +1143,11 @@ function registerTypeImports(ref: TypeRef, imports: Set<string>, ctx: EmitterCon
     }
     if (r.kind === 'model') {
       const referenced = ctx.spec.models.find((m) => m.name === r.name);
-      if (referenced && (isListWrapperModel(referenced) || isListMetadataModel(referenced))) return;
+      if (referenced) {
+        const skipWrapper = isListWrapperModel(referenced) && !nonPaginatedRefs.has(referenced.name);
+        const skipMetadata = isListMetadataModel(referenced) && !listMetadataNeeded.has(referenced.name);
+        if (skipWrapper || skipMetadata) return;
+      }
       imports.add(`com.workos.models.${className(r.name)}`);
     }
   });

--- a/src/node/fixtures.ts
+++ b/src/node/fixtures.ts
@@ -1,7 +1,14 @@
 import type { Model, TypeRef, Enum, EmitterContext } from '@workos/oagen';
 import { wireFieldName, fileName, resolveServiceDir } from './naming.js';
 import { resolveResourceClassName, resolveResourceDir } from './resources.js';
-import { createServiceDirResolver, assignModelsToServices, isListMetadataModel, isListWrapperModel } from './utils.js';
+import {
+  createServiceDirResolver,
+  assignModelsToServices,
+  isListMetadataModel,
+  isListWrapperModel,
+  collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
+} from './utils.js';
 
 export const ID_PREFIXES: Record<string, string> = {
   Connection: 'conn_',
@@ -75,11 +82,14 @@ export function generateFixtures(
     }
   }
 
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(spec.services);
+  const listMetadataNeeded = collectReferencedListMetadataModels(spec.models, nonPaginatedRefs);
+
   const seenFixturePaths = new Set<string>();
   for (const model of spec.models) {
     if (!fixtureReachable.has(model.name)) continue;
-    if (isListMetadataModel(model)) continue;
-    if (isListWrapperModel(model)) continue;
+    if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
 
     const service = modelToService.get(model.name);
     const dirName = resolveDir(service);

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -24,6 +24,7 @@ import {
   isListMetadataModel,
   isListWrapperModel,
   collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
   buildDeduplicationMap,
   relativeImport,
   modelHasNewFields,
@@ -214,11 +215,19 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
   // for `GET /vault/v1/kv/{id}/versions`) must still be emitted — the resource
   // code references them by name and pagination iterators don't unwrap them.
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+
+  // ListMetadata-shape models are usually subsumed by the SDK's shared
+  // pagination wrapper, so we blanket-skip them. But a non-paginated
+  // wrapper like vault's `VersionListResponse` keeps the reference live
+  // (`list_metadata: ListMetadata`), and skipping the emission leaves the
+  // wrapper's interface importing from a file that was never written.
+  const listMetadataNeeded = collectReferencedListMetadataModels(models, nonPaginatedRefs);
+
   for (const originalModel of models) {
     const model = projectedByName.get(originalModel.name) ?? originalModel;
     if (!reachableModels.has(model.name)) continue;
     if (interfaceEligibleModels && !interfaceEligibleModels.has(model.name)) continue;
-    if (isListMetadataModel(model)) continue;
+    if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
     if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     if (discriminatedSkip?.has(model.name)) continue;
     const service = modelToService.get(model.name);
@@ -739,12 +748,16 @@ export function generateSerializers(
 
   const discriminatedSerializerSkip = (ctx as { _discriminatedModelNames?: Set<string> })._discriminatedModelNames;
   const serializerNonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+
+  // Mirror the interface-emission gate (see `generateModels`).
+  const serializerListMetadataNeeded = collectReferencedListMetadataModels(models, serializerNonPaginatedRefs);
+
   const eligibleModels: Model[] = [];
   for (const originalModel of models) {
     const model = projectedByName.get(originalModel.name) ?? originalModel;
     if (!serializerReachable.has(model.name)) continue;
     if (serializerEligibleModels && !serializerEligibleModels.has(model.name)) continue;
-    if (isListMetadataModel(model)) continue;
+    if (isListMetadataModel(model) && !serializerListMetadataNeeded.has(model.name)) continue;
     if (isListWrapperModel(model) && !serializerNonPaginatedRefs.has(model.name)) continue;
     if (discriminatedSerializerSkip?.has(model.name)) continue;
     const service = modelToService.get(model.name);

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -281,6 +281,7 @@ export {
   isListMetadataModel,
   isListWrapperModel,
   collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
 
 function modelFingerprint(model: Model): string {

--- a/src/python/fixtures.ts
+++ b/src/python/fixtures.ts
@@ -2,6 +2,7 @@ import type { Model, TypeRef, Enum } from '@workos/oagen';
 
 import { fileName, fieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
+import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
 
 /**
  * Prefix mapping for generating realistic ID fixture values.
@@ -36,9 +37,12 @@ export function generateFixtures(spec: {
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
   const files: { path: string; content: string }[] = [];
 
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(spec.services);
+  const listMetadataNeeded = collectReferencedListMetadataModels(spec.models, nonPaginatedRefs);
+
   for (const model of spec.models) {
-    if (isListMetadataModel(model)) continue;
-    if (isListWrapperModel(model)) continue;
+    if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     // Skip models with no fields — these are typically discriminated unions
     // with hand-maintained @oagen-ignore overrides; generated empty fixtures
     // would not match the override's required fields.

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -46,12 +46,16 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // emitted — the resource code references them by name and SyncPage doesn't
   // wrap them.
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
+  // ListMetadata-shape models referenced by a surviving non-paginated wrapper
+  // (e.g. vault's `VersionListResponse`) must still emit a dataclass —
+  // otherwise the wrapper's module imports a class that was never written.
+  const listMetadataNeeded = collectReferencedListMetadataModels(models, nonPaginatedRefs);
 
   for (const model of models) {
     // Skip list wrapper models (e.g., OrganizationList) — SyncPage handles envelopes
     if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     // Skip all list metadata models (e.g., ListMetadata, FooListListMetadata)
-    if (isListMetadataModel(model)) continue;
+    if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
 
     const service = modelToService.get(model.name);
     const dirName = resolveDir(service);
@@ -875,5 +879,6 @@ import {
   isListMetadataModel,
   isListWrapperModel,
   collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
 export { isListMetadataModel, isListWrapperModel };

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -22,6 +22,7 @@ import { resolveResourceClassName, bodyParamName } from './resources.js';
 import { buildServiceAccessPaths } from './client.js';
 import { generateFixtures, generateModelFixture } from './fixtures.js';
 import { isListWrapperModel, isListMetadataModel } from './models.js';
+import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
 import {
   groupByMount,
   buildResolvedLookup,
@@ -1396,8 +1397,13 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
   // A model is request-only if it's used as a request body but never as a response
   for (const name of responseModelNames) requestOnlyModelNames.delete(name);
 
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(spec.services);
+  const listMetadataNeeded = collectReferencedListMetadataModels(spec.models, nonPaginatedRefs);
   const models = spec.models.filter(
-    (m) => !isListWrapperModel(m) && !isListMetadataModel(m) && !requestOnlyModelNames.has(m.name),
+    (m) =>
+      !(isListWrapperModel(m) && !nonPaginatedRefs.has(m.name)) &&
+      !(isListMetadataModel(m) && !listMetadataNeeded.has(m.name)) &&
+      !requestOnlyModelNames.has(m.name),
   );
   if (models.length === 0) return null;
 

--- a/src/ruby/parameter-groups.ts
+++ b/src/ruby/parameter-groups.ts
@@ -29,8 +29,10 @@ function mapSorbetType(ref: TypeRef): string {
       return `WorkOS::${className(ref.name)}`;
     case 'enum':
       return 'String';
-    case 'nullable':
-      return `T.nilable(${mapSorbetType(ref.inner)})`;
+    case 'nullable': {
+      const inner = mapSorbetType(ref.inner);
+      return inner === 'T.untyped' ? inner : `T.nilable(${inner})`;
+    }
     case 'literal':
       if (typeof ref.value === 'string') return 'String';
       if (ref.value === null) return 'NilClass';

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -316,6 +316,7 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
 
 /** Unwrap T.nilable(...) if already wrapped, to avoid double-wrapping. */
 function unwrapNilable(type: string): string {
+  if (type === 'T.untyped') return type;
   const match = type.match(/^T\.nilable\((.+)\)$/);
   return match ? match[1] : type;
 }

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -1,5 +1,5 @@
 import type { Model, Field, TypeRef, Enum, Service } from '@workos/oagen';
-import { toSnakeCase, toUpperSnakeCase, walkTypeRef } from '@workos/oagen';
+import { collectFieldDependencies, toSnakeCase, toUpperSnakeCase, walkTypeRef } from '@workos/oagen';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 // @ts-ignore -- js-yaml has no type declarations in this project
@@ -70,6 +70,41 @@ export function isListMetadataModel(model: Model): boolean {
   if (!before || !after) return false;
 
   return isNullableString(before) && isNullableString(after);
+}
+
+/**
+ * Compute the `ListMetadata`-shape model names that must still be emitted
+ * because some surviving wrapper references them.
+ *
+ * Each language emitter blanket-skips `isListMetadataModel` models on the
+ * assumption that the SDK's shared pagination wrapper subsumes them. That
+ * is correct for paginated list envelopes (the iterator unwraps the
+ * envelope and `list_metadata` is handled at runtime), but a *non-paginated*
+ * wrapper like vault's `VersionListResponse` still has a
+ * `list_metadata: ListMetadata` field — and skipping emission of
+ * `ListMetadata` leaves the wrapper's interface importing from a file that
+ * was never written.
+ *
+ * Pass the same `nonPaginatedRefs` set the emitter uses for its own
+ * wrapper-survival decision so the two answers stay in sync.
+ */
+export function collectReferencedListMetadataModels(models: Model[], nonPaginatedRefs: Set<string>): Set<string> {
+  const listMetadataNames = new Set<string>();
+  for (const m of models) {
+    if (isListMetadataModel(m)) listMetadataNames.add(m.name);
+  }
+  if (listMetadataNames.size === 0) return new Set();
+
+  const referenced = new Set<string>();
+  for (const model of models) {
+    if (isListMetadataModel(model)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
+    const deps = collectFieldDependencies(model);
+    for (const dep of deps.models) {
+      if (listMetadataNames.has(dep)) referenced.add(dep);
+    }
+  }
+  return referenced;
 }
 
 /** Check if a field type is nullable string (nullable<string> or just string). */

--- a/test/shared/model-utils.test.ts
+++ b/test/shared/model-utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { Model } from '@workos/oagen';
+import {
+  collectReferencedListMetadataModels,
+  isListMetadataModel,
+  isListWrapperModel,
+} from '../../src/shared/model-utils.js';
+
+const listMetadataModel: Model = {
+  name: 'ListMetadata',
+  fields: [
+    {
+      name: 'before',
+      type: { kind: 'nullable', inner: { kind: 'primitive', type: 'string' } },
+      required: false,
+    },
+    {
+      name: 'after',
+      type: { kind: 'nullable', inner: { kind: 'primitive', type: 'string' } },
+      required: false,
+    },
+  ],
+};
+
+describe('isListMetadataModel', () => {
+  it('matches a two-field nullable-string before/after shape', () => {
+    expect(isListMetadataModel(listMetadataModel)).toBe(true);
+  });
+});
+
+describe('collectReferencedListMetadataModels', () => {
+  it('returns nothing when no surviving wrapper references the model', () => {
+    // A paginated list wrapper that the SDK pagination machinery unwraps —
+    // not in `nonPaginatedRefs`, so it counts as skipped.
+    const paginatedWrapper: Model = {
+      name: 'OrgList',
+      fields: [
+        { name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Org' } }, required: true },
+        { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+      ],
+    };
+    const result = collectReferencedListMetadataModels([listMetadataModel, paginatedWrapper], new Set());
+    expect(result.size).toBe(0);
+  });
+
+  it('flags the ListMetadata model when a non-paginated wrapper still references it', () => {
+    // `VersionListResponse` is shaped like a list envelope but the operation
+    // has no pagination params, so it survives the wrapper skip — and its
+    // `list_metadata` field needs the `ListMetadata` interface on disk.
+    const versionWrapper: Model = {
+      name: 'VersionListResponse',
+      fields: [
+        { name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Version' } }, required: true },
+        { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+      ],
+    };
+    const result = collectReferencedListMetadataModels(
+      [listMetadataModel, versionWrapper],
+      new Set(['VersionListResponse']),
+    );
+    expect(result.has('ListMetadata')).toBe(true);
+  });
+
+  it('flags the ListMetadata model when a non-wrapper IR model references it directly', () => {
+    // Defensive: should anything else point at a `ListMetadata`-shape model
+    // as a regular field, we still need the file.
+    const customModel: Model = {
+      name: 'Custom',
+      fields: [{ name: 'meta', type: { kind: 'model', name: 'ListMetadata' }, required: true }],
+    };
+    const result = collectReferencedListMetadataModels([listMetadataModel, customModel], new Set());
+    expect(result.has('ListMetadata')).toBe(true);
+  });
+
+  it('returns an empty set when no ListMetadata-shape model exists in the IR', () => {
+    const regular: Model = {
+      name: 'Foo',
+      fields: [{ name: 'bar', type: { kind: 'primitive', type: 'string' }, required: true }],
+    };
+    const result = collectReferencedListMetadataModels([regular], new Set());
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('isListWrapperModel + isListMetadataModel — sanity', () => {
+  it('does not classify a wrapper as a metadata model', () => {
+    const wrapper: Model = {
+      name: 'OrgList',
+      fields: [
+        { name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Org' } }, required: true },
+        { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+      ],
+    };
+    expect(isListWrapperModel(wrapper)).toBe(true);
+    expect(isListMetadataModel(wrapper)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Every language emitter blanket-skipped `isListMetadataModel` models on the assumption that the SDK's shared pagination machinery subsumes them. That's correct for paginated list envelopes — the iterator unwraps the envelope and \`list_metadata\` is handled at runtime — but a **non-paginated** wrapper like vault's \`VersionListResponse\` (response of \`GET /vault/v1/kv/{id}/versions\`) still has a \`list_metadata: ListMetadata\` field. Skipping emission of \`ListMetadata\` left the wrapper's generated interface importing from a file that was never written:

```ts
// vault/interfaces/version-list-response.interface.ts (before)
import type { ListMetadata, ListMetadataResponse }
  from './list-metadata.interface';  // ← file doesn't exist
```

Same pattern in \`version-list-response.serializer.ts\` importing \`./list-metadata.serializer\`, plus the kotlin resource emitter (which also skipped importing the type from method signatures).

## Fix

Shared helper `collectReferencedListMetadataModels` in `shared/model-utils.ts` returns the set of `ListMetadata`-shape model names that at least one surviving wrapper still points at. Each emitter consults it when applying the `isListMetadataModel` skip:

```ts
if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
```

Applied at every emission gate this affects, across four languages:

- **node**: `models.ts` (interfaces + serializers), `fixtures.ts`
- **go**: `models.ts` (structural-hash + struct emission), `fixtures.ts`
- **python**: `models.ts` (dataclasses), `fixtures.ts`, `tests.ts` (round-trip test selection)
- **kotlin**: `models.ts` (data classes), `resources.ts` (method-signature imports)

The `isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)` asymmetry already existed; this PR is the matching `isListMetadataModel` half. Whenever a wrapper survives, the metadata model it points at survives too.

## Test plan

- [x] `npm test` — 55 files, 445 tests passing (6 new in `test/shared/model-utils.test.ts` covering the helper across paginated-only, non-paginated-survivor, direct-reference, and no-ListMetadata IRs)
- [x] Regenerated `workos-node` against the WorkOS spec — `vault/interfaces/list-metadata.interface.ts` and `vault/serializers/list-metadata.serializer.ts` now emit, and `version-list-response.interface.ts` resolves its `./list-metadata.interface` import cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)