### PR TITLE
fix(node): support owning services with hand-owned generic types

### DIFF
--- a/src/node/client.ts
+++ b/src/node/client.ts
@@ -179,7 +179,7 @@ function exportedNamesForSource(ctx: EmitterContext, sourceFile: string): string
  */
 function generateServiceBarrels(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
-  const { modelToService, resolveDir } = createServiceDirResolver(spec.models, spec.services, ctx);
+  const { modelToService, resolveDir, serviceNameMap } = createServiceDirResolver(spec.models, spec.services, ctx);
   const enumToService = assignEnumsToServices(spec.enums, spec.services, spec.models, ctx);
 
   // Group interface files by directory, tracking exported symbol names
@@ -190,7 +190,7 @@ function generateServiceBarrels(spec: ApiSpec, ctx: EmitterContext): GeneratedFi
   const dirSymbols = new Map<string, Set<string>>();
   const ownedDirNames = new Set<string>();
   for (const service of spec.services) {
-    if (isNodeOwnedService(ctx, service.name)) {
+    if (isNodeOwnedService(ctx, service.name, serviceNameMap.get(service.name))) {
       const dir = resolveDir(service.name);
       ownedDirNames.add(dir);
       // Ensure owned directories always get a barrel entry, even if no

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -11,6 +11,7 @@ import {
   wireInterfaceName,
   resolveMethodName,
   isAdoptedModelName,
+  buildServiceNameMap,
 } from './naming.js';
 import {
   collectFieldDependencies,
@@ -42,7 +43,7 @@ import {
   hasDateTimeConversion,
 } from './field-plan.js';
 import { liveSurfaceHasExistingSdk, liveSurfaceHasManagedFile, liveSurfaceInterfacePath } from './live-surface.js';
-import { isNodeOwnedService } from './options.js';
+import { isNodeOwnedService, isHandOwnedType } from './options.js';
 import { unwrapListModel } from './fixtures.js';
 import { groupByMount, buildResolvedLookup, lookupResolved } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
@@ -244,6 +245,14 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
     if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
     if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     if (discriminatedSkip?.has(model.name)) continue;
+    // Hand-owned types are declared in a hand-written file (e.g. generics the
+    // spec cannot express). Never generate an interface for them; references
+    // route to the existing declaration via its baseline source file.
+    if (
+      isHandOwnedType(ctx, model.name) ||
+      isHandOwnedType(ctx, resolveInterfaceName(model.name, ctx, { skipTypeAlias: true }))
+    )
+      continue;
     const service = modelToService.get(model.name);
     const isOwnedModel = isNodeOwnedService(ctx, service);
     if (!isOwnedModel && !modelHasNewFields(model, ctx) && !forceGenerate.has(model.name)) continue;
@@ -342,6 +351,10 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
     const crossServiceImports = new Map<string, { name: string; relPath: string }>();
     const unresolvableNames = new Set<string>();
     const enumToService = assignEnumsToServices(ctx.spec.enums, ctx.spec.services, ctx.spec.models, ctx);
+    // Resolve mounted/owned service names (e.g. IR `Directories` -> `DirectorySync`)
+    // so owned-service enum-import planning matches `generateEnums`, which keys
+    // ownership off the resolved name (see enums.ts).
+    const serviceNameMap = buildServiceNameMap(ctx.spec.services, ctx);
     const resolvedEnumNames = new Map<string, string>();
     for (const e of ctx.spec.enums) {
       resolvedEnumNames.set(resolveInterfaceName(e.name, ctx), e.name);
@@ -375,7 +388,7 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
             // even when the baseline declares the name elsewhere (usually in
             // the very file being overwritten), so import planning must
             // target the canonical path to agree with that emission.
-            const eEnumIsOwned = isNodeOwnedService(ctx, eService);
+            const eEnumIsOwned = isNodeOwnedService(ctx, eService, eService ? serviceNameMap.get(eService) : undefined);
             const bSrc = eEnumIsOwned ? undefined : ((bEnum as any)?.sourceFile ?? (bAlias as any)?.sourceFile);
             const gPath = `src/${eDir}/interfaces/${fileName(irEnumName)}.interface.ts`;
             const cPath = `src/${dirName}/interfaces/${fileName(model.name)}.interface.ts`;
@@ -453,7 +466,11 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
       const baselineEnum = ctx.apiSurface?.enums?.[dep];
       const baselineAlias = ctx.apiSurface?.typeAliases?.[dep];
       const depService = enumToService.get(dep);
-      const depEnumIsOwned = isNodeOwnedService(ctx, depService);
+      const depEnumIsOwned = isNodeOwnedService(
+        ctx,
+        depService,
+        depService ? serviceNameMap.get(depService) : undefined,
+      );
       // Fall back to the live-surface declaration path: `generateEnums` skips
       // emission when the enum is already declared elsewhere in the SDK (same
       // fallback, see enums.ts), so the import must follow that declaration —
@@ -835,6 +852,12 @@ export function generateSerializers(
     if (isListMetadataModel(model) && !serializerListMetadataNeeded.has(model.name)) continue;
     if (isListWrapperModel(model) && !serializerNonPaginatedRefs.has(model.name)) continue;
     if (discriminatedSerializerSkip?.has(model.name)) continue;
+    // Hand-owned types keep their hand-written serializer (see generateModels).
+    if (
+      isHandOwnedType(ctx, model.name) ||
+      isHandOwnedType(ctx, resolveInterfaceName(model.name, ctx, { skipTypeAlias: true }))
+    )
+      continue;
     const service = modelToService.get(model.name);
     const isOwnedModel = isNodeOwnedService(ctx, service);
     if (!isOwnedModel && !modelHasNewFields(model, ctx) && !forceGenerateSerializer.has(model.name)) continue;
@@ -979,12 +1002,28 @@ export function generateSerializers(
   }
   const liveRootForBarrel = ctx.outputDir ?? ctx.targetDir;
   for (const [dir, stems] of serializersByDir) {
-    if (liveRootForBarrel && !isNodeOwnedService(ctx, dir)) {
+    if (liveRootForBarrel) {
+      const dirIsOwned = isNodeOwnedService(ctx, dir);
       const serializersDir = path.join(liveRootForBarrel, 'src', dir, 'serializers');
       try {
         for (const entry of fs.readdirSync(serializersDir)) {
           if (!entry.endsWith('.serializer.ts')) continue;
-          stems.add(entry.replace(/\.serializer\.ts$/, ''));
+          const stem = entry.replace(/\.serializer\.ts$/, '');
+          if (stems.has(stem)) continue;
+          // Owned directories are otherwise fully regenerated. Only preserve a
+          // hand-written serializer when it belongs to a hand-owned type (i.e.
+          // exports `(de)serialize<HandOwnedType>`); stale auto-generated files
+          // should be pruned and unrelated hand-written files must not collide
+          // with generated exports.
+          if (dirIsOwned) {
+            const content = fs.readFileSync(path.join(serializersDir, entry), 'utf-8');
+            if (/auto-generated by oagen/i.test(content.slice(0, 400))) continue;
+            const serializerFns = [
+              ...content.matchAll(/export\s+(?:const|function)\s+((?:de)?serialize[A-Za-z0-9_]+)/g),
+            ].map((m) => m[1].replace(/^(?:de)?serialize/, ''));
+            if (!serializerFns.some((typeName) => isHandOwnedType(ctx, typeName))) continue;
+          }
+          stems.add(stem);
         }
       } catch {
         // Directory doesn't exist yet — only this-pass serializers will appear.

--- a/src/node/options.ts
+++ b/src/node/options.ts
@@ -38,6 +38,17 @@ export interface NodeEmitterOptions {
    * without affecting other languages.
    */
   operationOverrides?: Record<string, OperationOverride>;
+  /**
+   * Type/model names whose hand-written declarations are authoritative even
+   * inside an owned service. The emitter will NOT generate an interface or
+   * serializer for these names; instead it treats them like a baseline type,
+   * routing imports and barrel exports to the existing hand-written file.
+   *
+   * Use this to keep hand-owned generics the OpenAPI spec cannot express
+   * (for example `DirectoryUserWithGroups<TCustomAttributes>`) while still
+   * letting oagen own the rest of the service.
+   */
+  handOwnedTypes?: string[];
 }
 
 export function nodeOptions(ctx: EmitterContext): NodeEmitterOptions {
@@ -66,4 +77,16 @@ export function isNodeOwnedService(ctx: EmitterContext, ...names: Array<string |
   return names.some((name) =>
     name !== undefined ? ownedLookupNames(name).some((candidate) => owned.has(normalizeServiceName(candidate))) : false,
   );
+}
+
+/**
+ * True when `name` is a hand-owned type (see {@link NodeEmitterOptions.handOwnedTypes}).
+ * Hand-owned types are never generated; the emitter defers to the existing
+ * hand-written declaration and routes imports/barrel exports to it.
+ */
+export function isHandOwnedType(ctx: EmitterContext, name: string | undefined): boolean {
+  if (name === undefined) return false;
+  const configured = nodeOptions(ctx).handOwnedTypes;
+  if (!configured || configured.length === 0) return false;
+  return configured.includes(name);
 }

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -303,9 +303,26 @@ function optionsObjectInfo(
 
   if (!operationHasOptionsInput(op, plan, resolvedOp)) return undefined;
 
+  const resolvedService = resolveResourceClassName(service, ctx);
+  let optionsType = methodOptionsName(method, resolvedService);
+  // A bare `${Method}Options` name (e.g. `GetGroupOptions`) can collide with a
+  // same-named baseline type owned by a DIFFERENT service (for example the
+  // Groups module's `GetGroupOptions`, shaped `{ organizationId, groupId }`).
+  // Reusing it by name would import a foreign shape. When the existing
+  // declaration lives in another service directory, qualify the name with the
+  // service (mirroring the `list` -> `${Service}ListOptions` rule) so this
+  // service generates and imports its own options type.
+  if (method !== 'list') {
+    const baselineFile = baselineTypeSourceFile(ctx, optionsType);
+    const baselineDir = baselineFile?.match(/^src\/([^/]+)\//)?.[1];
+    if (baselineDir && baselineDir !== resolveResourceDir(service, ctx)) {
+      optionsType = `${toPascalCase(resolvedService)}${toPascalCase(method)}Options`;
+    }
+  }
+
   return {
     name: 'options',
-    type: methodOptionsName(method, resolveResourceClassName(service, ctx)),
+    type: optionsType,
     optional: optionsObjectShouldBeOptional(op, plan, resolvedOp),
     generated: true,
   };
@@ -1194,7 +1211,10 @@ function generateResourceClass(service: Service, ctx: EmitterContext): Generated
     const baselineMethod = baselineMethodFor(service, method, ctx);
     const optionInfo = optionsObjectInfo(service, method, op, plan, ctx, baselineMethod, resolved);
     if (plan.isPaginated) {
-      const extraParams = op.queryParams.filter((p) => !PAGINATION_PARAM_NAMES.has(p.name));
+      // Skip deprecated query params: the typed options interface omits them
+      // (the curated baseline drops deprecated params), so the wire serializer
+      // must not reference a field that does not exist on the options type.
+      const extraParams = op.queryParams.filter((p) => !PAGINATION_PARAM_NAMES.has(p.name) && !p.deprecated);
       if (extraParams.length > 0) {
         const optionsName = optionInfo?.type ?? paginatedOptionsName(method, resolvedName);
 

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -670,9 +670,11 @@ function buildOptionsObjectTestArg(
   if (plan.isPaginated) {
     entries.push("order: 'desc'");
   }
-  const queryParams = plan.isPaginated
-    ? op.queryParams.filter((param) => !['limit', 'before', 'after', 'order'].includes(param.name))
-    : op.queryParams;
+  const queryParams = (
+    plan.isPaginated
+      ? op.queryParams.filter((param) => !['limit', 'before', 'after', 'order'].includes(param.name))
+      : op.queryParams
+  ).filter((param) => !param.deprecated);
   for (const param of queryParams) {
     const localName = fieldName(param.name);
     const value = queryParamTestValue(param, modelMap);


### PR DESCRIPTION
## Summary
Enables owning DirectorySync (and similar services) whose public surface includes generics the OpenAPI spec cannot express (e.g. `DirectoryUserWithGroups<TCustomAttributes>`), while still letting oagen own the rest of the service.

- Add `handOwnedTypes` emitter option: named types whose hand-written declarations are authoritative. The emitter skips generating their interface + serializer and routes imports/barrel exports to the existing hand-written file.
- Resolve mounted/owned service names (IR `Directories` -> `DirectorySync`) in enum-import planning and barrel generation, so owned-service enums (DirectoryType/DirectoryState) get their imports and barrel exports (was keyed off the raw IR name only).
- Preserve hand-written serializers for hand-owned types in the owned-dir serializer barrel; stale auto-generated files are pruned.
- Drop deprecated query params from generated wire serializers and tests so they agree with the options interface (which already omits them).
- Service-qualify a generated options type when its bare name collides with a different-shaped baseline type in another service (e.g. getGroup -> DirectorySyncGetGroupOptions instead of reusing Groups' GetGroupOptions).

## Test plan
- [ ] `script/ci` passes in oagen-emitters
- [ ] Regenerate workos-node against the real spec; DirectorySync is owned and `DirectoryUserWithGroups<TCustomAttributes>` preserved
- [ ] DirectoryType/DirectoryState enum imports + barrel exports resolve
- [ ] No deprecated query params in generated serializers/tests
- [ ] getGroup uses DirectorySyncGetGroupOptions (no foreign Groups shape)
- [ ] `script/ci` passes in workos-node after regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)