### PR TITLE
fix(node): adopt spec request interface for owned inline-literal params; dedupe common enums

### DIFF
--- a/src/node/enums.ts
+++ b/src/node/enums.ts
@@ -186,5 +186,28 @@ export function assignEnumsToServices(
     }
   }
 
+  // A shared enum that already has a canonical declaration under `src/common/`
+  // must stay there. `common` is a shared module that owned-service
+  // regeneration never overwrites, so it is always the source of truth for
+  // these names. Without this, owning a service that references such an enum
+  // would emit a SECOND copy into the owned module's `interfaces/` dir (via the
+  // owned-service exception in `generateEnums`) while the `common` copy
+  // remains, and `src/index.ts` re-exports both barrels — a duplicate
+  // `export *` (TS2308). Unassigning the enum makes every consumer
+  // (`generateEnums`, model imports, barrels) resolve it to `common`.
+  if (ctx) {
+    const serviceNameMap = buildServiceNameMap(services, ctx);
+    const toUnassign: string[] = [];
+    for (const [name, service] of enumToService) {
+      if (!isNodeOwnedService(ctx, service, serviceNameMap.get(service))) continue;
+      const home =
+        (ctx.apiSurface?.enums?.[name] as any)?.sourceFile ??
+        (ctx.apiSurface?.typeAliases?.[name] as any)?.sourceFile ??
+        liveSurfaceInterfacePath(name);
+      if (home && home.startsWith('src/common/')) toUnassign.push(name);
+    }
+    for (const name of toUnassign) enumToService.delete(name);
+  }
+
   return enumToService;
 }

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -289,7 +289,34 @@ function optionsObjectInfo(
   resolvedOp?: ResolvedOperation,
 ): OptionsObjectParam | undefined {
   const baseline = optionsObjectParam(baselineMethod);
-  if (baseline) return baseline;
+  if (baseline) {
+    // A baseline param whose type is a pure inline object literal
+    // (e.g. `{ intent?: GenerateLinkIntent; organization: string; ... }`)
+    // cannot be referenced as a named import and routinely diverges from the
+    // spec-derived request interface that the generated serializer expects —
+    // field renames (`adminEmails` -> `itContactEmails`), widened enums
+    // (`string` vs `'GoogleSAML'`), differing optionality — which makes the
+    // generated `serialize${Model}(payload)` call fail to typecheck. When the
+    // operation owns a named request-body model, adopt that interface so the
+    // method signature, the serializer, and the request model all agree.
+    // Named baseline types (`CreateOrganizationApiKeyOptions`) and compound
+    // intersections (`X & { ... }`) are still preserved verbatim.
+    if (
+      baseline.type.trimStart().startsWith('{') &&
+      isNodeOwnedService(ctx, service.name, resolveResourceClassName(service, ctx))
+    ) {
+      const body = extractRequestBodyType(op, ctx);
+      if (body?.kind === 'model') {
+        return {
+          name: 'options',
+          type: resolveInterfaceName(body.name, ctx),
+          optional: optionsObjectShouldBeOptional(op, plan, resolvedOp),
+          generated: false,
+        };
+      }
+    }
+    return baseline;
+  }
 
   const overrideType = operationOverrideFor(ctx, op)?.optionsType;
   if (overrideType) {

--- a/test/node/enums.test.ts
+++ b/test/node/enums.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { EmitterContext, ApiSpec, Enum, Model } from '@workos/oagen';
+import type { EmitterContext, ApiSpec, Enum, Model, Service } from '@workos/oagen';
 import { defaultSdkBehavior } from '@workos/oagen';
-import { generateEnums } from '../../src/node/enums.js';
+import { generateEnums, assignEnumsToServices } from '../../src/node/enums.js';
 import { nodeEmitter } from '../../src/node/index.js';
 import { emptyLiveSurface, setActiveLiveSurface } from '../../src/node/live-surface.js';
 import * as fs from 'node:fs';
@@ -192,6 +192,142 @@ describe('assignEnumsToServices owned-service dependency reassignment', () => {
     } finally {
       setActiveLiveSurface(emptyLiveSurface());
     }
+  });
+});
+
+describe('assignEnumsToServices common-home unassignment under ownership', () => {
+  // Inverse of the reassignment case above: an enum referenced by an OWNED
+  // service is first-reference-assigned into that service, but its canonical
+  // declaration already lives under `src/common/`. The unassignment guard
+  // must drop it back to `common` so the owned-service exception in
+  // `generateEnums` does not emit a SECOND copy alongside the existing
+  // `common` one (a duplicate `export *` / TS2308).
+  const connectionType: Enum = {
+    name: 'ConnectionType',
+    values: [
+      { name: 'GOOGLE_SAML', value: 'GoogleSAML' },
+      { name: 'OKTA_SAML', value: 'OktaSAML' },
+    ],
+  };
+  const ssoService: Service = {
+    name: 'SSO',
+    operations: [
+      {
+        name: 'listConnections',
+        httpMethod: 'get',
+        path: '/connections',
+        pathParams: [],
+        queryParams: [
+          {
+            name: 'connectionType',
+            type: { kind: 'enum', name: 'ConnectionType', values: ['GoogleSAML', 'OktaSAML'] },
+            required: false,
+          },
+        ],
+        headerParams: [],
+        response: { kind: 'primitive', type: 'unknown' },
+        errors: [],
+        injectIdempotencyKey: false,
+      },
+    ],
+  };
+
+  const makeCtx = (overrides: Partial<EmitterContext>): EmitterContext =>
+    ({
+      ...ctx,
+      spec: { ...emptySpec, enums: [connectionType], services: [ssoService] },
+      emitterOptions: { ownedServices: ['SSO'] },
+      ...overrides,
+    }) as EmitterContext;
+
+  it('unassigns an owned-service enum whose apiSurface sourceFile is under src/common/', () => {
+    const ctxOwned = makeCtx({
+      apiSurface: {
+        classes: {},
+        interfaces: {},
+        typeAliases: {},
+        exports: {},
+        enums: { ConnectionType: { sourceFile: 'src/common/interfaces/connection-type.interface.ts' } },
+      },
+    } as unknown as Partial<EmitterContext>);
+
+    const map = assignEnumsToServices([connectionType], [ssoService], [], ctxOwned);
+    // Unassigned → resolves to `common`, not the owned `SSO` directory.
+    expect(map.has('ConnectionType')).toBe(false);
+  });
+
+  it('unassigns via the typeAliases sourceFile lookup (literal-union baseline form)', () => {
+    const ctxOwned = makeCtx({
+      apiSurface: {
+        classes: {},
+        interfaces: {},
+        enums: {},
+        exports: {},
+        typeAliases: {
+          ConnectionType: {
+            value: "'GoogleSAML' | 'OktaSAML'",
+            sourceFile: 'src/common/interfaces/connection-type.interface.ts',
+          },
+        },
+      },
+    } as unknown as Partial<EmitterContext>);
+
+    const map = assignEnumsToServices([connectionType], [ssoService], [], ctxOwned);
+    expect(map.has('ConnectionType')).toBe(false);
+  });
+
+  it('falls back to the live-surface interface path when no apiSurface entry exists', () => {
+    // Guards the `liveSurfaceInterfacePath(name)` fallback: with no apiSurface,
+    // the canonical home is only discoverable through the scanned live surface.
+    const surface = emptyLiveSurface();
+    surface.files.add('src/workos.ts');
+    surface.interfaces.set('ConnectionType', {
+      filePath: 'src/common/interfaces/connection-type.interface.ts',
+      fields: new Set(),
+    });
+    setActiveLiveSurface(surface);
+    try {
+      const map = assignEnumsToServices([connectionType], [ssoService], [], makeCtx({}));
+      expect(map.has('ConnectionType')).toBe(false);
+    } finally {
+      setActiveLiveSurface(emptyLiveSurface());
+    }
+  });
+
+  it('keeps an owned-service enum whose canonical home is NOT under src/common/', () => {
+    // The guard is specific to `src/common/`: an enum that genuinely belongs to
+    // the owned service must stay assigned there.
+    const ctxOwned = makeCtx({
+      apiSurface: {
+        classes: {},
+        interfaces: {},
+        typeAliases: {},
+        exports: {},
+        enums: { ConnectionType: { sourceFile: 'src/sso/interfaces/connection-type.interface.ts' } },
+      },
+    } as unknown as Partial<EmitterContext>);
+
+    const map = assignEnumsToServices([connectionType], [ssoService], [], ctxOwned);
+    expect(map.get('ConnectionType')).toBe('SSO');
+  });
+
+  it('does not unassign for a non-owned service even when the home is under src/common/', () => {
+    // The unassignment only applies under ownership — a non-owned service keeps
+    // its first-reference assignment regardless of where the enum's home is.
+    const ctxNotOwned = {
+      ...ctx,
+      spec: { ...emptySpec, enums: [connectionType], services: [ssoService] },
+      apiSurface: {
+        classes: {},
+        interfaces: {},
+        typeAliases: {},
+        exports: {},
+        enums: { ConnectionType: { sourceFile: 'src/common/interfaces/connection-type.interface.ts' } },
+      },
+    } as unknown as EmitterContext;
+
+    const map = assignEnumsToServices([connectionType], [ssoService], [], ctxNotOwned);
+    expect(map.get('ConnectionType')).toBe('SSO');
   });
 });
 

--- a/test/node/resources.test.ts
+++ b/test/node/resources.test.ts
@@ -895,81 +895,117 @@ describe('paginated list methods and path params (AutoPaginatable typing)', () =
 describe('inline object-literal baseline parameter types', () => {
   // The hand-written workos-node AdminPortal method uses an inline object-literal
   // parameter TYPE (`generateLink({ ... }: { intent: GenerateLinkIntent; ... })`).
-  // When the baseline surface reports that literal text as the param "type name",
-  // the emitter must keep it inline in the signature and must NOT slugify it into
-  // an interface filename or emit a named import of a brace-expression.
-  it('keeps the literal type inline and never imports it', () => {
-    const literalType = '{ intent: GenerateLinkIntent; organization: string; returnUrl?: string }';
-    const service: Service = {
-      name: 'AdminPortal',
-      operations: [
-        {
-          name: 'generateLink',
-          httpMethod: 'post',
-          path: '/portal/generate_link',
-          pathParams: [],
-          queryParams: [],
-          headerParams: [],
-          requestBody: { kind: 'model', name: 'GenerateLinkBody' },
-          response: { kind: 'model', name: 'PortalLink' },
-          errors: [],
-          injectIdempotencyKey: false,
-        },
-      ],
-    };
-    const spec: ApiSpec = {
-      ...emptySpec,
-      services: [service],
-      models: [
-        {
-          name: 'GenerateLinkBody',
-          fields: [
-            { name: 'intent', type: { kind: 'primitive', type: 'string' }, required: true },
-            { name: 'organization', type: { kind: 'primitive', type: 'string' }, required: true },
-          ],
-        },
-        {
-          name: 'PortalLink',
-          fields: [{ name: 'link', type: { kind: 'primitive', type: 'string' }, required: true }],
-        },
-      ],
-    };
-    const ctxWithBaseline: EmitterContext = {
-      ...ctx,
-      spec,
-      emitterOptions: { ownedServices: ['AdminPortal'] },
-      apiSurface: {
-        classes: {
-          AdminPortal: {
-            constructorParams: [{ name: 'workos', type: 'WorkOS' }],
-            methods: {
-              generateLink: [
-                {
-                  name: 'generateLink',
-                  params: [{ name: 'options', type: literalType, passingStyle: 'options_object' }],
-                  returnType: 'Promise<{ link: string }>',
-                  async: true,
-                },
-              ],
-            },
+  // For an OWNED service, that inline literal frequently diverges from the
+  // spec-derived request interface the generated serializer expects (field
+  // renames, widened enums, differing optionality), so the emitter adopts the
+  // named request-body interface instead of preserving the literal — while
+  // still never slugifying the literal text into an interface filename or
+  // emitting a named import of a brace-expression.
+  const literalType = '{ intent: GenerateLinkIntent; organization: string; returnUrl?: string }';
+
+  const adminPortalService = (requestBody: any): Service => ({
+    name: 'AdminPortal',
+    operations: [
+      {
+        name: 'generateLink',
+        httpMethod: 'post',
+        path: '/portal/generate_link',
+        pathParams: [],
+        queryParams: [],
+        headerParams: [],
+        requestBody,
+        response: { kind: 'model', name: 'PortalLink' },
+        errors: [],
+        injectIdempotencyKey: false,
+      },
+    ],
+  });
+
+  const baselineCtx = (service: Service, models: any[]): EmitterContext => ({
+    ...ctx,
+    spec: { ...emptySpec, services: [service], models },
+    emitterOptions: { ownedServices: ['AdminPortal'] },
+    apiSurface: {
+      classes: {
+        AdminPortal: {
+          constructorParams: [{ name: 'workos', type: 'WorkOS' }],
+          methods: {
+            generateLink: [
+              {
+                name: 'generateLink',
+                params: [{ name: 'options', type: literalType, passingStyle: 'options_object' }],
+                returnType: 'Promise<{ link: string }>',
+                async: true,
+              },
+            ],
           },
         },
-      } as any,
-    };
+      },
+    } as any,
+  });
 
-    const result = generateResources([service], ctxWithBaseline);
+  it('adopts the named request-body interface instead of the inline literal', () => {
+    const service = adminPortalService({ kind: 'model', name: 'GenerateLinkBody' });
+    const models = [
+      {
+        name: 'GenerateLinkBody',
+        fields: [
+          { name: 'intent', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'organization', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+      {
+        name: 'PortalLink',
+        fields: [{ name: 'link', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    const result = generateResources([service], baselineCtx(service, models));
     const resourceFile = result.find((f) => f.path === 'src/admin-portal/admin-portal.ts');
     expect(resourceFile).toBeDefined();
     const content = resourceFile!.content;
 
-    // The literal type stays inline in the method signature.
-    expect(content).toContain(`async generateLink(options: ${literalType})`);
-    // No named import of a brace-expression…
+    // The named request interface replaces the inline literal in the signature,
+    // so the method param, the request model, and `serialize*` all agree.
+    expect(content).toContain('async generateLink(options: GenerateLinkBody)');
+    expect(content).toContain('serializeGenerateLinkBody(payload)');
+    // The inline literal is gone from the signature.
+    expect(content).not.toContain(`options: ${literalType}`);
+    // No named import of a brace-expression, and no import path / interface
+    // file derived from slugifying the literal type's text.
     expect(content).not.toContain('import type { {');
-    // …and no import path derived from slugifying the literal type's text.
     expect(content).not.toContain('intent-generate-link-intent');
-    // No interface file is emitted for the literal type either.
     expect(result.some((f) => f.path.includes('intent-generate-link-intent'))).toBe(false);
+  });
+
+  it('keeps the literal inline when there is no single named request model', () => {
+    // A union request body has no single named interface to adopt, so the
+    // emitter must fall back to preserving the inline literal (and must still
+    // never slugify it into an import).
+    const service = adminPortalService({
+      kind: 'union',
+      variants: [
+        { kind: 'model', name: 'SsoLinkBody' },
+        { kind: 'model', name: 'DsyncLinkBody' },
+      ],
+    });
+    const models = [
+      {
+        name: 'SsoLinkBody',
+        fields: [{ name: 'organization', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'DsyncLinkBody',
+        fields: [{ name: 'organization', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      { name: 'PortalLink', fields: [{ name: 'link', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+
+    const result = generateResources([service], baselineCtx(service, models));
+    const content = result.find((f) => f.path === 'src/admin-portal/admin-portal.ts')!.content;
+
+    expect(content).toContain(`async generateLink(options: ${literalType})`);
+    expect(content).not.toContain('import type { {');
   });
 });
 


### PR DESCRIPTION
## Summary

Two Node-emitter bugs surfaced when adding an existing service whose hand-written method uses an **inline object-literal parameter type** (e.g. AdminPortal's `generateLink`) to `ownedServices`. Both produced invalid TypeScript in the regenerated SDK (`scripts/ci` typecheck failures).

### 1. Inline-literal param vs spec serializer mismatch (`src/node/resources.ts`)

`optionsObjectInfo` preserved the live-SDK inline object-literal param type verbatim, but the owned-service method body routes through the generated `serialize${Model}(payload)`, which is typed to the **spec-derived** request interface. When the published surface and the spec have diverged, the inline payload is not assignable to that interface:

- field renames — `adminEmails` → `itContactEmails`
- widened enums — `providerType?: string` vs `providerType?: 'GoogleSAML'`
- differing optionality — `sso` required vs optional

For an **owned** service whose baseline param is a *pure inline object literal*, the emitter now adopts the named request-body interface so the method signature, the serializer, and the request model all agree. Named baseline types (`CreateOrganizationApiKeyOptions`) and compound intersections (`X & { ... }`) are still preserved verbatim.

### 2. Duplicate shared enum under an owned module (`src/node/enums.ts`)

A shared enum already declared under `src/common/` was re-homed into an owned module's `interfaces/` dir by the owned-service exception, while the `common` copy stayed put. `src/index.ts` re-exports both barrels → duplicate `export *` (TS2308). `assignEnumsToServices` now unassigns any enum whose canonical declaration lives in `common`, so every consumer (`generateEnums`, model imports, barrels) resolves it to `common` only.

## Behavior change

This intentionally lets an owned method's public signature track the spec when the two have diverged (e.g. `generateLink` adopts `GenerateLink`: `itContactEmails`, `providerType: 'GoogleSAML'`, optional `sso`, `+domainVerification`). Breaking changes to a published SDK surface are surfaced by the downstream compat-diff gate for explicit acceptance.

## Testing

- `npm run typecheck` ✓
- Full vitest suite: **544 passing**
- Updated the inline-literal resource test to assert the new adoption behavior (keeping the no-brace-import / no-slugified-filename safety nets); added a fallback test proving the literal is preserved inline when there is no single named request model.
- Verified end-to-end: regenerated `workos-node` with AdminPortal owned → `tsc --noEmit` reports **0 errors** (previously 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)