### PR TITLE
test(node): cover urlBuilder positional + no-query paths and guard the invariant

### DIFF
--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -2308,8 +2308,9 @@ function renderUrlBuilderMethod(
   // Invariant: any visible query param forces the options-object branch above
   // (operationHasOptionsInput is true whenever one exists), so a positional
   // builder never declares query params in its signature. Fail loudly if a
-  // future spec breaks that — otherwise the queryParts loop below would emit
-  // references to camelCase variables that were never declared.
+  // future spec breaks that — its query value would have to come from an
+  // undeclared parameter. Past this guard the query is assembled solely from
+  // injected defaults and inferFromClient fields.
   if (visibleQueryParams.length > 0) {
     throw new Error(
       `renderUrlBuilderMethod: positional url builder "${method}" has visible query params ` +
@@ -2321,11 +2322,6 @@ function renderUrlBuilderMethod(
   lines.push(`  ${method}(${params}): string {`);
   if (hasQuery) {
     const queryParts: string[] = [];
-    for (const param of visibleQueryParams) {
-      const camel = fieldName(param.name);
-      const snake = wireFieldName(param.name);
-      queryParts.push(param.required ? `${snake}: ${camel}` : `...(${camel} !== undefined && { ${snake}: ${camel} })`);
-    }
     for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
       queryParts.push(`${key}: ${tsLiteral(value)}`);
     }

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -2305,6 +2305,18 @@ function renderUrlBuilderMethod(
   }
 
   // Positional convention (path-only url builders, possibly with injected fields).
+  // Invariant: any visible query param forces the options-object branch above
+  // (operationHasOptionsInput is true whenever one exists), so a positional
+  // builder never declares query params in its signature. Fail loudly if a
+  // future spec breaks that — otherwise the queryParts loop below would emit
+  // references to camelCase variables that were never declared.
+  if (visibleQueryParams.length > 0) {
+    throw new Error(
+      `renderUrlBuilderMethod: positional url builder "${method}" has visible query params ` +
+        `(${visibleQueryParams.map((p) => p.name).join(', ')}) but no options object; they would be ` +
+        'referenced without being declared. Expected the options-object convention.',
+    );
+  }
   const params = buildPathParams(op, specEnumNames);
   lines.push(`  ${method}(${params}): string {`);
   if (hasQuery) {

--- a/test/node/resources.test.ts
+++ b/test/node/resources.test.ts
@@ -243,6 +243,96 @@ describe('generateResources', () => {
     expect(content).toContain("import { toQueryString } from '../common/utils/query-string';");
   });
 
+  it('urlBuilder: positional convention emits a no-arg method when only injected fields supply the query', () => {
+    // A url builder with no path params and no visible query params takes the
+    // positional branch (operationHasOptionsInput is false), so the signature
+    // is argument-less; the query is assembled purely from inferFromClient
+    // (and defaults) rather than a options object.
+    const operation = {
+      name: 'getLogoutUrl',
+      httpMethod: 'get' as const,
+      path: '/sso/logout',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'primitive' as const, type: 'unknown' as const },
+      errors: [],
+      injectIdempotencyKey: false,
+    };
+    const service: Service = { name: 'Sso', operations: [operation] };
+    const spec: ApiSpec = { ...emptySpec, services: [service] };
+    const ctxWithResolved: EmitterContext = {
+      ...ctx,
+      spec,
+      emitterOptions: { ownedServices: ['Sso'] },
+      resolvedOperations: [
+        {
+          operation,
+          service,
+          methodName: 'get_logout_url',
+          mountOn: 'Sso',
+          defaults: {},
+          inferFromClient: ['client_id'],
+          urlBuilder: true,
+        },
+      ],
+    };
+
+    const result = nodeEmitter.generateResources(spec.services, ctxWithResolved);
+    const content = result.find((f) => f.path === 'src/sso/sso.ts')!.content;
+
+    // No options object and no path params: the signature takes no arguments.
+    expect(content).toMatch(/getLogoutUrl\(\): string \{/);
+    expect(content).not.toContain('async getLogoutUrl');
+    // Query built entirely from the injected client field.
+    expect(content).toContain('const query = toQueryString(');
+    expect(content).toContain('client_id: this.workos.options.clientId');
+    expect(content).toContain('return `${this.workos.baseURL}/sso/logout?${query}`;');
+  });
+
+  it('urlBuilder: with no query at all returns the bare base URL + path and skips the toQueryString import', () => {
+    // hasQuery is false (no visible params, defaults, or inferFromClient), so
+    // the method returns base URL + path with no `?${query}` segment, and the
+    // serializer import must not appear when nothing in the service uses it.
+    const operation = {
+      name: 'getJwksUrl',
+      httpMethod: 'get' as const,
+      path: '/sso/jwks',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'primitive' as const, type: 'unknown' as const },
+      errors: [],
+      injectIdempotencyKey: false,
+    };
+    const service: Service = { name: 'Sso', operations: [operation] };
+    const spec: ApiSpec = { ...emptySpec, services: [service] };
+    const ctxWithResolved: EmitterContext = {
+      ...ctx,
+      spec,
+      emitterOptions: { ownedServices: ['Sso'] },
+      resolvedOperations: [
+        {
+          operation,
+          service,
+          methodName: 'get_jwks_url',
+          mountOn: 'Sso',
+          defaults: {},
+          inferFromClient: [],
+          urlBuilder: true,
+        },
+      ],
+    };
+
+    const result = nodeEmitter.generateResources(spec.services, ctxWithResolved);
+    const content = result.find((f) => f.path === 'src/sso/sso.ts')!.content;
+
+    expect(content).toMatch(/getJwksUrl\(\): string \{/);
+    expect(content).toContain('return `${this.workos.baseURL}/sso/jwks`;');
+    expect(content).not.toContain('toQueryString');
+    expect(content).not.toContain("import { toQueryString } from '../common/utils/query-string';");
+  });
+
   it('options-object: URL template binds to the SDK field name, not the spec path-param name', () => {
     // When the spec uses `omId` as a path-param name but the baseline options
     // interface exposes `organizationMembershipId`, both the destructure and


### PR DESCRIPTION
Follow-up to the urlBuilder emitter (#146). The positional branch of renderUrlBuilderMethod references camelCase query variables that are only declared on the options-object path, relying on the unstated invariant that visible query params always force that path (operationHasOptionsInput is true whenever one exists). Make the invariant explicit with a throw so a future spec change fails loudly instead of emitting TypeScript that references undeclared variables.

Adds the two previously-uncovered branch tests:
- positional path: no path/query params, query assembled from inferFromClient, argument-less signature;
- no-query case: bare base URL + path, no toQueryString call or import.

With the guard in place, the loop that assembled query params from `visibleQueryParams` in the positional branch is unreachable, so it is removed; the positional query is now assembled solely from injected defaults and inferFromClient fields (addresses the Greptile review on this PR).

Verified node generation against the real spec is unchanged (the guard does not fire; getAuthorizationUrl's visible query params still route through the options-object convention).