### PR TITLE
fix(rust): correct inline-envelope list decoding and empty inferred fields

### DIFF
--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -1189,8 +1189,11 @@ function renderWrapperMethod(
 
 /**
  * Rust expression for reading a client-config field at request time. Mirrors
- * the Go emitter's `clientFieldExpression`. Falls back to an empty literal
- * for unknown fields so the body still compiles.
+ * the Go emitter's `clientFieldExpression`. Throws on unknown fields rather
+ * than falling back to an empty literal: with the `if !expr.is_empty()` guard
+ * in `renderWrapperMethod`, an empty literal would silently drop the field from
+ * every request body (and emit dead `if !"".is_empty()` Rust). Failing loud at
+ * generation time surfaces a missing case instead of shipping a broken SDK.
  */
 function clientFieldExpression(field: string): string {
   switch (field) {
@@ -1199,7 +1202,10 @@ function clientFieldExpression(field: string): string {
     case 'client_secret':
       return 'self.client.api_key()';
     default:
-      return '""';
+      throw new Error(
+        `Rust emitter: no client-config accessor for inferFromClient field "${field}". ` +
+          'Add a case to clientFieldExpression.',
+      );
   }
 }
 
@@ -1298,6 +1304,15 @@ function renderResponseType(op: Operation): string {
  * is still the envelope — decoding the body straight into `Vec<T>` fails, so
  * these ops decode into the hand-maintained `crate::pagination::Page<T>`
  * instead. Restricted to `data` because that's the field `Page<T>` declares.
+ *
+ * The `=== 'data'` is a strict equality on purpose — deliberately *not* the
+ * `?? 'data'` fallback used elsewhere. `dataPath` is the only signal that
+ * separates an inline envelope (decoded as `Page<T>`) from a genuine paginated
+ * bare array (decoded as `Vec<T>`, see the `responseKind === 'array'` branch in
+ * tests.ts). This therefore relies on the IR setting `dataPath: 'data'`
+ * explicitly for envelope responses and leaving it unset for bare arrays. If
+ * the IR ever omitted it for an envelope op, this would return `false` and the
+ * op would decode into `Vec<T>` and fail — so that invariant must hold upstream.
  */
 export function isInlineEnvelopeList(op: Operation): boolean {
   return op.response?.kind === 'array' && op.pagination?.dataPath === 'data';

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -886,29 +886,40 @@ function renderAutoPagingMethod(
   // need a different stream wrapper.
   if (op.pagination.strategy !== 'cursor') return null;
   if (resolved.urlBuilder) return null;
-  if (op.response.kind !== 'model') return null;
-
-  const responseModel = ctx.spec.models.find((m) => m.name === (op.response as { name: string }).name);
-  if (!responseModel) return null;
 
   const cursorParam = op.pagination.param;
   const dataPath = op.pagination.dataPath ?? 'data';
-  const dataField = responseModel.fields.find((f) => f.name === dataPath);
-  if (!dataField || dataField.type.kind !== 'array') return null;
-  const listMetadataField = responseModel.fields.find((f) => f.name === 'list_metadata');
-  if (!listMetadataField || listMetadataField.type.kind !== 'model') return null;
+  let itemType: string;
 
-  // The response cursor lives on the list-metadata model under the same name
-  // as the request param. Bail if it doesn't — that would mean a spec/IR
-  // mismatch and a hand-written wrapper is safer than a broken generated one.
-  const metadataModel = ctx.spec.models.find((m) => m.name === (listMetadataField.type as { name: string }).name);
-  if (!metadataModel) return null;
-  if (!metadataModel.fields.some((f) => f.name === cursorParam)) return null;
+  if (op.response.kind === 'model') {
+    const responseModel = ctx.spec.models.find((m) => m.name === (op.response as { name: string }).name);
+    if (!responseModel) return null;
 
-  // The IR's `pagination.itemType` is the response wrapper model (e.g.
-  // `OrganizationList`), so reach into the model's `data: Vec<T>` field to
-  // pull out the actual element type.
-  const itemType = mapTypeRef(dataField.type.items);
+    const dataField = responseModel.fields.find((f) => f.name === dataPath);
+    if (!dataField || dataField.type.kind !== 'array') return null;
+    const listMetadataField = responseModel.fields.find((f) => f.name === 'list_metadata');
+    if (!listMetadataField || listMetadataField.type.kind !== 'model') return null;
+
+    // The response cursor lives on the list-metadata model under the same name
+    // as the request param. Bail if it doesn't — that would mean a spec/IR
+    // mismatch and a hand-written wrapper is safer than a broken generated one.
+    const metadataModel = ctx.spec.models.find((m) => m.name === (listMetadataField.type as { name: string }).name);
+    if (!metadataModel) return null;
+    if (!metadataModel.fields.some((f) => f.name === cursorParam)) return null;
+
+    // The IR's `pagination.itemType` is the response wrapper model (e.g.
+    // `OrganizationList`), so reach into the model's `data: Vec<T>` field to
+    // pull out the actual element type.
+    itemType = mapTypeRef(dataField.type.items);
+  } else if (isInlineEnvelopeList(op) && cursorParam === 'after') {
+    // Inline-envelope responses decode into `crate::pagination::Page<T>`,
+    // which declares `data` + `list_metadata.after` by construction — only
+    // the request-side cursor param needs to exist.
+    if (!op.queryParams.some((p) => p.name === cursorParam)) return null;
+    itemType = mapTypeRef((op.response as { items: TypeRef }).items);
+  } else {
+    return null;
+  }
 
   const cursorField = fieldName(cursorParam);
   const dataAccessor = fieldName(dataPath);
@@ -1274,7 +1285,22 @@ function methodDocLines(op: Operation): string[] {
 
 function renderResponseType(op: Operation): string {
   if (isEmptyResponse(op)) return '()';
+  if (isInlineEnvelopeList(op)) {
+    return `crate::pagination::Page<${mapTypeRef((op.response as { items: TypeRef }).items)}>`;
+  }
   return mapTypeRef(op.response!);
+}
+
+/**
+ * True when the spec declared this response as an inline pagination envelope
+ * (`{ object, data: [...], list_metadata }` without a named component). The IR
+ * models these as a bare array plus `pagination.dataPath`, but the wire format
+ * is still the envelope — decoding the body straight into `Vec<T>` fails, so
+ * these ops decode into the hand-maintained `crate::pagination::Page<T>`
+ * instead. Restricted to `data` because that's the field `Page<T>` declares.
+ */
+export function isInlineEnvelopeList(op: Operation): boolean {
+  return op.response?.kind === 'array' && op.pagination?.dataPath === 'data';
 }
 
 /**

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -1144,19 +1144,27 @@ function renderWrapperMethod(
 
   sig.push(`        let method = http::Method::${op.httpMethod.toUpperCase()};`);
 
-  // Build the JSON body inline: defaults + inferFromClient (read from the
-  // client at request time) + each exposed param.
-  sig.push('        let body = serde_json::json!({');
+  // Build the JSON body inline: defaults + each exposed param. inferFromClient
+  // fields (read from the client at request time) are added afterwards, and
+  // only when non-empty — a client configured without an API key (e.g. a
+  // public client running a PKCE flow) must omit `client_secret` entirely
+  // rather than send `""`, which the API rejects. Mirrors the Go emitter's
+  // `omitempty` on inferred fields.
+  const inferredFields = wrapper.inferFromClient ?? [];
+  sig.push(`        let ${inferredFields.length > 0 ? 'mut ' : ''}body = serde_json::json!({`);
   for (const [k, v] of Object.entries(wrapper.defaults ?? {})) {
     sig.push(`            ${JSON.stringify(k)}: ${JSON.stringify(v)},`);
-  }
-  for (const k of wrapper.inferFromClient ?? []) {
-    sig.push(`            ${JSON.stringify(k)}: ${clientFieldExpression(k)},`);
   }
   for (const rp of params) {
     sig.push(`            ${JSON.stringify(rp.paramName)}: params.${fieldName(rp.paramName)},`);
   }
   sig.push('        });');
+  for (const k of inferredFields) {
+    const expr = clientFieldExpression(k);
+    sig.push(`        if !${expr}.is_empty() {`);
+    sig.push(`            body[${JSON.stringify(k)}] = serde_json::Value::String(${expr}.to_string());`);
+    sig.push('        }');
+  }
 
   sig.push('        #[derive(Serialize)]');
   sig.push('        struct EmptyQuery {}');

--- a/src/rust/tests.ts
+++ b/src/rust/tests.ts
@@ -14,6 +14,7 @@ import { methodName, moduleName, typeName } from './naming.js';
 import { groupByMount } from '../shared/resolved-ops.js';
 import { exampleFor, generateFixtures } from './fixtures.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
+import { isInlineEnvelopeList } from './resources.js';
 
 /**
  * Generate integration tests under `tests/`. Each mount group gets one
@@ -163,7 +164,11 @@ function renderRegularTest(
   const m = methodName(resolved.methodName);
   const literalPath = op.path.replace(/\{[^}]+\}/g, 'test_id');
   const httpMethod = op.httpMethod.toUpperCase();
-  const responseExpr = responseBodyExpr(op.response, modelMap, enumMap);
+  // Inline-envelope lists decode via crate::pagination::Page<T>, so the mock
+  // must serve the envelope even though the IR types the response as an array.
+  const responseExpr = isInlineEnvelopeList(op)
+    ? JSON.stringify('{"object":"list","data":[],"list_metadata":{"before":null,"after":null}}')
+    : responseBodyExpr(op.response, modelMap, enumMap);
   const isUrlBuilder = resolved.urlBuilder === true;
 
   const callArgs = buildCallArgs(op, resolved, crate, accessor, modelMap, enumMap).join(', ');
@@ -413,7 +418,12 @@ function emptyPageTest(op: Operation, shape: CallShape, accessor: string): strin
   const responseKind = op.response.kind;
   let body: string;
   let dataAccessor: string;
-  if (responseKind === 'array') {
+  if (isInlineEnvelopeList(op)) {
+    // Inline-envelope paginated response: SDK returns crate::pagination::Page<T>,
+    // so the mock must serve the envelope and assertions go through `.data`.
+    body = '{"object":"list","data":[],"list_metadata":{"before":null,"after":null}}';
+    dataAccessor = 'resp.data';
+  } else if (responseKind === 'array') {
     // Bare-array paginated response: SDK returns Vec<T>.
     body = '[]';
     dataAccessor = 'resp';
@@ -558,9 +568,10 @@ function encodesQueryParamsTest(
 /** Body expression for the encoding-test response (success, ignored). */
 function encodingResponseExpr(op: Operation, modelMap: Map<string, Model>, enumMap: Map<string, Enum>): string {
   // For paginated ops we serve an empty page so the call succeeds. Use the
-  // bare-array shape for `Vec<T>` responses, the wrapper shape otherwise.
+  // bare-array shape for `Vec<T>` responses, the wrapper shape for named
+  // wrapper models and inline envelopes (decoded via Page<T>).
   if (op.pagination) {
-    if (op.response.kind === 'array') return JSON.stringify('[]');
+    if (op.response.kind === 'array' && !isInlineEnvelopeList(op)) return JSON.stringify('[]');
     return JSON.stringify('{"object":"list","data":[],"list_metadata":{"before":null,"after":null}}');
   }
   return responseBodyExpr(op.response, modelMap, enumMap);

--- a/test/rust/resources.test.ts
+++ b/test/rust/resources.test.ts
@@ -214,11 +214,18 @@ describe('rust/resources', () => {
     const f = generateResources(services, ctxWithWrapper, new UnionRegistry()).find(
       (x) => x.path === 'src/resources/user_management.rs',
     )!;
-    // Inferred fields read from the runtime client, not empty literals.
-    expect(f.content).toContain('"client_id": self.client.client_id()');
-    expect(f.content).toContain('"client_secret": self.client.api_key()');
+    // Inferred fields read from the runtime client and inserted only when
+    // non-empty, so secretless clients (PKCE flows) omit them entirely.
+    expect(f.content).toContain('let mut body = serde_json::json!({');
+    expect(f.content).toContain('if !self.client.client_id().is_empty() {');
+    expect(f.content).toContain('body["client_id"] = serde_json::Value::String(self.client.client_id().to_string());');
+    expect(f.content).toContain('if !self.client.api_key().is_empty() {');
+    expect(f.content).toContain(
+      'body["client_secret"] = serde_json::Value::String(self.client.api_key().to_string());',
+    );
     expect(f.content).not.toContain('"client_id": "",');
     expect(f.content).not.toContain('"client_secret": "",');
+    expect(f.content).not.toContain('"client_secret": self.client.api_key()');
     // Defaults are still emitted as literal JSON values.
     expect(f.content).toContain('"grant_type": "authorization_code"');
   });

--- a/test/rust/resources.test.ts
+++ b/test/rust/resources.test.ts
@@ -670,6 +670,95 @@ describe('rust/resources', () => {
     expect(f.content).not.toContain('list_events_auto_paging');
   });
 
+  it('decodes inline-envelope list responses into Page<T> instead of Vec<T>', () => {
+    // Spec responses shaped `{ object, data: [...], list_metadata }` without a
+    // named component reach the IR as a bare array plus `pagination.dataPath`.
+    // The wire format is still the envelope, so the method must decode
+    // `crate::pagination::Page<T>` — `Vec<T>` fails with a serde type error.
+    const services: Service[] = [
+      {
+        name: 'Memberships',
+        operations: [
+          {
+            name: 'listMemberships',
+            httpMethod: 'get',
+            path: '/memberships',
+            pathParams: [],
+            queryParams: [
+              {
+                name: 'after',
+                type: { kind: 'primitive', type: 'string' },
+                required: false,
+              },
+            ],
+            headerParams: [],
+            response: { kind: 'array', items: { kind: 'model', name: 'Membership' } },
+            errors: [],
+            injectIdempotencyKey: false,
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'Membership' },
+            },
+          },
+        ],
+      },
+    ];
+    const baseCtx = ctxWithResolved(services);
+    const ctx: EmitterContext = {
+      ...baseCtx,
+      spec: { ...baseCtx.spec, models: [{ name: 'Membership', fields: [] }] },
+    };
+    const f = generateResources(services, ctx, new UnionRegistry()).find(
+      (x) => x.path === 'src/resources/memberships.rs',
+    )!;
+    expect(f.content).toContain('Result<crate::pagination::Page<Membership>, Error>');
+    expect(f.content).not.toContain('Result<Vec<Membership>, Error>');
+    // Page<T> carries `data` + `list_metadata.after`, so auto-paging works too.
+    expect(f.content).toContain('list_memberships_auto_paging');
+    expect(f.content).toContain('Ok((page.data, page.list_metadata.after))');
+  });
+
+  it('keeps Vec<T> for true bare-array responses without an envelope', () => {
+    // A response that really is a JSON array (e.g. /users/{id}/identities)
+    // has no pagination dataPath — it must keep decoding into Vec<T>.
+    const services: Service[] = [
+      {
+        name: 'Identities',
+        operations: [
+          {
+            name: 'getUserIdentities',
+            httpMethod: 'get',
+            path: '/users/{id}/identities',
+            pathParams: [
+              {
+                name: 'id',
+                type: { kind: 'primitive', type: 'string' },
+                required: true,
+              },
+            ],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'array', items: { kind: 'model', name: 'Identity' } },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const baseCtx = ctxWithResolved(services);
+    const ctx: EmitterContext = {
+      ...baseCtx,
+      spec: { ...baseCtx.spec, models: [{ name: 'Identity', fields: [] }] },
+    };
+    const f = generateResources(services, ctx, new UnionRegistry()).find(
+      (x) => x.path === 'src/resources/identities.rs',
+    )!;
+    expect(f.content).toContain('Result<Vec<Identity>, Error>');
+    expect(f.content).not.toContain('crate::pagination::Page');
+  });
+
   it('adds serialize_with attribute on Vec query params with explode=false', () => {
     const services: Service[] = [
       {

--- a/test/rust/resources.test.ts
+++ b/test/rust/resources.test.ts
@@ -230,6 +230,50 @@ describe('rust/resources', () => {
     expect(f.content).toContain('"grant_type": "authorization_code"');
   });
 
+  it('throws on an unrecognized inferFromClient field instead of dropping it', () => {
+    // With the `if !expr.is_empty()` guard, an unknown field falling back to an
+    // empty literal would silently vanish from every request body (and emit
+    // dead `if !"".is_empty()` Rust). Generation must fail loud instead so a
+    // missing accessor is caught at build time, not shipped in a broken SDK.
+    const services: Service[] = [
+      {
+        name: 'UserManagement',
+        operations: [
+          {
+            name: 'authenticate',
+            httpMethod: 'post',
+            path: '/user_management/authenticate',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'AuthenticateResponse' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const baseCtx = ctxWithResolved(services);
+    const ctxWithWrapper: EmitterContext = {
+      ...baseCtx,
+      resolvedOperations: baseCtx.resolvedOperations!.map((r) => ({
+        ...r,
+        wrappers: [
+          {
+            name: 'authenticate_with_code',
+            targetVariant: 'AuthorizationCodeSessionAuthenticateRequest',
+            defaults: { grant_type: 'authorization_code' },
+            inferFromClient: ['client_id', 'tenant_id'],
+            exposedParams: ['code'],
+            optionalParams: [],
+            responseModelName: null,
+          },
+        ],
+      })),
+    };
+    expect(() => generateResources(services, ctxWithWrapper, new UnionRegistry())).toThrow(/tenant_id/);
+  });
+
   it('renders spec-level parameter defaults as doc comments', () => {
     const services: Service[] = [
       {


### PR DESCRIPTION
## Summary
- Inline-envelope list responses (`{ object, data, list_metadata }` with no named component) reached the IR as a bare array + pagination dataPath, so the Rust emitter decoded the body into `Vec<T>` and failed with a serde type error. They now decode into the hand-maintained `crate::pagination::Page<T>`.
- Restores auto-paging for those ops, since `Page<T>` exposes `data` and `list_metadata.after`. True bare-array responses (no dataPath) still decode as `Vec<T>`.
- Wrapper request bodies now write inferred client fields (`client_id`/`client_secret`) only when non-empty. Public PKCE clients carry no API key, and emitting `client_secret: ""` was rejected by the API; mirrors the Go emitter's `omitempty`.
- Generated mocks/tests for inline-envelope ops now serve the envelope shape and assert through `.data` / `Page<T>`.

## Test plan
- [ ] `script/ci` (lint, format, unit tests) passes
- [ ] New tests: inline-envelope decodes to `Page<T>`; bare arrays stay `Vec<T>`; secretless client omits `client_secret`
- [ ] Regenerate workos-rust against the real spec; confirm paginated list ops compile and auto-paging works