### PR TITLE
fix(node): only adopt named request interface for pure object-literal params

### DIFF
--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -279,6 +279,24 @@ function operationHasOptionsInput(op: Operation, plan: OperationPlan, resolvedOp
   );
 }
 
+// True only when the type is a SINGLE closed object literal (`{ ... }`), not
+// the head of a compound type such as `{ ... } & X` or `{ ... } | Y`. Counting
+// brace depth locates the literal's matching close brace (handling nesting like
+// `{ a: { b: string } }`); any non-whitespace after it means the type is not a
+// pure literal and must be preserved verbatim rather than replaced by a named
+// request interface.
+function isClosedObjectLiteral(type: string): boolean {
+  const t = type.trim();
+  if (!t.startsWith('{')) return false;
+  let depth = 0;
+  for (let i = 0; i < t.length; i++) {
+    const ch = t[i];
+    if (ch === '{') depth++;
+    else if (ch === '}' && --depth === 0) return i === t.length - 1;
+  }
+  return false;
+}
+
 function optionsObjectInfo(
   service: Service,
   method: string,
@@ -300,9 +318,10 @@ function optionsObjectInfo(
     // operation owns a named request-body model, adopt that interface so the
     // method signature, the serializer, and the request model all agree.
     // Named baseline types (`CreateOrganizationApiKeyOptions`) and compound
-    // intersections (`X & { ... }`) are still preserved verbatim.
+    // intersections (`X & { ... }` or `{ ... } & X`) are still preserved
+    // verbatim — only a single, closed object literal is eligible for adoption.
     if (
-      baseline.type.trimStart().startsWith('{') &&
+      isClosedObjectLiteral(baseline.type) &&
       isNodeOwnedService(ctx, service.name, resolveResourceClassName(service, ctx))
     ) {
       const body = extractRequestBodyType(op, ctx);

--- a/test/node/resources.test.ts
+++ b/test/node/resources.test.ts
@@ -921,7 +921,7 @@ describe('inline object-literal baseline parameter types', () => {
     ],
   });
 
-  const baselineCtx = (service: Service, models: any[]): EmitterContext => ({
+  const baselineCtx = (service: Service, models: any[], paramType: string = literalType): EmitterContext => ({
     ...ctx,
     spec: { ...emptySpec, services: [service], models },
     emitterOptions: { ownedServices: ['AdminPortal'] },
@@ -933,7 +933,7 @@ describe('inline object-literal baseline parameter types', () => {
             generateLink: [
               {
                 name: 'generateLink',
-                params: [{ name: 'options', type: literalType, passingStyle: 'options_object' }],
+                params: [{ name: 'options', type: paramType, passingStyle: 'options_object' }],
                 returnType: 'Promise<{ link: string }>',
                 async: true,
               },
@@ -1005,6 +1005,35 @@ describe('inline object-literal baseline parameter types', () => {
     const content = result.find((f) => f.path === 'src/admin-portal/admin-portal.ts')!.content;
 
     expect(content).toContain(`async generateLink(options: ${literalType})`);
+    expect(content).not.toContain('import type { {');
+  });
+
+  it('keeps a `{ ... } & X` compound intersection inline even with a named request model', () => {
+    // The adoption guard targets a PURE object literal. A baseline param that
+    // LEADS with a literal but is actually a compound intersection
+    // (`{ ... } & WithMetadata`) carries the hand-authored `& X` portion, which
+    // a named-interface swap would silently drop. It must be preserved verbatim
+    // even though the operation has a single named request-body model.
+    const compoundType = `${literalType} & WithMetadata`;
+    const service = adminPortalService({ kind: 'model', name: 'GenerateLinkBody' });
+    const models = [
+      {
+        name: 'GenerateLinkBody',
+        fields: [
+          { name: 'intent', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'organization', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+      { name: 'PortalLink', fields: [{ name: 'link', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+
+    const result = generateResources([service], baselineCtx(service, models, compoundType));
+    const content = result.find((f) => f.path === 'src/admin-portal/admin-portal.ts')!.content;
+
+    // The compound type (including the `& WithMetadata` tail) survives intact;
+    // it is NOT replaced by the named `GenerateLinkBody` interface.
+    expect(content).toContain(`async generateLink(options: ${compoundType})`);
+    expect(content).not.toContain('async generateLink(options: GenerateLinkBody)');
     expect(content).not.toContain('import type { {');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up hardening to #154. That PR taught the Node emitter to adopt a spec-derived named request interface in place of an owned service's inline object-literal param (e.g. AdminPortal's `generateLink`), so the method signature, the `serialize${Model}` call, and the request model all agree.

The eligibility check was `baseline.type.trimStart().startsWith('{')`. That correctly matches a pure literal `{ ... }` and correctly skips a leading-named intersection `X & { ... }` — but it **also** matches a compound type that merely *leads* with a literal, e.g. `{ ... } & WithMetadata`. In that case the emitter would swap in the named interface and **silently drop the hand-authored `& X` tail** from the public signature.

This doesn't occur in the current SDK (intersections are written named-type-first), so it's a latent edge case rather than a live bug — flagged by Greptile's review of #154.

## Change

Replace the prefix check with `isClosedObjectLiteral`, which brace-counts to confirm the literal's matching close brace is the last non-whitespace char (handling nesting like `{ a: { b: string } }`). Adoption now fires **only** for a single, closed object literal:

| Baseline param type | Before | After |
|---|---|---|
| `{ ... }` | adopt named interface | adopt named interface (unchanged) |
| `X & { ... }` | preserved | preserved (unchanged) |
| `{ ... } & X` | **adopted — drops `& X`** | **preserved** ✅ |

This makes the guard match its stated intent — a *pure* inline object literal.

## Testing

- Added a `{ ... } & X` test asserting the compound type survives intact and is **not** replaced by the named `GenerateLinkBody` interface. Verified it **fails** against the old `startsWith('{')` check and **passes** with the closed-literal guard.
- `npm run typecheck` ✓
- Full vitest suite: **550 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)