### PR TITLE
fix(dotnet): emit envelope fixture for list-wrappers returned by non-paginated ops

### DIFF
--- a/src/dotnet/fixtures.ts
+++ b/src/dotnet/fixtures.ts
@@ -1,6 +1,7 @@
 import type { Model, TypeRef, Enum } from '@workos/oagen';
 import { fixtureFileName, fieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
+import { collectNonPaginatedResponseModelNames } from '../shared/model-utils.js';
 
 /**
  * Prefix mapping for generating realistic ID fixture values.
@@ -35,9 +36,19 @@ export function generateFixtures(spec: {
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
   const files: { path: string; content: string }[] = [];
 
+  // List-wrappers are normally represented only by the per-operation
+  // `list_<item>.json` fixtures generated from paginated operations below. But
+  // a wrapper returned by a NON-paginated operation (e.g.
+  // `PUT /authorization/groups/{id}/role_assignments` -> GroupRoleAssignmentList)
+  // is emitted as a real model (see models.ts) and its generated test references
+  // `testdata/<type>.json` (tests.ts). Emit that envelope fixture too, mirroring
+  // the non-wrapper `VersionListResponse` precedent — otherwise the test loads a
+  // file that was never written.
+  const nonPaginatedWrapperRefs = collectNonPaginatedResponseModelNames(spec.services);
+
   for (const model of spec.models) {
     if (isListMetadataModel(model)) continue;
-    if (isListWrapperModel(model)) continue;
+    if (isListWrapperModel(model) && !nonPaginatedWrapperRefs.has(model.name)) continue;
 
     const fixture = model.fields.length === 0 ? {} : generateModelFixture(model, modelMap, enumMap);
 


### PR DESCRIPTION
## Problem

A list-wrapper model (`data[]` + `list_metadata`) returned by a **non-paginated** operation — e.g. `PUT /authorization/groups/{id}/role_assignments` → `GroupRoleAssignmentList` — is emitted as a real model (`models.ts`, via `collectNonPaginatedResponseModelNames`) and its generated test references `testdata/<type>.json` (`tests.ts:207`). But `generateFixtures()` skipped **every** list-wrapper (`fixtures.ts:40`), so the fixture file was never written. The generated test then failed at runtime:

```
WorkOSTests.AuthorizationServiceTest.TestUpdateGroupRoleAssignmentsAsync
System.IO.FileNotFoundException : Could not find file '.../testdata/group_role_assignment_list.json'
```

Paginated GET lists were unaffected because they use the per-operation `list_<item>.json` fixtures (and reference those). The non-wrapper precedent `VersionListResponse` already works because it isn't classified as a list-wrapper and gets a normal `<type>.json` fixture — this brings list-wrappers in non-paginated responses to parity.

## Fix

In `generateFixtures()`, don't skip a list-wrapper that's referenced by a non-paginated response — emit its envelope fixture (`{ object, data: [item], list_metadata }`) under `testdata/<type>.json`, reusing the existing `collectNonPaginatedResponseModelNames` helper. One-line behavioral change guarded by `nonPaginatedRefs`.

## Verification

- Regenerated `workos-dotnet` with this build: `testdata/group_role_assignment_list.json` is now written, and `dotnet test --filter TestUpdateGroupRoleAssignmentsAsync` **passes** (was failing).
- Full emitter suite green (549 tests).

## Context

Surfaced by workos/openapi-spec#31. The dotnet **build** failure there was already fixed by spec-side policy changes; this was the remaining **test** failure, masked until the build compiled. After this is released, bump `@workos/oagen-emitters` in `openapi-spec` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)