### PR TITLE
fix(node): align AutoPaginatable type param with serialized runtime shape

### DIFF
--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -1673,10 +1673,13 @@ function renderOptionsObjectMethod(
       (itemRawName ? resolveInterfaceName(itemRawName, ctx) : responseModel);
     if (!itemType) return false;
     const wireType = wireInterfaceName(itemType);
-    const returnType =
-      preferredBaselineReturnType(ctx, baselineMethod?.returnType) ?? `Promise<AutoPaginatable<${itemType}>>`;
     const extraParams = op.queryParams.filter((p) => !PAGINATION_PARAM_NAMES.has(p.name));
     const needsWireSerializer = extraParams.some((p) => fieldName(p.name) !== wireFieldName(p.name));
+    const paginationType = needsWireSerializer ? 'PaginationOptions' : optionParam.type;
+    const returnType = needsWireSerializer
+      ? `Promise<AutoPaginatable<${itemType}, ${paginationType}>>`
+      : (preferredBaselineReturnType(ctx, baselineMethod?.returnType) ??
+        `Promise<AutoPaginatable<${itemType}, ${paginationType}>>`);
     const listOptionsExpr = needsWireSerializer
       ? `options ? serialize${optionParam.type}(options) : undefined`
       : 'paginationOptions';
@@ -1887,7 +1890,8 @@ function renderPaginatedMethod(
   const wireType = wireInterfaceName(itemType);
   const serializeCall = serializerArg ? `options ? serialize${optionsType}(options) : undefined` : 'options';
 
-  lines.push(`  async ${method}(${allParams}): Promise<AutoPaginatable<${itemType}, ${optionsType}>> {`);
+  const paginationType = needsWireSerializer ? 'PaginationOptions' : optionsType;
+  lines.push(`  async ${method}(${allParams}): Promise<AutoPaginatable<${itemType}, ${paginationType}>> {`);
   lines.push(`    return new AutoPaginatable(`);
   lines.push(`      await fetchAndDeserialize<${wireType}, ${itemType}>(`);
   lines.push(`        this.workos,`);


### PR DESCRIPTION
## Summary
- After #132, paginated methods that serialize options pass snake_case
  to `AutoPaginatable` at runtime, but the type parameter still declared
  the camelCase domain type (e.g. `ListApplicationsOptions`)
- Callers reading `.options.organizationId` get `undefined` because the
  actual runtime key is `organization_id`
- When `needsWireSerializer` is true, the second generic is now
  `PaginationOptions` to match the serialized shape

## Test plan
- [x] `npx vitest run test/node/models.test.ts test/node/resources.test.ts test/node/tests.test.ts` (40/40 pass)
- [ ] Regenerate workos-node and verify `listApplications` return type uses `PaginationOptions`