### PR TITLE
feat(node): honor urlBuilder operation hint

### DIFF
--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -933,6 +933,20 @@ function generateResourceClass(service: Service, ctx: EmitterContext): Generated
     lines.push("import { AutoPaginatable } from '../common/utils/pagination';");
     lines.push("import { fetchAndDeserialize } from '../common/utils/fetch-and-deserialize';");
   }
+  // URL-builder methods serialize their query string client-side via toQueryString.
+  const needsQueryStringImport = plans.some((p) => {
+    const r = lookupResolved(p.op, resolvedLookup);
+    if (!r?.urlBuilder) return false;
+    const hidden = hiddenParamsFor(r);
+    return (
+      p.op.queryParams.some((qp) => !hidden.has(qp.name)) ||
+      Object.keys(getOpDefaults(r)).length > 0 ||
+      getOpInferFromClient(r).length > 0
+    );
+  });
+  if (needsQueryStringImport) {
+    lines.push("import { toQueryString } from '../common/utils/query-string';");
+  }
   const shouldEmitVaultCryptoHelpers =
     serviceClass === 'Vault' && !ignoredMethodNames.has('encrypt') && !ignoredMethodNames.has('decrypt');
   if (shouldEmitVaultCryptoHelpers) {
@@ -1333,6 +1347,16 @@ function renderMethod(
   const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
   const baselineClassMethod = baselineMethodFor(service, method, ctx);
   const optionInfo = optionsObjectInfo(service, method, op, plan, ctx, baselineClassMethod, resolvedOp);
+
+  // URL-builder operations (e.g. GET /sso/authorize) are spec-marked client-side
+  // URL constructors: emit a synchronous method that returns the request URL as
+  // a string without performing any I/O. This bypasses the HTTP method dispatch
+  // and the Promise-typed JSDoc below.
+  if (resolvedOp?.urlBuilder) {
+    renderUrlBuilderMethod(lines, op, method, pathStr, optionInfo, specEnumNames, resolvedOp);
+    return lines;
+  }
+
   const overlayMethod = ctx.overlayLookup?.methodByOperation?.get(httpKey) ?? baselineClassMethod;
   let validParamNames: Set<string> | null = null;
   if (optionInfo) {
@@ -2207,6 +2231,101 @@ function clientFieldExpression(field: string): string {
     default:
       return `this.workos.${toCamelCase(field)}`;
   }
+}
+
+/**
+ * Compose a `` `${this.workos.baseURL}<path>[?${query}]` `` template literal from
+ * a path expression produced by {@link buildPathStr}. The path expression is
+ * either a single-quoted static literal (`'/sso/authorize'`) or a backtick
+ * template with interpolated path params; either way its inner body is spliced
+ * into the URL template.
+ */
+function urlTemplateLiteral(pathExpr: string, hasQuery: boolean): string {
+  let inner: string;
+  if ((pathExpr.startsWith('`') && pathExpr.endsWith('`')) || (pathExpr.startsWith("'") && pathExpr.endsWith("'"))) {
+    inner = pathExpr.slice(1, -1);
+  } else {
+    inner = '${' + pathExpr + '}';
+  }
+  return '`${this.workos.baseURL}' + inner + (hasQuery ? '?${query}' : '') + '`';
+}
+
+/**
+ * Emit a URL-builder method for an operation marked with the `urlBuilder` hint
+ * (OAuth-style redirect endpoints such as `/sso/authorize`). The method is
+ * synchronous, returns the constructed URL as a string, and makes no HTTP call.
+ * Visible query params, constant `defaults`, and `inferFromClient` fields are
+ * serialized via `toQueryString` (wire-name keyed), matching the SDK's
+ * hand-written URL builders.
+ */
+function renderUrlBuilderMethod(
+  lines: string[],
+  op: Operation,
+  method: string,
+  pathStr: string,
+  optionInfo: OptionsObjectParam | undefined,
+  specEnumNames: Set<string> | undefined,
+  resolvedOp: ResolvedOperation | undefined,
+): void {
+  const hidden = hiddenParamsFor(resolvedOp);
+  const visibleQueryParams = op.queryParams.filter((p) => !hidden.has(p.name));
+  const hasQuery =
+    visibleQueryParams.length > 0 ||
+    Object.keys(getOpDefaults(resolvedOp)).length > 0 ||
+    getOpInferFromClient(resolvedOp).length > 0;
+
+  // Concise JSDoc — url builders return a string, not a Promise.
+  {
+    const docParts: string[] = [];
+    if (op.description) docParts.push(op.description);
+    docParts.push('@returns {string} The constructed URL.');
+    if (op.deprecated) docParts.push('@deprecated');
+    const allLines = docParts.flatMap((p) => p.split('\n'));
+    if (allLines.length === 1) {
+      lines.push(`  /** ${allLines[0]} */`);
+    } else {
+      lines.push('  /**');
+      for (const line of allLines) lines.push(line === '' ? '   *' : `   * ${line}`);
+      lines.push('   */');
+    }
+  }
+
+  if (optionInfo) {
+    // Options-object convention (matches the surrounding generated methods).
+    lines.push(`  ${method}(${renderOptionsParam(optionInfo)}): string {`);
+    if (hasQuery) {
+      const queryExpr = renderQueryExprWithOptions(visibleQueryParams, optionInfo.optional, resolvedOp);
+      lines.push(`    const query = toQueryString(${queryExpr});`);
+      lines.push(`    return ${urlTemplateLiteral(pathStr, true)};`);
+    } else {
+      lines.push(`    return ${urlTemplateLiteral(pathStr, false)};`);
+    }
+    lines.push('  }');
+    return;
+  }
+
+  // Positional convention (path-only url builders, possibly with injected fields).
+  const params = buildPathParams(op, specEnumNames);
+  lines.push(`  ${method}(${params}): string {`);
+  if (hasQuery) {
+    const queryParts: string[] = [];
+    for (const param of visibleQueryParams) {
+      const camel = fieldName(param.name);
+      const snake = wireFieldName(param.name);
+      queryParts.push(param.required ? `${snake}: ${camel}` : `...(${camel} !== undefined && { ${snake}: ${camel} })`);
+    }
+    for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
+      queryParts.push(`${key}: ${tsLiteral(value)}`);
+    }
+    for (const field of getOpInferFromClient(resolvedOp)) {
+      queryParts.push(`${field}: ${clientFieldExpression(field)}`);
+    }
+    lines.push(`    const query = toQueryString({ ${queryParts.join(', ')} });`);
+    lines.push(`    return ${urlTemplateLiteral(pathStr, true)};`);
+  } else {
+    lines.push(`    return ${urlTemplateLiteral(pathStr, false)};`);
+  }
+  lines.push('  }');
 }
 
 function renderVoidMethod(

--- a/test/node/resources.test.ts
+++ b/test/node/resources.test.ts
@@ -186,6 +186,63 @@ describe('generateResources', () => {
     expect(resourceFile!.content).toContain('async listGroupsForOrganizationMembership');
   });
 
+  it('urlBuilder: emits a synchronous string method that builds the URL via toQueryString', () => {
+    // Operations marked `urlBuilder` (e.g. GET /sso/authorize) are client-side
+    // URL constructors: the generated method must return a string synchronously,
+    // serialize visible query params + defaults + inferred client fields via
+    // toQueryString, and concatenate onto the client base URL — no HTTP call.
+    const operation = {
+      name: 'getAuthorizationUrl',
+      httpMethod: 'get' as const,
+      path: '/sso/authorize',
+      pathParams: [],
+      queryParams: [
+        { name: 'connection', type: { kind: 'primitive' as const, type: 'string' as const }, required: false },
+        { name: 'organization', type: { kind: 'primitive' as const, type: 'string' as const }, required: false },
+      ],
+      headerParams: [],
+      response: { kind: 'primitive' as const, type: 'unknown' as const },
+      errors: [],
+      injectIdempotencyKey: false,
+    };
+    const service: Service = { name: 'Sso', operations: [operation] };
+    const spec: ApiSpec = { ...emptySpec, services: [service] };
+    const ctxWithResolved: EmitterContext = {
+      ...ctx,
+      spec,
+      emitterOptions: { ownedServices: ['Sso'] },
+      resolvedOperations: [
+        {
+          operation,
+          service,
+          methodName: 'get_authorization_url',
+          mountOn: 'Sso',
+          defaults: { response_type: 'code' },
+          inferFromClient: ['client_id'],
+          urlBuilder: true,
+        },
+      ],
+    };
+
+    const result = nodeEmitter.generateResources(spec.services, ctxWithResolved);
+    const resourceFile = result.find((f) => f.path === 'src/sso/sso.ts');
+    expect(resourceFile).toBeDefined();
+    const content = resourceFile!.content;
+
+    // Synchronous, string-returning — not an async HTTP wrapper.
+    expect(content).toMatch(/getAuthorizationUrl\(options\??: [^)]*\): string \{/);
+    expect(content).not.toContain('async getAuthorizationUrl');
+    expect(content).not.toContain('this.workos.get(');
+    // Query assembled client-side: visible params + constant default + inferred field.
+    expect(content).toContain('const query = toQueryString(');
+    expect(content).toContain("response_type: 'code'");
+    expect(content).toContain('client_id: this.workos.options.clientId');
+    // URL is base URL + path + query.
+    expect(content).toContain('return `${this.workos.baseURL}/sso/authorize?${query}`;');
+    // The serializer helper is imported.
+    expect(content).toContain("import { toQueryString } from '../common/utils/query-string';");
+  });
+
   it('options-object: URL template binds to the SDK field name, not the spec path-param name', () => {
     // When the spec uses `omId` as a path-param name but the baseline options
     // interface exposes `organizationMembershipId`, both the destructure and


### PR DESCRIPTION
## Summary
- Teaches the Node emitter to honor the `urlBuilder` operation hint, which Go, Rust, PHP, and .NET already implement.
- For ops marked `urlBuilder` (e.g. `GET /sso/authorize`), emits a synchronous, string-returning method that serializes query params + `defaults` + `inferFromClient` via `toQueryString` and concatenates onto `this.workos.baseURL` — no HTTP call.
- These endpoints previously had to be hand-written in `@oagen-ignore` regions; generating them from the existing spec policy is a prerequisite to dropping those markers in workos-node.
- Safe to land: the generator already skips any method present in an `@oagen-ignore` region, so workos-node's hand-written `getAuthorizationUrl` is not duplicated until its region is removed.

## Test plan
- [ ] `npx vitest run` (full suite: 525 passing)
- [ ] New test asserts sync `string` return, `toQueryString` usage, injected `response_type`/`client_id`, base-URL template, and the import
- [ ] `npx tsc --noEmit`, `oxlint`, and `oxfmt --check` clean