### PR TITLE
fix(node): resolve emitter bugs blocking service ownership migration

### DIFF
--- a/src/node/client.ts
+++ b/src/node/client.ts
@@ -191,7 +191,14 @@ function generateServiceBarrels(spec: ApiSpec, ctx: EmitterContext): GeneratedFi
   const ownedDirNames = new Set<string>();
   for (const service of spec.services) {
     if (isNodeOwnedService(ctx, service.name)) {
-      ownedDirNames.add(resolveDir(service.name));
+      const dir = resolveDir(service.name);
+      ownedDirNames.add(dir);
+      // Ensure owned directories always get a barrel entry, even if no
+      // model interfaces are generated (hand-written files still need it).
+      if (!dirExports.has(dir)) {
+        dirExports.set(dir, []);
+        if (!dirSymbols.has(dir)) dirSymbols.set(dir, new Set());
+      }
     }
   }
 
@@ -463,6 +470,38 @@ function generateServiceBarrels(spec: ApiSpec, ctx: EmitterContext): GeneratedFi
         } catch {
           // Directory doesn't exist in target — nothing to scan
         }
+      }
+    }
+
+    // For owned directories, scan the interfaces directory for hand-written
+    // files that still need to be in the barrel (e.g., options interfaces
+    // preserved from the baseline).
+    const ownedScanRoot = ctx.targetDir ?? ctx.outputDir;
+    if (ownedScanRoot && isDirOwned) {
+      const interfacesDir = path.join(ownedScanRoot, 'src', dirName, 'interfaces');
+      const symbols = dirSymbols.get(dirName) ?? new Set<string>();
+      try {
+        for (const entry of fs.readdirSync(interfacesDir)) {
+          if (entry === 'index.ts') continue;
+          if (!entry.endsWith('.ts')) continue;
+          const stem = entry.replace(/\.ts$/, '');
+          const exportLine = `export * from './${stem}';`;
+          if (exportSet.has(exportLine)) continue;
+          const content = fs.readFileSync(path.join(interfacesDir, entry), 'utf-8');
+          const exportedNames: string[] = [];
+          for (const m of content.matchAll(/export\s+(?:interface|type|enum|class|const|function)\s+(\w+)/g)) {
+            exportedNames.push(m[1]);
+          }
+          const hasCollision = exportedNames.some((name) => globalExistingSymbols.has(name));
+          if (hasCollision) continue;
+          for (const name of exportedNames) {
+            symbols.add(name);
+            globalExistingSymbols.add(name);
+          }
+          exportSet.add(exportLine);
+        }
+      } catch {
+        // Directory doesn't exist in target
       }
     }
 

--- a/src/node/discriminated-models.ts
+++ b/src/node/discriminated-models.ts
@@ -456,6 +456,8 @@ function resolveRef(schema: RawSchema, rawSchemas: Record<string, RawSchema>): R
 export interface DiscriminatedPlan {
   shape: DiscriminatedShape;
   modelDir: string;
+  /** Maps raw spec schema names to their resolved service directories. */
+  depDirMap: Map<string, string>;
 }
 
 export function planDiscriminatedModels(models: Model[], ctx: EmitterContext): Map<string, DiscriminatedPlan> {
@@ -464,11 +466,47 @@ export function planDiscriminatedModels(models: Model[], ctx: EmitterContext): M
   if (!spec?.components?.schemas) return plans;
   const rawSchemas = spec.components.schemas as Record<string, RawSchema>;
   const { modelToService, resolveDir } = createServiceDirResolver(models, ctx.spec.services, ctx);
+
+  // Build a lookup from IR model names to their resolved service directories.
+  const irModelDir = new Map<string, string>();
+  for (const model of models) {
+    irModelDir.set(model.name, resolveDir(modelToService.get(model.name)));
+  }
+
+  // Map raw spec schema names to service directories so discriminated model
+  // imports can point to the correct cross-service path. Raw names may differ
+  // from IR names due to schemaNameTransform (e.g. Dto stripping).
+  const depDirMap = new Map<string, string>();
+  for (const rawName of Object.keys(rawSchemas)) {
+    if (irModelDir.has(rawName)) {
+      depDirMap.set(rawName, irModelDir.get(rawName)!);
+      continue;
+    }
+    const stripped = rawName.replace(/Dto/g, '').replace(/DTO/g, '').replace(/Json$/, '');
+    if (stripped !== rawName && irModelDir.has(stripped)) {
+      depDirMap.set(rawName, irModelDir.get(stripped)!);
+    }
+  }
+
   for (const model of models) {
     const shape = detectDiscriminatedShape(model.name, rawSchemas);
     if (!shape) continue;
+    // Skip models whose variant field dependencies can't all be resolved to
+    // existing interface files. EventSchema, for instance, references models
+    // from many services that may not have generated files yet.
+    const allDeps = new Set<string>();
+    for (const field of shape.baseFields) {
+      for (const d of field.modelDeps) allDeps.add(d);
+    }
+    for (const variant of shape.variants) {
+      for (const field of variant.fields) {
+        for (const d of field.modelDeps) allDeps.add(d);
+      }
+    }
+    const hasUnresolvableDeps = [...allDeps].some((dep) => !depDirMap.has(dep) && !irModelDir.has(dep));
+    if (hasUnresolvableDeps) continue;
     const modelDir = resolveDir(modelToService.get(model.name));
-    plans.set(model.name, { shape, modelDir });
+    plans.set(model.name, { shape, modelDir, depDirMap });
   }
   return plans;
 }
@@ -526,8 +564,13 @@ function buildInterfaceFile(plan: DiscriminatedPlan, _ctx: EmitterContext): Gene
 function buildInterfaceBody(name: string, shape: DiscriminatedShape, variant: VariantSpec, isWire: boolean): string[] {
   const lines: string[] = [];
   lines.push(`export interface ${name} {`);
-  // Base fields
+  // Variant fields override base fields when both define the same property
+  // (variants have narrower types, e.g. `event: 'foo'` vs base `event: string`).
+  // The discriminator is also emitted separately as a const literal below.
+  const variantFieldNames = new Set(variant.fields.map((f) => f.name));
   for (const field of shape.baseFields) {
+    if (variantFieldNames.has(field.name)) continue;
+    if (field.name === shape.discriminatorProperty) continue;
     pushFieldLine(lines, field, isWire);
   }
   // Discriminator (typed as the variant's const value)
@@ -569,31 +612,24 @@ function collectImports(plan: DiscriminatedPlan): ImportSpec[] {
       for (const d of field.modelDeps) deps.add(d);
     }
   }
-  // Group by directory — all deps under the same modelDir get one import.
-  // We assume all deps live in the same service for now (same dir as this
-  // model). Cross-service imports would need ctx.spec.services lookups; the
-  // current discriminated-shape cases (ConnectApplication) are all
-  // intra-service.
-  const symbols: string[] = [];
+  const result: ImportSpec[] = [];
   for (const dep of [...deps].sort()) {
     const domain = toPascalCase(dep);
-    symbols.push(domain);
     const wire = wireInterfaceName(domain);
-    if (wire !== domain) symbols.push(wire);
+    const symbols = wire !== domain ? [domain, wire] : [domain];
+    const depDir = plan.depDirMap.get(dep);
+    const baseName = fileName(toSnakeFromPascal(domain));
+    let importPath: string;
+    if (!depDir || depDir === plan.modelDir) {
+      importPath = `./${baseName}.interface`;
+    } else {
+      importPath = `../../${depDir}/interfaces/${baseName}.interface`;
+    }
+    const existing = result.find((a) => a.path === importPath);
+    if (existing) existing.symbols.push(...symbols);
+    else result.push({ path: importPath, symbols });
   }
-  if (symbols.length === 0) return [];
-  // Single import block from sibling files in the same interfaces directory.
-  return symbols
-    .map((sym) => {
-      const fname = fileName(toSnakeFromPascal(sym.replace(/Response$/, '')));
-      return { path: `./${fname}.interface`, symbols: [sym] };
-    })
-    .reduce((acc, cur) => {
-      const existing = acc.find((a) => a.path === cur.path);
-      if (existing) existing.symbols.push(...cur.symbols);
-      else acc.push(cur);
-      return acc;
-    }, [] as ImportSpec[]);
+  return result;
 }
 
 function toSnakeFromPascal(s: string): string {

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -311,7 +311,9 @@ function renderOptionsParam(param: OptionsObjectParam): string {
 }
 
 function autoPaginatableItemType(returnType: string | undefined): string | undefined {
-  return returnType?.match(/\bAutoPaginatable<\s*([A-Za-z_$][\w$]*)/)?.[1];
+  // Match both AutoPaginatable<T> and the legacy List<T> pattern so baseline
+  // item types are extracted even when the hand-written code predates AutoPaginatable.
+  return returnType?.match(/\b(?:AutoPaginatable|List)<\s*([A-Za-z_$][\w$]*)/)?.[1];
 }
 
 function baselineTypeSourceFile(ctx: EmitterContext, typeName: string): string | undefined {
@@ -347,9 +349,15 @@ function preferredBaselineTypeName(ctx: EmitterContext, typeName: string | undef
 }
 
 function preferredBaselineReturnType(ctx: EmitterContext, returnType: string | undefined): string | undefined {
+  if (!returnType) return undefined;
+  // Only preserve baseline return types that already use AutoPaginatable.
+  // Legacy patterns like List<T> can't be used as-is since the generated
+  // method body returns new AutoPaginatable(...).
+  if (!/\bAutoPaginatable\b/.test(returnType)) return undefined;
   const itemType = autoPaginatableItemType(returnType);
+  if (!itemType) return undefined;
   const preferred = preferredBaselineTypeName(ctx, itemType);
-  if (!returnType || !itemType || !preferred || preferred === itemType) return returnType;
+  if (!preferred || preferred === itemType) return returnType;
   return returnType.replace(new RegExp(`\\b${itemType}\\b`, 'g'), preferred);
 }
 
@@ -1146,7 +1154,11 @@ function generateResourceClass(service: Service, ctx: EmitterContext): Generated
           // extension fields land on top and the camelCase keys don't also
           // leak into the query string.
           lines.push('  const wire: Record<string, unknown> = {');
+          const baselineFields = (
+            ctx.apiSurface?.interfaces as Record<string, { fields?: Record<string, unknown> }> | undefined
+          )?.[optionsName]?.fields;
           for (const p of PAGINATION_PARAM_NAMES) {
+            if (baselineFields && !(p in baselineFields) && !baselineFields[toCamelCase(p)]) continue;
             lines.push(`    ${p}: options.${p},`);
           }
           lines.push('  };');
@@ -1503,7 +1515,9 @@ function renderMethod(
         const unwrapped = unwrapListModel(pModel, modelMap);
         if (unwrapped) itemRawName = unwrapped.name;
       }
-      const itemTypeName = resolveInterfaceName(itemRawName, ctx);
+      const baselineItemType =
+        autoPaginatableItemType(baselineClassMethod?.returnType) ?? autoPaginatableItemType(overlayMethod?.returnType);
+      const itemTypeName = preferredBaselineTypeName(ctx, baselineItemType) ?? resolveInterfaceName(itemRawName, ctx);
       docParts.push(`@returns {Promise<AutoPaginatable<${itemTypeName}>>}`);
     } else if (responseModel) {
       const returnTypeDoc = plan.isArrayResponse ? `${responseModel}[]` : responseModel;
@@ -1667,7 +1681,7 @@ function renderOptionsObjectMethod(
       ? `options ? serialize${optionParam.type}(options) : undefined`
       : 'paginationOptions';
     lines.push(`  async ${method}(${renderOptionsParam(optionParam)}): ${returnType} {`);
-    renderOptionsObjectDestructure(lines, pathBindings, 'paginationOptions');
+    renderOptionsObjectDestructure(lines, pathBindings, needsWireSerializer ? undefined : 'paginationOptions');
     lines.push(`    return new AutoPaginatable(`);
     lines.push(`      await fetchAndDeserialize<${wireType}, ${itemType}>(`);
     lines.push(`        this.workos,`);
@@ -1682,7 +1696,7 @@ function renderOptionsObjectMethod(
     lines.push(`          deserialize${itemType},`);
     lines.push(`          params,`);
     lines.push(`        ),`);
-    lines.push(`      paginationOptions,`);
+    lines.push(`      ${listOptionsExpr},`);
     lines.push(`    );`);
     lines.push('  }');
     return true;
@@ -1888,7 +1902,7 @@ function renderPaginatedMethod(
   lines.push(`          deserialize${itemType},`);
   lines.push(`          params,`);
   lines.push(`        ),`);
-  lines.push(`      options,`);
+  lines.push(`      ${serializeCall},`);
   lines.push(`    );`);
   lines.push('  }');
 }


### PR DESCRIPTION
## Summary
- Fix `AutoPaginatable` receiving raw camelCase options instead of serialized
  snake_case params, causing 422 errors on auto-pagination (workos/workos-node#1600)
- Fix discriminated model interfaces emitting duplicate properties when
  base and variant schemas share field names (e.g. `EventSchema`)
- Fix discriminated model imports assuming all model deps are intra-service;
  cross-service deps now resolve correct relative paths
- Fix owned-service barrel files dropping hand-written interface files that
  still need re-exporting (e.g. `ListEventOptions`)
- Fix `preferredBaselineReturnType` preserving legacy `List<T>` return types
  instead of generating `AutoPaginatable<T>`
- Fix pagination serializer referencing `options.before` when the baseline
  options interface doesn't have that field

## Test plan
- [x] `npx vitest run test/node/models.test.ts test/node/resources.test.ts test/node/tests.test.ts` (40/40 pass)
- [x] Regenerate workos-node with Events in `ownedServices` and verify `bash scripts/ci` passes
- [x] Verify `connect.listApplications` generates serialized pagination options

Fixes workos/workos-node#1600