### PR TITLE
fix(ruby): avoid double-wrapping T.nilable and skip T.untyped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.14.3",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.20.0"
+        "@workos/oagen": "^0.21.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.1",
         "@commitlint/config-conventional": "^21.0.1",
         "@types/node": "^25.9.1",
         "husky": "^9.1.7",
-        "oxfmt": "^0.51.0",
-        "oxlint": "^1.66.0",
+        "oxfmt": "^0.52.0",
+        "oxlint": "^1.67.0",
         "prettier": "^3.8.3",
         "tsdown": "^0.22.0",
         "tsx": "^4.22.3",
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.51.0.tgz",
-      "integrity": "sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.52.0.tgz",
+      "integrity": "sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==",
       "cpu": [
         "arm"
       ],
@@ -943,9 +943,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.51.0.tgz",
-      "integrity": "sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.52.0.tgz",
+      "integrity": "sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==",
       "cpu": [
         "arm64"
       ],
@@ -960,9 +960,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.51.0.tgz",
-      "integrity": "sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.52.0.tgz",
+      "integrity": "sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==",
       "cpu": [
         "arm64"
       ],
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.51.0.tgz",
-      "integrity": "sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.52.0.tgz",
+      "integrity": "sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==",
       "cpu": [
         "x64"
       ],
@@ -994,9 +994,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.51.0.tgz",
-      "integrity": "sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.52.0.tgz",
+      "integrity": "sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==",
       "cpu": [
         "x64"
       ],
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.51.0.tgz",
-      "integrity": "sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.52.0.tgz",
+      "integrity": "sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==",
       "cpu": [
         "arm"
       ],
@@ -1028,9 +1028,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.51.0.tgz",
-      "integrity": "sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.52.0.tgz",
+      "integrity": "sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==",
       "cpu": [
         "arm"
       ],
@@ -1045,9 +1045,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.51.0.tgz",
-      "integrity": "sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.52.0.tgz",
+      "integrity": "sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==",
       "cpu": [
         "arm64"
       ],
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.51.0.tgz",
-      "integrity": "sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.52.0.tgz",
+      "integrity": "sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==",
       "cpu": [
         "arm64"
       ],
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.51.0.tgz",
-      "integrity": "sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.52.0.tgz",
+      "integrity": "sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==",
       "cpu": [
         "ppc64"
       ],
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.51.0.tgz",
-      "integrity": "sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.52.0.tgz",
+      "integrity": "sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==",
       "cpu": [
         "riscv64"
       ],
@@ -1125,9 +1125,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.51.0.tgz",
-      "integrity": "sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.52.0.tgz",
+      "integrity": "sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==",
       "cpu": [
         "riscv64"
       ],
@@ -1145,9 +1145,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.51.0.tgz",
-      "integrity": "sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.52.0.tgz",
+      "integrity": "sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==",
       "cpu": [
         "s390x"
       ],
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.51.0.tgz",
-      "integrity": "sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.52.0.tgz",
+      "integrity": "sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==",
       "cpu": [
         "x64"
       ],
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.51.0.tgz",
-      "integrity": "sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.52.0.tgz",
+      "integrity": "sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==",
       "cpu": [
         "x64"
       ],
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.51.0.tgz",
-      "integrity": "sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.52.0.tgz",
+      "integrity": "sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==",
       "cpu": [
         "arm64"
       ],
@@ -1222,9 +1222,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.51.0.tgz",
-      "integrity": "sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.52.0.tgz",
+      "integrity": "sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==",
       "cpu": [
         "arm64"
       ],
@@ -1239,9 +1239,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.51.0.tgz",
-      "integrity": "sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.52.0.tgz",
+      "integrity": "sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==",
       "cpu": [
         "ia32"
       ],
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.51.0.tgz",
-      "integrity": "sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.52.0.tgz",
+      "integrity": "sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==",
       "cpu": [
         "x64"
       ],
@@ -1273,9 +1273,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.66.0.tgz",
-      "integrity": "sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
+      "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
       "cpu": [
         "arm"
       ],
@@ -1290,9 +1290,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.66.0.tgz",
-      "integrity": "sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
+      "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
       "cpu": [
         "arm64"
       ],
@@ -1307,9 +1307,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.66.0.tgz",
-      "integrity": "sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
+      "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
       "cpu": [
         "arm64"
       ],
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.66.0.tgz",
-      "integrity": "sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
+      "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
       "cpu": [
         "x64"
       ],
@@ -1341,9 +1341,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.66.0.tgz",
-      "integrity": "sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
+      "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
       "cpu": [
         "x64"
       ],
@@ -1358,9 +1358,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.66.0.tgz",
-      "integrity": "sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
+      "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
       "cpu": [
         "arm"
       ],
@@ -1375,9 +1375,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.66.0.tgz",
-      "integrity": "sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
+      "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
       "cpu": [
         "arm"
       ],
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.66.0.tgz",
-      "integrity": "sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
+      "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
       "cpu": [
         "arm64"
       ],
@@ -1412,9 +1412,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.66.0.tgz",
-      "integrity": "sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
+      "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
       "cpu": [
         "arm64"
       ],
@@ -1432,9 +1432,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.66.0.tgz",
-      "integrity": "sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
+      "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
       "cpu": [
         "ppc64"
       ],
@@ -1452,9 +1452,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.66.0.tgz",
-      "integrity": "sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
+      "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1472,9 +1472,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.66.0.tgz",
-      "integrity": "sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
+      "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
       "cpu": [
         "riscv64"
       ],
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.66.0.tgz",
-      "integrity": "sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
+      "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
       "cpu": [
         "s390x"
       ],
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.66.0.tgz",
-      "integrity": "sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
+      "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
       "cpu": [
         "x64"
       ],
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.66.0.tgz",
-      "integrity": "sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
+      "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
       "cpu": [
         "x64"
       ],
@@ -1552,9 +1552,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.66.0.tgz",
-      "integrity": "sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
+      "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
       "cpu": [
         "arm64"
       ],
@@ -1569,9 +1569,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.66.0.tgz",
-      "integrity": "sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
+      "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
       "cpu": [
         "arm64"
       ],
@@ -1586,9 +1586,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.66.0.tgz",
-      "integrity": "sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
+      "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
       "cpu": [
         "ia32"
       ],
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.66.0.tgz",
-      "integrity": "sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
+      "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
       "cpu": [
         "x64"
       ],
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.20.0.tgz",
-      "integrity": "sha512-9MuG/yKRngmowJnfi5X3lpZ6XCN5L+lud5815ugafHVLs08+LnC4CJM+exzm10Kd4ZtBhI7QrBJzBvAELSpgMw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.21.0.tgz",
+      "integrity": "sha512-1ZtYqeniCDbTDKzWu3hq207NCSftKfTgGF6LDIHu8Fl6ns6hziDqY++hbYek3I04blrzsLxB2C1cg/dLkubdBA==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",
@@ -3547,9 +3547,9 @@
       "license": "MIT"
     },
     "node_modules/oxfmt": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.51.0.tgz",
-      "integrity": "sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.52.0.tgz",
+      "integrity": "sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3565,39 +3565,43 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.51.0",
-        "@oxfmt/binding-android-arm64": "0.51.0",
-        "@oxfmt/binding-darwin-arm64": "0.51.0",
-        "@oxfmt/binding-darwin-x64": "0.51.0",
-        "@oxfmt/binding-freebsd-x64": "0.51.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.51.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.51.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.51.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.51.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.51.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.51.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.51.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.51.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.51.0",
-        "@oxfmt/binding-linux-x64-musl": "0.51.0",
-        "@oxfmt/binding-openharmony-arm64": "0.51.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.51.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.51.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.51.0"
+        "@oxfmt/binding-android-arm-eabi": "0.52.0",
+        "@oxfmt/binding-android-arm64": "0.52.0",
+        "@oxfmt/binding-darwin-arm64": "0.52.0",
+        "@oxfmt/binding-darwin-x64": "0.52.0",
+        "@oxfmt/binding-freebsd-x64": "0.52.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.52.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.52.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.52.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.52.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.52.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.52.0",
+        "@oxfmt/binding-linux-x64-musl": "0.52.0",
+        "@oxfmt/binding-openharmony-arm64": "0.52.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.52.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.52.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.52.0"
       },
       "peerDependencies": {
-        "svelte": "^5.0.0"
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
       },
       "peerDependenciesMeta": {
         "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
           "optional": true
         }
       }
     },
     "node_modules/oxlint": {
-      "version": "1.66.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.66.0.tgz",
-      "integrity": "sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
+      "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3610,31 +3614,35 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.66.0",
-        "@oxlint/binding-android-arm64": "1.66.0",
-        "@oxlint/binding-darwin-arm64": "1.66.0",
-        "@oxlint/binding-darwin-x64": "1.66.0",
-        "@oxlint/binding-freebsd-x64": "1.66.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.66.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.66.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.66.0",
-        "@oxlint/binding-linux-arm64-musl": "1.66.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.66.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.66.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.66.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.66.0",
-        "@oxlint/binding-linux-x64-gnu": "1.66.0",
-        "@oxlint/binding-linux-x64-musl": "1.66.0",
-        "@oxlint/binding-openharmony-arm64": "1.66.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.66.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.66.0",
-        "@oxlint/binding-win32-x64-msvc": "1.66.0"
+        "@oxlint/binding-android-arm-eabi": "1.67.0",
+        "@oxlint/binding-android-arm64": "1.67.0",
+        "@oxlint/binding-darwin-arm64": "1.67.0",
+        "@oxlint/binding-darwin-x64": "1.67.0",
+        "@oxlint/binding-freebsd-x64": "1.67.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.67.0",
+        "@oxlint/binding-linux-arm64-musl": "1.67.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.67.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.67.0",
+        "@oxlint/binding-linux-x64-gnu": "1.67.0",
+        "@oxlint/binding-linux-x64-musl": "1.67.0",
+        "@oxlint/binding-openharmony-arm64": "1.67.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.67.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.67.0",
+        "@oxlint/binding-win32-x64-msvc": "1.67.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.22.1"
+        "oxlint-tsgolint": ">=0.22.1",
+        "vite-plus": "*"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@commitlint/config-conventional": "^21.0.1",
     "@types/node": "^25.9.1",
     "husky": "^9.1.7",
-    "oxfmt": "^0.51.0",
-    "oxlint": "^1.66.0",
+    "oxfmt": "^0.52.0",
+    "oxlint": "^1.67.0",
     "prettier": "^3.8.3",
     "tsdown": "^0.22.0",
     "tsx": "^4.22.3",
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.20.0"
+    "@workos/oagen": "^0.21.0"
   }
 }

--- a/src/node/discriminated-models.ts
+++ b/src/node/discriminated-models.ts
@@ -124,14 +124,14 @@ export function detectDiscriminatedShape(
       return {
         nameSuffix: variantNameSuffix(discValue),
         discriminatorValue: discValue,
-        fields: variantFields(fv, discProp, modelName, rawSchemas),
+        fields: variantFields(fv, discProp, modelName),
       };
     })
     .filter((v): v is VariantSpec => v !== null);
 
   if (variants.length !== flattenedVariants.length) return null;
 
-  const baseFields = baseObject ? collectObjectFields(baseObject, modelName, rawSchemas) : [];
+  const baseFields = baseObject ? collectObjectFields(baseObject, modelName) : [];
 
   return {
     modelName,
@@ -146,7 +146,7 @@ function mergeBase(prev: RawSchema | null, next: RawSchema): RawSchema {
   if (!prev) return next;
   return {
     type: 'object',
-    properties: { ...(prev.properties ?? {}), ...(next.properties ?? {}) },
+    properties: { ...prev.properties, ...next.properties },
     required: [...new Set([...(prev.required ?? []), ...(next.required ?? [])])],
   };
 }
@@ -328,48 +328,33 @@ function variantNameSuffix(constValue: string): string {
 // Field extraction
 // ---------------------------------------------------------------------------
 
-function collectObjectFields(
-  schema: RawSchema,
-  parentName: string,
-  rawSchemas: Record<string, RawSchema>,
-): FieldSpec[] {
+function collectObjectFields(schema: RawSchema, parentName: string): FieldSpec[] {
   const props = schema.properties ?? {};
   const required = new Set(schema.required ?? []);
   const fields: FieldSpec[] = [];
   for (const [name, propSchema] of Object.entries(props)) {
-    fields.push(buildField(name, propSchema, required.has(name), parentName, rawSchemas));
+    fields.push(buildField(name, propSchema, required.has(name), parentName));
   }
   return fields;
 }
 
-function variantFields(
-  fv: FlattenedVariant,
-  discriminatorProperty: string,
-  parentName: string,
-  rawSchemas: Record<string, RawSchema>,
-): FieldSpec[] {
+function variantFields(fv: FlattenedVariant, discriminatorProperty: string, parentName: string): FieldSpec[] {
   const fields: FieldSpec[] = [];
   for (const [name, propSchema] of fv.alwaysProperties) {
     if (name === discriminatorProperty) continue;
-    fields.push(buildField(name, propSchema, fv.required.has(name), parentName, rawSchemas));
+    fields.push(buildField(name, propSchema, fv.required.has(name), parentName));
   }
   for (const [name, propSchema] of fv.optionalProperties) {
     if (name === discriminatorProperty) continue;
-    fields.push(buildField(name, propSchema, false, parentName, rawSchemas));
+    fields.push(buildField(name, propSchema, false, parentName));
   }
   return fields;
 }
 
-function buildField(
-  rawName: string,
-  schema: RawSchema,
-  required: boolean,
-  parentName: string,
-  rawSchemas: Record<string, RawSchema>,
-): FieldSpec {
+function buildField(rawName: string, schema: RawSchema, required: boolean, parentName: string): FieldSpec {
   const modelDeps = new Set<string>();
-  const domainType = rawSchemaToTS(schema, parentName, rawName, false, modelDeps, rawSchemas);
-  const wireType = rawSchemaToTS(schema, parentName, rawName, true, modelDeps, rawSchemas);
+  const domainType = rawSchemaToTS(schema, parentName, rawName, false, modelDeps);
+  const wireType = rawSchemaToTS(schema, parentName, rawName, true, modelDeps);
   return {
     name: rawName,
     description: schema.description,
@@ -404,7 +389,6 @@ function rawSchemaToTS(
   fieldName: string,
   isWire: boolean,
   modelDeps: Set<string>,
-  rawSchemas: Record<string, RawSchema>,
 ): string {
   if (schema.$ref) {
     const refName = schema.$ref.split('/').pop()!;
@@ -428,7 +412,7 @@ function rawSchemaToTS(
   } else if (baseType === 'boolean') {
     core = 'boolean';
   } else if (baseType === 'array' && schema.items) {
-    const items = rawSchemaToTS(schema.items, parentName, singularize(fieldName), isWire, modelDeps, rawSchemas);
+    const items = rawSchemaToTS(schema.items, parentName, singularize(fieldName), isWire, modelDeps);
     core = `${parenthesizeUnion(items)}[]`;
   } else if (baseType === 'object' && schema.properties) {
     // Inline object — refer to the synthetic model name that

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -49,7 +49,7 @@ function mapSorbetType(ref: TypeRef): string {
       if (unique.length === 1) return unique[0];
       return `T.any(${unique.join(', ')})`;
     },
-    nullable: (_ref, inner) => `T.nilable(${inner})`,
+    nullable: (_ref, inner) => wrapNilable(inner),
     literal: (r) =>
       typeof r.value === 'string'
         ? 'String'
@@ -95,7 +95,7 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
       const fname = fieldName(f.name);
       if (seenFieldNames.has(fname)) continue;
       seenFieldNames.add(fname);
-      const sorbetType = f.required ? mapSorbetType(f.type) : `T.nilable(${unwrapNilable(mapSorbetType(f.type))})`;
+      const sorbetType = f.required ? mapSorbetType(f.type) : wrapNilable(mapSorbetType(f.type));
       lines.push(`    sig { returns(${sorbetType}) }`);
       lines.push(`    def ${fname}; end`);
       lines.push('');
@@ -238,7 +238,7 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
         const n = fieldName(f.name);
         if (seen.has(n)) continue;
         seen.add(n);
-        sigParams.push(`${n}: T.nilable(${unwrapNilable(mapSorbetType(f.type))})`);
+        sigParams.push(`${n}: ${wrapNilable(mapSorbetType(f.type))}`);
       }
       for (const q of queryParams) {
         if (hiddenParams.has(q.name)) continue;
@@ -246,14 +246,14 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
         const n = safeParamName(q.name);
         if (seen.has(n)) continue;
         seen.add(n);
-        sigParams.push(`${n}: T.nilable(${unwrapNilable(mapSorbetType(q.type))})`);
+        sigParams.push(`${n}: ${wrapNilable(mapSorbetType(q.type))}`);
       }
       for (const group of parameterGroups) {
         if (!group.optional) continue;
         const n = fieldName(group.name);
         if (seen.has(n)) continue;
         seen.add(n);
-        sigParams.push(`${n}: T.nilable(${groupSorbetType(group)})`);
+        sigParams.push(`${n}: ${wrapNilable(groupSorbetType(group))}`);
       }
       sigParams.push('request_options: T::Hash[Symbol, T.untyped]');
 
@@ -321,6 +321,12 @@ function unwrapNilable(type: string): string {
   return match ? match[1] : type;
 }
 
+/** Wrap a type in T.nilable(), skipping T.untyped (which already includes nil) and avoiding double-wrapping. */
+function wrapNilable(type: string): string {
+  if (type === 'T.untyped') return type;
+  return `T.nilable(${unwrapNilable(type)})`;
+}
+
 /** Map a response TypeRef to a Sorbet return type. */
 function mapSorbetReturnType(ref: TypeRef, listWrapperModels: Map<string, Model>, modelNames: Set<string>): string {
   if (ref.kind === 'model' && listWrapperModels.has(ref.name)) {
@@ -333,7 +339,7 @@ function mapSorbetReturnType(ref: TypeRef, listWrapperModels: Map<string, Model>
     return `T::Array[WorkOS::${className(ref.items.name)}]`;
   }
   if (ref.kind === 'nullable') {
-    return `T.nilable(${mapSorbetReturnType(ref.inner, listWrapperModels, modelNames)})`;
+    return wrapNilable(mapSorbetReturnType(ref.inner, listWrapperModels, modelNames));
   }
   if (ref.kind === 'primitive' && ref.type === 'unknown') {
     return 'NilClass';


### PR DESCRIPTION
## Summary
- **Ruby RBI emitter**: prevent double-wrapping `T.nilable()` on
  optional fields whose mapped type is already nilable, and skip
  wrapping `T.untyped` (which inherently includes nil). A single
  `wrapNilable()` helper handles both cases consistently across
  model attrs, method params, and return types.
- **Node emitter**: remove unnecessary empty-object fallbacks in
  discriminated-model spreads and drop the unused `rawSchemas`
  parameter that was only threaded through recursive calls.
- **Deps**: routine dependency update.

## Test plan
- [ ] Regenerate Ruby SDK against real spec and verify no
      double-wrapped `T.nilable(T.nilable(...))` or
      `T.nilable(T.untyped)` in generated `.rbi` files
- [ ] Run `script/ci` in workos-ruby
- [ ] Run `script/ci` in workos-node
- [ ] Confirm no diff regressions in other emitters