### PR TITLE
fix(go,kotlin,node): preserve all variant fields on discriminated-union fields

### DIFF
--- a/src/go/index.ts
+++ b/src/go/index.ts
@@ -11,6 +11,7 @@ import type {
 
 import { generateModels } from './models.js';
 import { enrichModelsFromSpec, getSyntheticEnums } from '../shared/model-utils.js';
+import { flattenDiscriminatedUnionFields } from '../shared/union-flatten.js';
 import { generateEnums } from './enums.js';
 import { generateResources } from './resources.js';
 import { generateClient } from './client.js';
@@ -47,7 +48,11 @@ export const goEmitter: Emitter = {
       }
       return m;
     });
-    return ensureTrailingNewlines(generateModels(goModels, ctx));
+    // Go has no sum types: a discriminated-union field (e.g. ApiKey.owner)
+    // renders as its first variant, dropping fields that only exist on later
+    // variants (organization_id on the user owner). Flatten such unions into a
+    // single superset struct so every variant field survives.
+    return ensureTrailingNewlines(generateModels(flattenDiscriminatedUnionFields(goModels), ctx));
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {

--- a/src/kotlin/index.ts
+++ b/src/kotlin/index.ts
@@ -18,6 +18,7 @@ import { generateClient } from './client.js';
 import { generateTests } from './tests.js';
 import { buildOperationsMap } from './manifest.js';
 import { enrichModelsFromSpec, getSyntheticEnums } from '../shared/model-utils.js';
+import { flattenDiscriminatedUnionFields } from '../shared/union-flatten.js';
 
 /** Ensure every generated file ends with a trailing newline. */
 function ensureTrailingNewlines(files: GeneratedFile[]): GeneratedFile[] {
@@ -49,7 +50,11 @@ export const kotlinEmitter: Emitter = {
       }
       return m;
     });
-    return ensureTrailingNewlines(generateModels(kotlinModels, ctx));
+    // Kotlin renders a discriminated-union field as its first variant's data
+    // class, so fields unique to later variants (organization_id on the user
+    // owner) are lost. Flatten such unions into one superset data class so
+    // every variant field is reachable.
+    return ensureTrailingNewlines(generateModels(flattenDiscriminatedUnionFields(kotlinModels), ctx));
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
@@ -78,8 +83,9 @@ export const kotlinEmitter: Emitter = {
 
   generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
     // Pass enriched models so round-trip tests see the full field set
-    // (including optional oneOf-enriched fields) and can filter accurately.
-    const enrichedModels = enrichModelsFromSpec(spec.models);
+    // (including optional oneOf-enriched fields and flattened discriminated-
+    // union owner fields) and can filter accurately.
+    const enrichedModels = flattenDiscriminatedUnionFields(enrichModelsFromSpec(spec.models));
     const enrichedSpec: ApiSpec = { ...spec, models: enrichedModels };
     return ensureTrailingNewlines(generateTests(enrichedSpec, { ...ctx, spec: enrichedSpec }));
   },

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -18,6 +18,7 @@ import { generateResources, resolveResourceClassName, resolveResourceDir } from 
 import { generateClient } from './client.js';
 import { generateTests as generateTestFiles } from './tests.js';
 import { enrichModelsFromSpec, getSyntheticEnums } from '../shared/model-utils.js';
+import { flattenDiscriminatedUnionFields } from '../shared/union-flatten.js';
 import { planDiscriminatedModels, generateDiscriminatedFiles } from './discriminated-models.js';
 import {
   buildLiveSurface,
@@ -766,7 +767,7 @@ function carryForwardManagedFiles(ctx: EmitterContext, surface: LiveSurface): Ge
 function enrichModelsForNode(models: Model[]): Model[] {
   const enriched = enrichModelsFromSpec(models);
   const originalByName = new Map(models.map((m) => [m.name, m]));
-  return enriched.map((m) => {
+  const restored = enriched.map((m) => {
     if ((m as { discriminator?: unknown }).discriminator && m.fields.length === 0) {
       const original = originalByName.get(m.name);
       if (original && original.fields.length > 0) {
@@ -775,6 +776,11 @@ function enrichModelsForNode(models: Model[]): Model[] {
     }
     return m;
   });
+  // Field-level discriminated unions (e.g. ApiKey.owner) otherwise render as
+  // `FirstVariant | SecondVariant`; collapse them to one flat superset
+  // interface so callers see every variant field (organization_id on the user
+  // owner) on a single type — parity with the other flat-emit languages.
+  return flattenDiscriminatedUnionFields(restored);
 }
 
 export const nodeEmitter: Emitter = {

--- a/src/shared/union-flatten.ts
+++ b/src/shared/union-flatten.ts
@@ -1,0 +1,159 @@
+import type { Model, Field, TypeRef, UnionType } from '@workos/oagen';
+
+/**
+ * Flatten field-level discriminated unions into a single superset model for
+ * the flat-emit languages (Go, Kotlin, Node) that have no native sum type.
+ *
+ * Background: a property like `ApiKey.owner` is a discriminated `oneOf` whose
+ * variants are inline objects — `{ type: 'organization', id }` and
+ * `{ type: 'user', id, organization_id }`. The IR represents this as a `union`
+ * TypeRef referencing two variant models (`ApiKeyOwner`, `UserApiKeyOwner`).
+ * Languages that render such a union as "the first variant" — Go's
+ * `unionResolverName`, Kotlin's `baseName` — silently drop every field that
+ * only exists on a later variant, so `organization_id` disappears for
+ * user-scoped keys. (See the SDK compat report's owner-field note.)
+ *
+ * This transform, applied only by the flat-emit emitters, merges every
+ * variant's fields into the first variant (the union's canonical model),
+ * marks any field not shared by all variants optional, widens the
+ * discriminator property to the union of its per-variant literal values, and
+ * rewrites the field to a plain model ref to that canonical model. The result
+ * is one flat struct/data class/interface that carries every variant field,
+ * with the discriminator property telling callers which variant they hold —
+ * exactly how these emitters already flatten `allOf [base, oneOf]`
+ * discriminated bases (see `enrichModelsFromSpec`).
+ *
+ * Returns a new models array; the input models are not mutated. Union-emitting
+ * languages (Python, PHP, Rust, Ruby, .NET) must NOT call this — they emit a
+ * real discriminated union and lose nothing.
+ */
+export function flattenDiscriminatedUnionFields(models: Model[]): Model[] {
+  const byName = new Map(models.map((m) => [m.name, m]));
+  // Canonical (first-variant) model name → its merged superset field list.
+  const mergedFieldsByCanonical = new Map<string, Field[]>();
+
+  /**
+   * Decide whether a union is a flat-flattenable discriminated union of inline
+   * object variants. When it is, record the merged field set for its canonical
+   * model and return that model's name; otherwise return null.
+   */
+  function planUnion(union: UnionType): string | null {
+    if (!union.discriminator) return null;
+
+    const variantNames = union.variants.map((v) => (v.kind === 'model' ? v.name : null));
+    // Require that *every* variant is a model ref (the inline-object oneOf
+    // shape). Untagged unions of primitives (e.g. AuditLogEvent actor
+    // metadata: string | number | boolean) carry no discriminator and never
+    // reach here, but guard anyway.
+    if (variantNames.length < 2 || variantNames.some((n) => n === null)) return null;
+
+    const variantModels = (variantNames as string[]).map((n) => byName.get(n));
+    // Every variant must resolve to a concrete data model — not a discriminator
+    // dispatcher (empty-field base with its own `discriminator`) and not a
+    // fieldless placeholder. This keeps event-style unions out of scope.
+    if (variantModels.some((m) => !m || (m as { discriminator?: unknown }).discriminator || m.fields.length === 0)) {
+      return null;
+    }
+
+    const canonical = (variantNames as string[])[0];
+    mergedFieldsByCanonical.set(canonical, mergeVariantFields(variantModels as Model[], union.discriminator.property));
+    return canonical;
+  }
+
+  /** Rewrite a TypeRef, collapsing flattenable unions to a canonical model ref. */
+  function rewriteRef(ref: TypeRef): TypeRef {
+    switch (ref.kind) {
+      case 'union': {
+        const canonical = planUnion(ref);
+        return canonical ? { kind: 'model', name: canonical } : ref;
+      }
+      case 'nullable':
+        return { kind: 'nullable', inner: rewriteRef(ref.inner) };
+      case 'array':
+        return { kind: 'array', items: rewriteRef(ref.items) };
+      default:
+        return ref;
+    }
+  }
+
+  // Pass 1: rewrite container fields, recording the merges to apply in pass 2.
+  const rewritten = models.map((model) => {
+    let changed = false;
+    const fields = model.fields.map((field) => {
+      const type = rewriteRef(field.type);
+      if (type === field.type) return field;
+      changed = true;
+      return { ...field, type };
+    });
+    return changed ? { ...model, fields } : model;
+  });
+
+  if (mergedFieldsByCanonical.size === 0) return models;
+
+  // Pass 2: replace each canonical variant model with its merged superset.
+  return rewritten.map((model) => {
+    const merged = mergedFieldsByCanonical.get(model.name);
+    return merged ? { ...model, fields: merged } : model;
+  });
+}
+
+/**
+ * Build the merged field list for a discriminated union's variant models.
+ *
+ * - A field is required only when present-and-required in *every* variant; a
+ *   field missing from some variant (e.g. the user variant's `organization_id`)
+ *   becomes optional.
+ * - The discriminator property is widened to the union of its per-variant
+ *   literal values (`'organization' | 'user'`) so it isn't pinned to the first
+ *   variant's constant. (Flat-emit type maps collapse a single-typed literal
+ *   union to a plain string, so this is a no-op for Go/Kotlin and a precise
+ *   `'organization' | 'user'` for Node.)
+ * - Field order follows the first variant, then newly-seen fields from later
+ *   variants.
+ */
+function mergeVariantFields(variants: Model[], discriminatorProp: string): Field[] {
+  const total = variants.length;
+  const order: string[] = [];
+  const defByName = new Map<string, Field>();
+  const presence = new Map<string, number>();
+  const requiredCount = new Map<string, number>();
+
+  for (const variant of variants) {
+    for (const field of variant.fields) {
+      if (!defByName.has(field.name)) {
+        defByName.set(field.name, field);
+        order.push(field.name);
+      }
+      presence.set(field.name, (presence.get(field.name) ?? 0) + 1);
+      if (field.required) requiredCount.set(field.name, (requiredCount.get(field.name) ?? 0) + 1);
+    }
+  }
+
+  return order.map((name) => {
+    const def = defByName.get(name)!;
+
+    if (name === discriminatorProp) {
+      const literals = dedupeLiteralTypes(
+        variants.map((v) => v.fields.find((f) => f.name === name)?.type).filter((t): t is TypeRef => t != null),
+      );
+      const type: TypeRef = literals.length > 1 ? { kind: 'union', variants: literals } : (literals[0] ?? def.type);
+      return { ...def, type, required: presence.get(name) === total };
+    }
+
+    const required = presence.get(name) === total && requiredCount.get(name) === total;
+    return required === def.required ? def : { ...def, required };
+  });
+}
+
+/** Deduplicate literal TypeRefs by value, preserving first-seen order. */
+function dedupeLiteralTypes(types: TypeRef[]): TypeRef[] {
+  const seen = new Set<string>();
+  const out: TypeRef[] = [];
+  for (const t of types) {
+    const key = t.kind === 'literal' ? `lit:${String(t.value)}` : JSON.stringify(t);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out;
+}

--- a/src/shared/union-flatten.ts
+++ b/src/shared/union-flatten.ts
@@ -56,7 +56,23 @@ export function flattenDiscriminatedUnionFields(models: Model[]): Model[] {
     }
 
     const canonical = (variantNames as string[])[0];
-    mergedFieldsByCanonical.set(canonical, mergeVariantFields(variantModels as Model[], union.discriminator.property));
+    const merged = mergeVariantFields(variantModels as Model[], union.discriminator.property);
+
+    // The merge map is keyed by the first-variant model name. The same union
+    // referenced by several container fields re-plans to an identical merge
+    // (harmless). But two *distinct* unions that share a first variant would
+    // each want a different superset on that one model — pass 2 can apply only
+    // one, silently dropping the other's fields. Fail loudly instead; the spec
+    // must disambiguate (rename one union's leading variant).
+    const existing = mergedFieldsByCanonical.get(canonical);
+    if (existing && fieldListSignature(existing) !== fieldListSignature(merged)) {
+      throw new Error(
+        `flattenDiscriminatedUnionFields: model "${canonical}" is the first variant of two distinct ` +
+          'discriminated unions that merge to different field sets. Flattening both onto one model would ' +
+          'silently drop fields; disambiguate the variants in the spec (rename the leading variant of one union).',
+      );
+    }
+    mergedFieldsByCanonical.set(canonical, merged);
     return canonical;
   }
 
@@ -67,10 +83,16 @@ export function flattenDiscriminatedUnionFields(models: Model[]): Model[] {
         const canonical = planUnion(ref);
         return canonical ? { kind: 'model', name: canonical } : ref;
       }
-      case 'nullable':
-        return { kind: 'nullable', inner: rewriteRef(ref.inner) };
-      case 'array':
-        return { kind: 'array', items: rewriteRef(ref.items) };
+      case 'nullable': {
+        // Preserve reference identity when nothing inside changed, so pass 1's
+        // `type === field.type` check doesn't flag (and rebuild) union-free fields.
+        const inner = rewriteRef(ref.inner);
+        return inner === ref.inner ? ref : { kind: 'nullable', inner };
+      }
+      case 'array': {
+        const items = rewriteRef(ref.items);
+        return items === ref.items ? ref : { kind: 'array', items };
+      }
       default:
         return ref;
     }
@@ -120,9 +142,19 @@ function mergeVariantFields(variants: Model[], discriminatorProp: string): Field
 
   for (const variant of variants) {
     for (const field of variant.fields) {
-      if (!defByName.has(field.name)) {
+      const seen = defByName.get(field.name);
+      if (!seen) {
         defByName.set(field.name, field);
         order.push(field.name);
+      } else if (field.name !== discriminatorProp && !sameTypeRef(seen.type, field.type)) {
+        // Only the first-seen definition is kept, so a shared field whose type
+        // differs across variants would be merged with the wrong type for the
+        // other variants. The discriminator is exempt (it is widened below).
+        throw new Error(
+          `flattenDiscriminatedUnionFields: field "${field.name}" has conflicting types across variants ` +
+            'of a discriminated union; a flat superset model cannot represent both. Align the field type ' +
+            'across variants in the spec.',
+        );
       }
       presence.set(field.name, (presence.get(field.name) ?? 0) + 1);
       if (field.required) requiredCount.set(field.name, (requiredCount.get(field.name) ?? 0) + 1);
@@ -143,6 +175,16 @@ function mergeVariantFields(variants: Model[], discriminatorProp: string): Field
     const required = presence.get(name) === total && requiredCount.get(name) === total;
     return required === def.required ? def : { ...def, required };
   });
+}
+
+/** Structural equality of two TypeRefs (IR refs have a stable, deterministic shape). */
+function sameTypeRef(a: TypeRef, b: TypeRef): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Stable signature of a merged field list, used to detect canonical collisions. */
+function fieldListSignature(fields: Field[]): string {
+  return JSON.stringify(fields.map((f) => [f.name, f.required, f.type]));
 }
 
 /** Deduplicate literal TypeRefs by value, preserving first-seen order. */

--- a/test/shared/union-flatten.test.ts
+++ b/test/shared/union-flatten.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { Model, TypeRef, UnionType } from '@workos/oagen';
+import { flattenDiscriminatedUnionFields } from '../../src/shared/union-flatten.js';
+
+/** The `ApiKey.owner` discriminated-union shape from the WorkOS spec. */
+function ownerUnion(): UnionType {
+  return {
+    kind: 'union',
+    compositionKind: 'oneOf',
+    discriminator: { property: 'type', mapping: { organization: 'ApiKeyOwner', user: 'UserApiKeyOwner' } },
+    variants: [
+      { kind: 'model', name: 'ApiKeyOwner' },
+      { kind: 'model', name: 'UserApiKeyOwner' },
+    ],
+  };
+}
+
+function baseModels(ownerType: TypeRef): Model[] {
+  return [
+    {
+      name: 'ApiKey',
+      fields: [{ name: 'owner', type: ownerType, required: true }],
+    },
+    {
+      name: 'ApiKeyOwner',
+      fields: [
+        { name: 'type', type: { kind: 'literal', value: 'organization' }, required: true },
+        { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+      ],
+    },
+    {
+      name: 'UserApiKeyOwner',
+      fields: [
+        { name: 'type', type: { kind: 'literal', value: 'user' }, required: true },
+        { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+        { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+      ],
+    },
+  ];
+}
+
+describe('flattenDiscriminatedUnionFields', () => {
+  it('rewrites a discriminated-union field to a ref to the first variant', () => {
+    const out = flattenDiscriminatedUnionFields(baseModels(ownerUnion()));
+    const apiKey = out.find((m) => m.name === 'ApiKey')!;
+    expect(apiKey.fields[0].type).toEqual({ kind: 'model', name: 'ApiKeyOwner' });
+  });
+
+  it('merges later-variant fields into the canonical model as optional', () => {
+    const out = flattenDiscriminatedUnionFields(baseModels(ownerUnion()));
+    const canonical = out.find((m) => m.name === 'ApiKeyOwner')!;
+    const orgId = canonical.fields.find((f) => f.name === 'organization_id');
+    expect(orgId).toBeDefined();
+    expect(orgId!.required).toBe(false);
+    // Fields shared (and required) by every variant stay required.
+    expect(canonical.fields.find((f) => f.name === 'id')!.required).toBe(true);
+  });
+
+  it('widens the discriminator property to a union of its literal values', () => {
+    const out = flattenDiscriminatedUnionFields(baseModels(ownerUnion()));
+    const canonical = out.find((m) => m.name === 'ApiKeyOwner')!;
+    const typeField = canonical.fields.find((f) => f.name === 'type')!;
+    expect(typeField.type).toEqual({
+      kind: 'union',
+      variants: [
+        { kind: 'literal', value: 'organization' },
+        { kind: 'literal', value: 'user' },
+      ],
+    });
+  });
+
+  it('flattens the union when wrapped in nullable', () => {
+    const out = flattenDiscriminatedUnionFields(baseModels({ kind: 'nullable', inner: ownerUnion() }));
+    const apiKey = out.find((m) => m.name === 'ApiKey')!;
+    expect(apiKey.fields[0].type).toEqual({ kind: 'nullable', inner: { kind: 'model', name: 'ApiKeyOwner' } });
+  });
+
+  it('leaves a non-discriminated (untagged) primitive union untouched', () => {
+    // AuditLogEvent actor metadata: string | number | boolean — no discriminator.
+    const union: TypeRef = {
+      kind: 'union',
+      compositionKind: 'anyOf',
+      variants: [
+        { kind: 'primitive', type: 'string' },
+        { kind: 'primitive', type: 'number' },
+        { kind: 'primitive', type: 'boolean' },
+      ],
+    };
+    const models: Model[] = [{ name: 'Meta', fields: [{ name: 'value', type: union, required: false }] }];
+    expect(flattenDiscriminatedUnionFields(models)).toBe(models);
+  });
+
+  it('skips a union whose variants are dispatcher (discriminated) models', () => {
+    // Event-style union: each variant is itself a discriminated base. Must not flatten.
+    const union: UnionType = {
+      kind: 'union',
+      discriminator: { property: 'event', mapping: { a: 'EventA', b: 'EventB' } },
+      variants: [
+        { kind: 'model', name: 'EventA' },
+        { kind: 'model', name: 'EventB' },
+      ],
+    };
+    const models: Model[] = [
+      { name: 'Envelope', fields: [{ name: 'data', type: union, required: true }] },
+      { name: 'EventA', fields: [], discriminator: { property: 'x', mapping: {} } },
+      { name: 'EventB', fields: [], discriminator: { property: 'x', mapping: {} } },
+    ];
+    const out = flattenDiscriminatedUnionFields(models);
+    expect(out.find((m) => m.name === 'Envelope')!.fields[0].type).toBe(union);
+  });
+
+  it('does not mutate the input models', () => {
+    const models = baseModels(ownerUnion());
+    const canonicalBefore = models.find((m) => m.name === 'ApiKeyOwner')!;
+    const fieldCountBefore = canonicalBefore.fields.length;
+    flattenDiscriminatedUnionFields(models);
+    expect(canonicalBefore.fields.length).toBe(fieldCountBefore);
+    expect(models.find((m) => m.name === 'ApiKey')!.fields[0].type).toEqual(ownerUnion());
+  });
+});

--- a/test/shared/union-flatten.test.ts
+++ b/test/shared/union-flatten.test.ts
@@ -109,6 +109,60 @@ describe('flattenDiscriminatedUnionFields', () => {
     expect(out.find((m) => m.name === 'Envelope')!.fields[0].type).toBe(union);
   });
 
+  it('does not throw when the same union is referenced by multiple container fields', () => {
+    // Re-planning the same union (canonical re-seen with an identical merge) is
+    // harmless and must not trip the collision guard.
+    const models = baseModels(ownerUnion());
+    models.push({ name: 'ApiKeyList', fields: [{ name: 'owner', type: ownerUnion(), required: false }] });
+    const out = flattenDiscriminatedUnionFields(models);
+    expect(out.find((m) => m.name === 'ApiKey')!.fields[0].type).toEqual({ kind: 'model', name: 'ApiKeyOwner' });
+    expect(out.find((m) => m.name === 'ApiKeyList')!.fields[0].type).toEqual({ kind: 'model', name: 'ApiKeyOwner' });
+  });
+
+  it('throws when two distinct unions share a first variant with differing merges', () => {
+    const unionA: UnionType = {
+      kind: 'union',
+      discriminator: { property: 'type', mapping: { shared: 'Shared', a: 'VariantA' } },
+      variants: [
+        { kind: 'model', name: 'Shared' },
+        { kind: 'model', name: 'VariantA' },
+      ],
+    };
+    const unionB: UnionType = {
+      kind: 'union',
+      discriminator: { property: 'type', mapping: { shared: 'Shared', b: 'VariantB' } },
+      variants: [
+        { kind: 'model', name: 'Shared' },
+        { kind: 'model', name: 'VariantB' },
+      ],
+    };
+    const models: Model[] = [
+      { name: 'C1', fields: [{ name: 'value', type: unionA, required: true }] },
+      { name: 'C2', fields: [{ name: 'value', type: unionB, required: true }] },
+      {
+        name: 'Shared',
+        fields: [{ name: 'type', type: { kind: 'literal', value: 'shared' }, required: true }],
+      },
+      {
+        name: 'VariantA',
+        fields: [{ name: 'foo', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'VariantB',
+        fields: [{ name: 'bar', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+    expect(() => flattenDiscriminatedUnionFields(models)).toThrow(/first variant of two distinct/);
+  });
+
+  it('throws when a field shared across variants has conflicting types', () => {
+    const models = baseModels(ownerUnion());
+    // Make `id` diverge: string on the org variant, number on the user variant.
+    const user = models.find((m) => m.name === 'UserApiKeyOwner')!;
+    user.fields = user.fields.map((f) => (f.name === 'id' ? { ...f, type: { kind: 'primitive', type: 'number' } } : f));
+    expect(() => flattenDiscriminatedUnionFields(models)).toThrow(/conflicting types/);
+  });
+
   it('does not mutate the input models', () => {
     const models = baseModels(ownerUnion());
     const canonicalBefore = models.find((m) => m.name === 'ApiKeyOwner')!;


### PR DESCRIPTION
## Problem

A field whose type is a discriminated `oneOf` of inline objects — e.g. `ApiKey.owner`:

```yaml
owner:
  discriminator: { propertyName: type }
  oneOf:
    - { type: { const: organization }, id }                     # ApiKeyOwner
    - { type: { const: user }, id, organization_id }            # UserApiKeyOwner
```

is represented in the IR as a `union` TypeRef carrying **both** variant models plus a discriminator. But the flat-emit languages render that union as its **first variant only**:

- Go — `unionResolverName` returns `variants[0]` (`*APIKeyOwner`)
- Kotlin — `joinUnionVariants` returns `baseName` = `variants[0]` (`ApiKeyOwner` data class)

So `organization_id` silently disappears from the owner of a **user-scoped** API key (e.g. the response of [validate API key](https://workos.com/docs/reference/authkit/api-keys#validate-api-key)). The Go emitter even documented the loss in its type-map comment rather than fixing it.

Union-emitting languages were already fine: Python (`Union[…]`), Rust (tagged enum), PHP (`A|B`), Ruby (runtime dispatch), .NET (`object` + `JsonConverter`) all keep the field.

## Fix

New shared transform `flattenDiscriminatedUnionFields` (`src/shared/union-flatten.ts`), applied by the Go, Kotlin, and Node emitters right after `enrichModelsFromSpec`. For each field whose type is a discriminated union of inline-object variants it:

- merges every variant's fields into the **first** (canonical) variant model as a single superset,
- marks fields not shared by all variants **optional**,
- widens the discriminator property to the union of its literal values (`'organization' | 'user'`),
- rewrites the field to a plain model ref to the canonical model.

This mirrors how these emitters already flatten `allOf [base, oneOf]` discriminated bases — one flat type with every variant field reachable, the discriminator telling callers which variant they hold.

Scope is limited to discriminated unions of concrete (non-dispatcher) model variants, so untagged primitive unions (`AuditLogEvent` actor metadata) and event-style dispatcher unions are skipped. The five union-emitting languages are untouched (they don't call the helper).

## Result (baseline regen → fixed regen, isolated from pre-existing drift)

- **Go** — `APIKeyCreatedDataOwner` (aliased by `APIKeyOwner`/`APIKeyRevokedDataOwner`/`APIKeyUpdatedDataOwner`) gains `OrganizationID *string \`json:"organization_id,omitempty"\``; the standalone org-only `OrganizationAPIKeyOwner` correctly de-aliases to `{type,id}`.
- **Kotlin** — `ApiKeyOwner` data class gains `organizationId: String? = null`; discriminator widens from a pinned `"organization"` default to plain `String`.
- **Node** — emitter now produces `ApiKeyOwner` with `organizationId?: string` and `type: 'organization' | 'user'`, plus a deserializer that maps `organization_id`.

> [!NOTE]
> workos-node's `api-key.interface.ts` / `created-api-key.interface.ts` are frozen (no oagen autogen header → live-surface treats them as hand-written), so they keep inlining `owner` org-only. The emitter fix is correct and lands on a fresh/un-frozen generation, but won't reach the existing workos-node `ApiKey.owner` until those files are refreshed.

## Tests

- `npm run typecheck` clean
- Full suite **531 passed** (added `test/shared/union-flatten.test.ts`, 7 cases covering rewrite, optional merge, discriminator widening, nullable wrapping, and the untagged/dispatcher skip guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)