### PR TITLE
fix: cross-emitter domainName, Node owned-service fixes, Rust unions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.18.3",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.22.6"
+        "@workos/oagen": "^0.22.7"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
         "@commitlint/config-conventional": "^21.0.2",
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.0.0",
         "husky": "^9.1.7",
         "oxfmt": "^0.55.0",
         "oxlint": "^1.70.0",
@@ -2064,13 +2064,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.22.6.tgz",
-      "integrity": "sha512-kTgaAIyCP1/ZT305lHmFV6y+CAD+IgrXMVQXhDgCLLNEIufK5vRm2eDee6Y4ZZg6zZ5tlyqsvS8L18RBejBwBA==",
+      "version": "0.22.7",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.22.7.tgz",
+      "integrity": "sha512-7PaQ588YFK5l3QBf2at3dVDVt7bRp39omYHkExBaFxHEDFbueUT27wRZgly5pntBAi9AOS5hH/p3H9dEK5zaZg==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",
@@ -4200,9 +4200,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "husky": "^9.1.7",
     "oxfmt": "^0.55.0",
     "oxlint": "^1.70.0",
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.22.6"
+    "@workos/oagen": "^0.22.7"
   }
 }

--- a/src/dotnet/fixtures.ts
+++ b/src/dotnet/fixtures.ts
@@ -1,5 +1,5 @@
 import type { Model, TypeRef, Enum } from '@workos/oagen';
-import { fixtureFileName, fieldName } from './naming.js';
+import { fixtureFileName, domainFieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
 import { collectNonPaginatedResponseModelNames } from '../shared/model-utils.js';
 
@@ -155,7 +155,10 @@ export function generateModelFixture(
 
   const seenFieldNames = new Set<string>();
   const deduplicatedFields = model.fields.filter((f) => {
-    const csName = fieldName(f.name);
+    // Dedup on the DOMAIN identifier (the C# property name, honoring a
+    // `domainName` override) to mirror the dedup in models.ts. The fixture
+    // payload below still keys on the wire name (`field.name`).
+    const csName = domainFieldName(f);
     if (seenFieldNames.has(csName)) return false;
     seenFieldNames.add(csName);
     return true;

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -12,6 +12,7 @@ import {
 import {
   articleFor,
   fieldName,
+  domainFieldName,
   humanize,
   emitXmlDoc,
   deprecationMessage,
@@ -93,7 +94,10 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
         const baseClassName = modelClassName(model.name);
         const fieldMap = new Map<string, string>();
         for (const field of model.fields) {
-          let csName = fieldName(field.name);
+          // DOMAIN identifier: the C# property name used for inheritance
+          // comparison (honors a `domainName` override). Must match the
+          // property name emitted below so variant fields dedup correctly.
+          let csName = domainFieldName(field);
           if (csName === baseClassName) csName = `${csName}Value`;
           fieldMap.set(csName, mapTypeRef(field.type));
         }
@@ -119,8 +123,16 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
     // Required enums need JsonProperty / STJS; a field whose PascalCase name
     // collides with the enclosing class needs the same imports for the wire-
     // name override emitted below.
-    const hasClassNameCollision = model.fields.some((f) => fieldName(f.name) === csClassName);
-    const needsJsonAttrs = hasClassNameCollision || model.fields.some((f) => f.required && isEnumRef(f.type));
+    // DOMAIN identifier: the emitted C# property name (honors `domainName`)
+    // is what can collide with the enclosing class name.
+    const hasClassNameCollision = model.fields.some((f) => domainFieldName(f) === csClassName);
+    // A `domainName` override renames the C# property away from the wire key
+    // (e.g. wire `connection_type` surfaced as domain `Type`). The
+    // SnakeCaseLower naming policy would otherwise serialize the domain name,
+    // so these fields need an explicit pinned wire name (and thus the imports).
+    const hasDomainRename = model.fields.some((f) => domainFieldName(f) !== fieldName(f.name));
+    const needsJsonAttrs =
+      hasClassNameCollision || hasDomainRename || model.fields.some((f) => f.required && isEnumRef(f.type));
 
     lines.push(`namespace ${ctx.namespacePascal}`);
     lines.push('{');
@@ -175,9 +187,16 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
       // when that happens. Track the rename so we emit an explicit
       // `[JsonProperty]` attribute below — the SnakeCaseLower naming policy
       // would otherwise serialize `ErrorValue` as `error_value`, not `error`.
-      let csFieldName = fieldName(field.name);
+      // DOMAIN identifier: the C# property name, honoring a `domainName`
+      // override (e.g. wire `connection_type` → domain `Type`). The wire key
+      // passed to `emitJsonPropertyAttributes` below still derives from
+      // `field.name`.
+      let csFieldName = domainFieldName(field);
       const collidesWithClassName = csFieldName === csClassName;
       if (collidesWithClassName) csFieldName = `${csFieldName}Value`;
+      // When the domain rename diverges from the wire key, the SnakeCaseLower
+      // naming policy can't recover the wire name from the property — pin it.
+      const hasDomainOverride = domainFieldName(field) !== fieldName(field.name);
       if (seenFieldNames.has(csFieldName)) continue;
       seenFieldNames.add(csFieldName);
 
@@ -257,8 +276,14 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
       }
 
       const isRequiredEnum = field.required && isEnumRef(field.type) && constInit === null;
+      // WIRE key: always derives from `field.name`. Pin it explicitly when the
+      // C# property name (collision suffix or `domainName` override) no longer
+      // round-trips to the wire name via the SnakeCaseLower naming policy.
       lines.push(
-        ...emitJsonPropertyAttributes(field.name, { isRequiredEnum, explicitWireName: collidesWithClassName }),
+        ...emitJsonPropertyAttributes(field.name, {
+          isRequiredEnum,
+          explicitWireName: collidesWithClassName || hasDomainOverride,
+        }),
       );
       // Discriminated-union-typed field: attach the variant-dispatching converter
       // so Newtonsoft picks the right subtype on deserialization. The converter

--- a/src/dotnet/naming.ts
+++ b/src/dotnet/naming.ts
@@ -39,6 +39,16 @@ export function fieldName(name: string): string {
   return toPascalCase(name);
 }
 
+/**
+ * PascalCase domain property name for a model field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier C# property name. The wire/serialization key (the
+ * `[JsonPropertyName("...")]` value) still derives from `field.name`.
+ */
+export function domainFieldName(field: { name: string; domainName?: string }): string {
+  return toPascalCase(field.domainName ?? field.name);
+}
+
 /** PascalCase directory name for service modules. */
 export function moduleName(name: string): string {
   return toPascalCase(name);

--- a/src/dotnet/tests.ts
+++ b/src/dotnet/tests.ts
@@ -3,6 +3,7 @@ import { planOperation } from '@workos/oagen';
 import {
   fixtureFileName,
   fieldName as csFieldName,
+  domainFieldName as csDomainFieldName,
   methodName as csMethodName,
   appendAsyncSuffix,
   modelClassName,
@@ -694,7 +695,10 @@ function buildFixtureAssertions(model: import('@workos/oagen').Model, spec: ApiS
     if (field.type.kind !== 'primitive' || field.type.type !== 'string') continue;
     if (field.type.format === 'date-time' || field.type.format === 'date') continue;
     if (field.type.format === 'binary') continue;
-    const csField = csFieldName(field.name);
+    // DOMAIN identifier: the C# property accessed on the deserialized model
+    // (honors a `domainName` override). The fixture lookup below uses the wire
+    // key (`field.name`).
+    const csField = csDomainFieldName(field);
     const val = fixture[field.name];
     if (typeof val === 'string' && val.length > 0) {
       assertions.push(`Assert.Equal(${csStringLiteral(val)}, result.${csField});`);

--- a/src/go/fixtures.ts
+++ b/src/go/fixtures.ts
@@ -1,5 +1,5 @@
 import type { Model, TypeRef, Enum } from '@workos/oagen';
-import { fileName, fieldName } from './naming.js';
+import { fileName, domainFieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
 import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
 
@@ -131,7 +131,9 @@ export function generateModelFixture(
 
   const seenFieldNames = new Set<string>();
   const deduplicatedFields = model.fields.filter((f) => {
-    const goName = fieldName(f.name);
+    // Dedup by the domain Go field name to mirror the struct in models.ts; the
+    // fixture key itself (wireName below) still derives from field.name.
+    const goName = domainFieldName(f);
     if (seenFieldNames.has(goName)) return false;
     seenFieldNames.add(goName);
     return true;

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -1,7 +1,7 @@
 import type { Model, EmitterContext, GeneratedFile, TypeRef, Service } from '@workos/oagen';
 import { walkTypeRef } from '@workos/oagen';
 import { mapTypeRef } from './type-map.js';
-import { className, fieldName } from './naming.js';
+import { className, domainFieldName } from './naming.js';
 import { lowerFirstForDoc, fieldDocComment, articleFor } from '../shared/naming-utils.js';
 
 // Import and re-export shared model detection utilities
@@ -185,7 +185,9 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     // Deduplicate fields by Go field name
     const seenFieldNames = new Set<string>();
     for (const field of model.fields) {
-      const goFieldName = fieldName(field.name);
+      // Domain identifier honors a `fieldHints` override (e.g. connection_type
+      // → type); the json struct tag below still derives from `field.name`.
+      const goFieldName = domainFieldName(field);
       if (seenFieldNames.has(goFieldName)) continue;
       seenFieldNames.add(goFieldName);
 

--- a/src/go/naming.ts
+++ b/src/go/naming.ts
@@ -61,6 +61,16 @@ export function fieldName(name: string): string {
   return applyAcronyms(toPascalCase(name));
 }
 
+/**
+ * PascalCase domain field name for a model field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier name. The wire name (the `json:"..."` struct tag) still derives
+ * from `field.name`.
+ */
+export function domainFieldName(field: { name: string; domainName?: string }): string {
+  return applyAcronyms(toPascalCase(field.domainName ?? field.name));
+}
+
 /** snake_case module/directory name. */
 export function moduleName(name: string): string {
   return toSnakeCase(name);

--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -9,7 +9,15 @@ import type {
 import { planOperation, toSnakeCase } from '@workos/oagen';
 import { isListWrapperModel } from './models.js';
 import { mapTypeRef, mapTypeRefValue } from './type-map.js';
-import { className, fieldName, methodName, resolveClassName, resolveMethodName, unexportedName } from './naming.js';
+import {
+  className,
+  domainFieldName,
+  fieldName,
+  methodName,
+  resolveClassName,
+  resolveMethodName,
+  unexportedName,
+} from './naming.js';
 import {
   buildResolvedLookup,
   lookupResolved,
@@ -404,7 +412,8 @@ function generateParamsStruct(
       for (const field of bodyModel.fields) {
         if (hidden.has(field.name)) continue;
         if (groupedParams.has(field.name)) continue;
-        const goField = fieldName(field.name);
+        // Domain struct field; the json tag below keeps deriving from field.name.
+        const goField = domainFieldName(field);
         if (emittedFields.has(goField)) continue;
         emittedFields.add(goField);
         const isOptional = !field.required;
@@ -942,7 +951,8 @@ function emitHiddenParamsBodyStruct(
       if (hidden.has(field.name)) continue;
       if (groupedParamNames.has(field.name)) continue;
       if (!field.required) continue;
-      const goField = fieldName(field.name);
+      // Domain struct field; the json tag below keeps deriving from field.name.
+      const goField = domainFieldName(field);
       const goType = mapTypeRef(field.type);
       lines.push(`\t${goField} ${goType} \`json:"${field.name}"\``);
     }
@@ -960,7 +970,8 @@ function emitHiddenParamsBodyStruct(
       if (hidden.has(field.name)) continue;
       if (groupedParamNames.has(field.name)) continue;
       if (field.required) continue;
-      const goField = fieldName(field.name);
+      // Domain struct field; the json tag below keeps deriving from field.name.
+      const goField = domainFieldName(field);
       const goType = makeOptional(mapTypeRef(field.type));
       lines.push(`\t${goField} ${goType} \`json:"${field.name},omitempty"\``);
     }
@@ -1007,7 +1018,8 @@ function emitBodyWithHiddenParams(
     for (const field of bodyModel.fields) {
       if (hidden.has(field.name)) continue;
       if (!field.required) continue;
-      const goField = fieldName(field.name);
+      // Domain struct field on both the body literal and the params struct.
+      const goField = domainFieldName(field);
       lines.push(`\t\t${goField}: params.${goField},`);
     }
   }
@@ -1025,7 +1037,8 @@ function emitBodyWithHiddenParams(
     for (const field of bodyModel.fields) {
       if (hidden.has(field.name)) continue;
       if (field.required) continue;
-      const goField = fieldName(field.name);
+      // Domain struct field on both the body struct and the params struct.
+      const goField = domainFieldName(field);
       lines.push(`\tbody.${goField} = params.${goField}`);
     }
   }

--- a/src/kotlin/models.ts
+++ b/src/kotlin/models.ts
@@ -1,6 +1,6 @@
 import type { Model, EmitterContext, GeneratedFile, TypeRef, Field } from '@workos/oagen';
 import { mapTypeRef, discriminatedUnions } from './type-map.js';
-import { className, propertyName, ktStringLiteral, humanize } from './naming.js';
+import { className, domainPropertyName, ktStringLiteral, humanize } from './naming.js';
 import { enumCanonicalMap } from './enums.js';
 import {
   isListWrapperModel,
@@ -374,7 +374,10 @@ function renderFields(fields: Field[], overrideFields: Set<string> = new Set()):
 
   for (const rawField of fields) {
     const field = promoteFieldType(rawField);
-    const kotlinName = propertyName(field.name);
+    // DOMAIN identifier: the data class property name. Honors a `domainName`
+    // override (e.g. connection_type -> type); the `@JsonProperty(...)` wire
+    // key below still derives from `field.name`.
+    const kotlinName = domainPropertyName(field);
     if (seen.has(kotlinName)) continue;
     seen.add(kotlinName);
 

--- a/src/kotlin/naming.ts
+++ b/src/kotlin/naming.ts
@@ -57,6 +57,17 @@ export function propertyName(name: string): string {
   return escapeReserved(camel);
 }
 
+/**
+ * camelCase domain property name for a MODEL field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier name. The wire key (the `@JsonProperty("...")` argument) still
+ * derives from `field.name`. No-op when `domainName` is unset, so it is also
+ * safe on params. Only apply to model fields.
+ */
+export function domainPropertyName(field: { name: string; domainName?: string }): string {
+  return propertyName(field.domainName ?? field.name);
+}
+
 /** camelCase alias (kept for parity with other emitters). */
 export const fieldName = propertyName;
 export const localName = propertyName;

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -17,6 +17,7 @@ import {
   ktStringLiteral,
   className,
   propertyName,
+  domainPropertyName,
   buildExportedClassNameSet,
 } from './naming.js';
 import { mapTypeRef } from './type-map.js';
@@ -713,7 +714,10 @@ function buildResponseAssertions(
   for (const field of model.fields) {
     if (!field.required) continue;
     if (assertions.length >= MAX_RESPONSE_ASSERTIONS) break;
-    const ktProp = propertyName(field.name);
+    // DOMAIN identifier: the property accessor on the deserialized model.
+    // Honors a `domainName` override; the synthesized JSON above keys off
+    // `field.name` (the wire key).
+    const ktProp = domainPropertyName(field);
     const type = field.type;
     if (type.kind === 'primitive') {
       if (type.format === 'date-time') continue;

--- a/src/node/field-plan.ts
+++ b/src/node/field-plan.ts
@@ -388,7 +388,7 @@ export function serializerHasBaselineIncompatibility(
   const irDomainFields = new Set<string>();
   for (const field of model.fields) {
     irWireFields.add(wireFieldName(field.name));
-    irDomainFields.add(fieldName(field.name));
+    irDomainFields.add(fieldName(field.domainName ?? field.name));
   }
 
   for (const [wireField2, fieldDef] of Object.entries(baselineResponse.fields)) {
@@ -463,7 +463,7 @@ export function planDeserializeField(
   skipFormatFields: Set<string>,
   ctx: EmitterContext,
 ): { line: string; skip: boolean } {
-  const domain = fieldName(field.name);
+  const domain = fieldName(field.domainName ?? field.name);
   const wire = wireFieldName(field.name);
   const wireAccess = `response.${wire}`;
   const skip = skipFormatFields.has(field.name);
@@ -543,7 +543,7 @@ export function planSerializeField(
   ctx: EmitterContext,
 ): { line: string; skip: boolean } {
   const wire = wireFieldName(field.name);
-  const domain = fieldName(field.name);
+  const domain = fieldName(field.domainName ?? field.name);
   const domainAccess = `model.${domain}`;
   const skip = skipFormatFields.has(field.name);
 

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -527,7 +527,9 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
     } else {
       lines.push(`export interface ${domainName}${typeParams} {`);
       for (const field of model.fields) {
-        const domainFieldName = fieldName(field.name);
+        // Domain identifier honors a `fieldHints` override (e.g. connection_type
+        // → type); the wire name below still derives from `field.name`.
+        const domainFieldName = fieldName(field.domainName ?? field.name);
         if (seenDomainFields.has(domainFieldName)) continue;
         seenDomainFields.add(domainFieldName);
         if (field.description || field.deprecated || field.readOnly || field.writeOnly || field.default !== undefined) {

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -546,6 +546,19 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
           baselineField && !baselineField.optional && responseBaselineField && responseBaselineField.optional;
         const readonlyPrefix = field.readOnly ? 'readonly ' : '';
         if (
+          genericDefaults.has(model.name) &&
+          baselineField &&
+          typeReferencesUnresolvable(baselineField.type, unresolvableNames)
+        ) {
+          // Baseline typed this field with the model's generic param (e.g.
+          // `customAttributes?: CustomAttributesType`). The emitted interface
+          // renames the param to `GenericType`; remap the field so the param is
+          // actually used — otherwise it trips TS6133 (declared, never read).
+          const opt = baselineField.optional ? '?' : '';
+          lines.push(
+            `  ${readonlyPrefix}${domainFieldName}${opt}: ${substituteGenericParam(baselineField.type, unresolvableNames)};`,
+          );
+        } else if (
           baselineField &&
           !domainResponseOptionalMismatch &&
           !hasDateTimeConversion(field.type) &&
@@ -597,6 +610,15 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
           seenWireFields.add(wireField);
           const baselineField = baselineResponse?.fields?.[wireField];
           if (
+            genericDefaults.has(model.name) &&
+            baselineField &&
+            typeReferencesUnresolvable(baselineField.type, unresolvableNames)
+          ) {
+            // Mirror the domain side: keep the generic param wired on the
+            // response interface so `GenericType` is used, not orphaned.
+            const opt = baselineField.optional ? '?' : '';
+            lines.push(`  ${wireField}${opt}: ${substituteGenericParam(baselineField.type, unresolvableNames)};`);
+          } else if (
             baselineField &&
             baselineTypeResolvable(baselineField.type, importableNames) &&
             baselineFieldCompatible(baselineField, field)
@@ -1299,6 +1321,21 @@ function hasSpecificIRType(ref: TypeRef): boolean {
     default:
       return false;
   }
+}
+
+/** True when a baseline field type references one of the model's generic
+ *  param identifiers (collected as `unresolvableNames` — bare type names that
+ *  resolve to nothing importable, which for a generic model are its params). */
+function typeReferencesUnresolvable(type: string, unresolvable: Set<string>): boolean {
+  if (unresolvable.size === 0) return false;
+  const names = type.match(/\b[A-Z][a-zA-Z0-9]*\b/g);
+  return !!names && names.some((n) => unresolvable.has(n));
+}
+
+/** Rewrite a baseline field type so references to the model's (renamed)
+ *  generic param resolve to the emitted `GenericType` param. */
+function substituteGenericParam(type: string, unresolvable: Set<string>): string {
+  return type.replace(/\b[A-Z][a-zA-Z0-9]*\b/g, (name) => (unresolvable.has(name) ? 'GenericType' : name));
 }
 
 function renderTypeParams(model: Model, genericDefaults?: Map<string, string>): string {

--- a/src/node/naming.ts
+++ b/src/node/naming.ts
@@ -32,6 +32,16 @@ export function fieldName(name: string): string {
   return toCamelCase(name);
 }
 
+/**
+ * camelCase domain field name for a model field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier name. The wire name (see {@link wireFieldName}) still derives
+ * from `field.name`.
+ */
+export function domainFieldName(field: { name: string; domainName?: string }): string {
+  return toCamelCase(field.domainName ?? field.name);
+}
+
 /** snake_case field name for wire/response interfaces. */
 export function wireFieldName(name: string): string {
   return toSnakeCase(name);

--- a/src/node/options.ts
+++ b/src/node/options.ts
@@ -5,6 +5,14 @@ export interface OperationOverride {
   mountOn?: string;
   optionsType?: string;
   bodyFieldMap?: Record<string, string>;
+  /**
+   * Rename spec path parameters to the SDK options-object field they should be
+   * exposed as, keyed by the spec path-param name (e.g. `{ resourceId: 'targetId' }`).
+   * Applied to the destructure, the URL template binding, and generated tests so
+   * a published SDK field name can diverge from the spec path-param name without
+   * a global spec rewrite (which would ripple across every language).
+   */
+  pathFieldMap?: Record<string, string>;
   returnType?: string;
   returnDataProperty?: string;
   returnTypeImports?: string[];

--- a/src/node/options.ts
+++ b/src/node/options.ts
@@ -1,4 +1,5 @@
-import type { EmitterContext } from '@workos/oagen';
+import type { EmitterContext, Operation, OperationPlan } from '@workos/oagen';
+import { planOperation } from '@workos/oagen';
 
 export interface OperationOverride {
   methodName?: string;
@@ -17,6 +18,15 @@ export interface OperationOverride {
   returnDataProperty?: string;
   returnTypeImports?: string[];
   returnExpression?: string;
+  /**
+   * Override the response model the operation deserializes, by model name.
+   * Replaces the spec-derived response model so the resource (and its test)
+   * reference a different wire type / deserializer — e.g. mapping
+   * Authorization's role responses to the full `OrganizationRole` instead of
+   * the slim `Role`/`RoleResponse` shape shared with SSO and UserManagement.
+   * Node-only; never affects the global spec or other SDKs.
+   */
+  responseModel?: string;
 }
 
 export interface NodeEmitterOptions {
@@ -97,4 +107,27 @@ export function isHandOwnedType(ctx: EmitterContext, name: string | undefined): 
   const configured = nodeOptions(ctx).handOwnedTypes;
   if (!configured || configured.length === 0) return false;
   return configured.includes(name);
+}
+
+/**
+ * Resolve the Node operation override for an operation, keyed by "METHOD /path".
+ */
+export function operationOverrideFor(ctx: EmitterContext, op: Operation): OperationOverride | undefined {
+  return nodeOptions(ctx).operationOverrides?.[`${op.httpMethod.toUpperCase()} ${op.path}`];
+}
+
+/**
+ * `planOperation` plus the Node `responseModel` override. When an operation
+ * override supplies `responseModel`, the resolved response model name is
+ * replaced so the resource and its generated test reference the desired wire
+ * type and deserializer. Use this everywhere the Node emitter would otherwise
+ * call `planOperation(op)` directly so resource and test stay in lockstep.
+ */
+export function planOperationFor(op: Operation, ctx: EmitterContext): OperationPlan {
+  const plan = planOperation(op);
+  const responseModel = operationOverrideFor(ctx, op)?.responseModel;
+  if (responseModel && responseModel !== plan.responseModelName) {
+    return { ...plan, responseModelName: responseModel, isModelResponse: true };
+  }
+  return plan;
 }

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -238,8 +238,13 @@ function optionsObjectParam(method: BaselineMethod | undefined): OptionsObjectPa
   const [param] = method.params;
   if (param.name !== 'options') return undefined;
   if (param.passingStyle && param.passingStyle !== 'options_object') return undefined;
-  if (!param.type || /^(Record|object|any|unknown)\b/.test(param.type)) return undefined;
-  return { name: 'options', type: param.type, optional: param.optional === true, generated: false };
+  // An optional param's surface type is `Options | undefined`; the optionality
+  // is carried by `param.optional`, so strip the nullable arm to recover the
+  // bare type NAME (used for `serialize${type}` + imports). Leaving it in emits
+  // `serializeOptions | undefined` — a syntax error.
+  const type = param.type?.replace(/(?:\s*\|\s*(?:undefined|null))+\s*$/, '').trim();
+  if (!type || /^(Record|object|any|unknown)\b/.test(type)) return undefined;
+  return { name: 'options', type, optional: param.optional === true, generated: false };
 }
 
 function methodOptionsName(method: string, resolvedServiceName: string): string {
@@ -1041,6 +1046,10 @@ function generateResourceClass(service: Service, ctx: EmitterContext): Generated
   }
 
   const importedTypeNames = new Set<string>();
+  // `PaginationOptions` is already imported once above when any method
+  // paginates; a method whose options type IS `PaginationOptions` would
+  // otherwise re-import it here (TS2300 duplicate identifier).
+  if (needsPaginationOptionsImport) importedTypeNames.add('PaginationOptions');
   for (const optionType of optionObjectTypes) {
     if (isValidTypeIdentifier(optionType)) {
       if (importedTypeNames.has(optionType)) continue;

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -11,7 +11,7 @@ import type {
   Model,
   ResolvedOperation,
 } from '@workos/oagen';
-import { planOperation, toPascalCase, toCamelCase } from '@workos/oagen';
+import { toPascalCase, toCamelCase } from '@workos/oagen';
 import type { OperationPlan } from '@workos/oagen';
 import { mapTypeRef, isInlineEnum } from './type-map.js';
 import {
@@ -84,7 +84,7 @@ import {
 import { generateWrapperMethods, collectWrapperResponseModels } from './wrappers.js';
 import { buildNodePathExpression } from './path-expression.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
-import { isNodeOwnedService, nodeOptions } from './options.js';
+import { isNodeOwnedService, operationOverrideFor, planOperationFor } from './options.js';
 
 /**
  * Check whether the baseline (hand-written) class has a constructor compatible
@@ -200,10 +200,6 @@ function existingInterfaceBarrelExports(ctx: EmitterContext, serviceDir: string,
   }
   const escapedStem = stem.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp(`export\\s+(?:type\\s+)?(?:\\*|\\{[^}]+\\})\\s+from\\s+['"]\\./${escapedStem}['"]`).test(content);
-}
-
-function operationOverrideFor(ctx: EmitterContext, op: Operation) {
-  return nodeOptions(ctx).operationOverrides?.[`${op.httpMethod.toUpperCase()} ${op.path}`];
 }
 
 function baselineMethodFor(service: Service, method: string, ctx: EmitterContext): BaselineMethod | undefined {
@@ -568,7 +564,7 @@ function generateOptionsInterfaces(service: Service, ctx: EmitterContext, specEn
 
   const plans = service.operations.map((op) => ({
     op,
-    plan: planOperation(op),
+    plan: planOperationFor(op, ctx),
     method: resolveMethodName(op, service, ctx),
   }));
 
@@ -577,7 +573,13 @@ function generateOptionsInterfaces(service: Service, ctx: EmitterContext, specEn
     const baselineMethod = baselineMethodFor(service, method, ctx);
     const optionInfo = optionsObjectInfo(service, method, op, plan, ctx, baselineMethod, resolvedOp);
     if (!optionInfo?.generated) continue;
-    if (baselineTypeSourceFile(ctx, optionInfo.type)) continue;
+    // A baseline type of the same name normally means "hand-owned / preserved —
+    // do not regenerate" (guards the alias-feedback loop). But when the op has
+    // path params, the modernized resource folds them INTO the options object
+    // (`const { organizationId, ...payload } = options`), so a body-only
+    // baseline interface (from a legacy `(pathParam, options)` signature) is
+    // definitionally incompatible. Regenerate it to include the path params.
+    if (op.pathParams.length === 0 && baselineTypeSourceFile(ctx, optionInfo.type)) continue;
 
     const optionsName = optionInfo.type;
     const optionFileStem = `${fileName(optionsName)}.interface`;
@@ -645,9 +647,10 @@ function generateOptionsInterfaces(service: Service, ctx: EmitterContext, specEn
       headerParts.push(`  ${name}${opt}: ${type};`);
     };
 
+    const optionsPathFieldMap = operationOverrideFor(ctx, op)?.pathFieldMap;
     for (const param of op.pathParams) {
       pushField(
-        fieldName(param.name),
+        optionsPathFieldMap?.[fieldName(param.name)] ?? fieldName(param.name),
         true,
         mapParamType(param.type, specEnumNames),
         param.description,
@@ -779,7 +782,7 @@ function generateResourceClass(service: Service, ctx: EmitterContext): Generated
 
   let plans = service.operations.map((op) => ({
     op,
-    plan: planOperation(op),
+    plan: planOperationFor(op, ctx),
     method: resolveMethodName(op, service, ctx),
   }));
 
@@ -2029,13 +2032,15 @@ function resolveOptionsObjectField(
   ctx: EmitterContext,
   pathFieldMap?: Record<string, string>,
 ): string {
+  // Operation-override rename (Node-scoped) wins unconditionally: an explicit
+  // pathFieldMap is honored even when the (freshly generated) options interface
+  // isn't in the baseline surface yet — generateOptionsInterfaces applies the
+  // same map to the emitted field, so destructure and interface stay in lockstep.
+  const mapped = pathFieldMap?.[localName];
+  if (mapped) return mapped;
   const fields = ctx.apiSurface?.interfaces?.[optionType]?.fields;
   if (!fields) return localName;
   if (fields[localName]) return localName;
-  // Operation-override rename (Node-scoped): honor an explicit spec-param ->
-  // SDK-field mapping when the target field exists on the options interface.
-  const mapped = pathFieldMap?.[localName];
-  if (mapped && fields[mapped]) return mapped;
   if (localName === 'omId' && fields.organizationMembershipId) return 'organizationMembershipId';
   return localName;
 }

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -1954,7 +1954,20 @@ function renderOptionsObjectMethod(
     return true;
   }
 
-  return false;
+  // Body-less, response-less mutation with path params and/or query folded into
+  // the options object (e.g. POST /feature-flags/{slug}/targets/{targetId} -> 204).
+  // The DELETE equivalent is handled above; this covers POST/PUT/PATCH (and any
+  // other verb) that returns no content. Without this branch such operations
+  // fall through to the positional renderVoidMethod, which is inconsistent with
+  // the options-object surface the rest of an owned service uses.
+  {
+    lines.push(`  async ${method}(${renderOptionsParam(optionParam)}): Promise<void> {`);
+    renderOptionsObjectDestructure(lines, pathBindings);
+    const emptyBodyArg = httpMethodNeedsBody(op.httpMethod) ? ', {}' : '';
+    lines.push(`    await this.workos.${op.httpMethod}(${pathStr}${emptyBodyArg}${queryOptionsArg});`);
+    lines.push('  }');
+    return true;
+  }
 }
 
 function renderOptionsObjectDestructure(lines: string[], pathBindings: string[], restName?: string): void {
@@ -1988,7 +2001,8 @@ function buildOptionsObjectPathBindings(op: Operation, optionType: string, ctx: 
   // Return resolved SDK field names directly — the URL template uses these
   // names too (via the param-name map threaded into buildNodePathExpression),
   // so the destructure no longer needs `optionField: localName` renames.
-  return op.pathParams.map((param) => resolveOptionsObjectField(fieldName(param.name), optionType, ctx));
+  const pathFieldMap = operationOverrideFor(ctx, op)?.pathFieldMap;
+  return op.pathParams.map((param) => resolveOptionsObjectField(fieldName(param.name), optionType, ctx, pathFieldMap));
 }
 
 /**
@@ -2000,18 +2014,28 @@ function buildOptionsObjectPathBindings(op: Operation, optionType: string, ctx: 
  */
 function buildOptionsObjectPathParamMap(op: Operation, optionType: string, ctx: EmitterContext): Map<string, string> {
   const map = new Map<string, string>();
+  const pathFieldMap = operationOverrideFor(ctx, op)?.pathFieldMap;
   for (const param of op.pathParams) {
     const localName = fieldName(param.name);
-    const sdkField = resolveOptionsObjectField(localName, optionType, ctx);
+    const sdkField = resolveOptionsObjectField(localName, optionType, ctx, pathFieldMap);
     if (sdkField !== localName) map.set(param.name, sdkField);
   }
   return map;
 }
 
-function resolveOptionsObjectField(localName: string, optionType: string, ctx: EmitterContext): string {
+function resolveOptionsObjectField(
+  localName: string,
+  optionType: string,
+  ctx: EmitterContext,
+  pathFieldMap?: Record<string, string>,
+): string {
   const fields = ctx.apiSurface?.interfaces?.[optionType]?.fields;
   if (!fields) return localName;
   if (fields[localName]) return localName;
+  // Operation-override rename (Node-scoped): honor an explicit spec-param ->
+  // SDK-field mapping when the target field exists on the options interface.
+  const mapped = pathFieldMap?.[localName];
+  if (mapped && fields[mapped]) return mapped;
   if (localName === 'omId' && fields.organizationMembershipId) return 'organizationMembershipId';
   return localName;
 }

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -211,7 +211,7 @@ function baselineMethodFor(service: Service, method: string, ctx: EmitterContext
   return ctx.apiSurface?.classes?.[serviceClass]?.methods?.[method]?.[0] as BaselineMethod | undefined;
 }
 
-function ignoredResourceMethodNames(ctx: EmitterContext, resourcePath: string): Set<string> {
+export function ignoredResourceMethodNames(ctx: EmitterContext, resourcePath: string): Set<string> {
   const root = ctx.outputDir ?? ctx.targetDir;
   if (!root) return new Set();
 

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -1032,7 +1032,7 @@ function buildFieldAssertions(model: Model, accessor: string, modelMap?: Map<str
 
   for (const field of model.fields) {
     if (!field.required) continue;
-    const domainField = fieldName(field.name);
+    const domainField = fieldName(field.domainName ?? field.name);
     // `string` + `format: 'date-time'` is deserialized to `Date` by the
     // serializer (see `mapPrimitive` in type-map.ts). Asserting against a
     // string literal would fail Object.is — compare via `.toISOString()`.

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -10,7 +10,7 @@ import type {
   EmitterContext,
   GeneratedFile,
 } from '@workos/oagen';
-import { planOperation, toCamelCase, toPascalCase } from '@workos/oagen';
+import { toCamelCase, toPascalCase } from '@workos/oagen';
 import { unwrapListModel, ID_PREFIXES } from './fixtures.js';
 import {
   fieldName,
@@ -36,7 +36,7 @@ import {
   computeNonEventReachable,
 } from './utils.js';
 import { groupByMount, buildResolvedLookup, lookupResolved } from '../shared/resolved-ops.js';
-import { isNodeOwnedService, nodeOptions } from './options.js';
+import { isNodeOwnedService, nodeOptions, planOperationFor } from './options.js';
 
 type BaselineMethod = {
   params: Array<{ name: string; type: string; optional?: boolean; passingStyle?: string }>;
@@ -217,7 +217,7 @@ function generateServiceTest(
 
   const allPlans = service.operations.map((op) => ({
     op,
-    plan: planOperation(op),
+    plan: planOperationFor(op, ctx),
     method: resolveMethodName(op, service, ctx),
   }));
   // `plans` drives everything that becomes generated text (fixture imports,
@@ -333,6 +333,7 @@ function generateServiceTest(
   // be an unused function.
   const ignoreRegionText = existingTestIgnoreText(ctx, testPath);
   const { lines: helperLines, helpers: entityHelperNames } = generateEntityHelpers(
+    service,
     allPlans,
     plans,
     ignoreRegionText,
@@ -889,11 +890,13 @@ function resolveOptionsObjectField(
   ctx?: EmitterContext,
   pathFieldMap?: Record<string, string>,
 ): string {
+  // An explicit pathFieldMap wins unconditionally (mirrors resources.ts) so the
+  // generated test destructures the same renamed field the resource does.
+  const mapped = pathFieldMap?.[localName];
+  if (mapped) return mapped;
   const fields = ctx?.apiSurface?.interfaces?.[optionType]?.fields;
   if (!fields) return localName;
   if (fields[localName]) return localName;
-  const mapped = pathFieldMap?.[localName];
-  if (mapped && fields[mapped]) return mapped;
   if (localName === 'omId' && fields.organizationMembershipId) return 'organizationMembershipId';
   return localName;
 }
@@ -957,6 +960,7 @@ function existingTestIgnoreText(ctx: EmitterContext, relPath: string): string {
 }
 
 function generateEntityHelpers(
+  service: Service,
   allPlans: { op: Operation; plan: any; method: string }[],
   renderedPlans: { op: Operation; plan: any; method: string }[],
   ignoreRegionText: string,
@@ -991,7 +995,23 @@ function generateEntityHelpers(
   const renderedModels = new Set<string>();
   for (const entry of renderedPlans) {
     const modelName = responseModelOf(entry);
-    if (modelName) renderedModels.add(modelName);
+    if (!modelName) continue;
+    // A paginated test that skips item field assertions (baseline returns a
+    // non-paginatable type, or a different item type than the spec) never
+    // invokes the per-item entity helper — mirror renderPaginatedTest's
+    // `skipFieldAssertions` here so we don't emit a helper no call site
+    // references (TS6133). A model also reached by a non-skipped test is still
+    // added via that entry, so a genuinely-called helper is never dropped.
+    if (entry.plan.isPaginated && entry.op.pagination?.itemType.kind === 'model') {
+      const baselineMethod = optionsMethodFor(service, entry.method, entry.op, entry.plan, ctx);
+      const baselineItemType = autoPaginatableItemType(baselineMethod?.returnType);
+      const generatedItemType = resolveInterfaceName(modelName, ctx);
+      const skipFieldAssertions =
+        Boolean(baselineMethod?.returnType && !baselineItemType) ||
+        Boolean(baselineItemType && generatedItemType && baselineItemType !== generatedItemType);
+      if (skipFieldAssertions) continue;
+    }
+    renderedModels.add(modelName);
   }
 
   const lines: string[] = [];

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -829,9 +829,10 @@ function buildOptionsObjectTestArg(
   if (!optionParam) return null;
 
   const entries: string[] = [];
+  const pathFieldMap = ctx ? operationOverrideFor(ctx, op)?.pathFieldMap : undefined;
   for (const param of op.pathParams) {
     const localName = fieldName(param.name);
-    const optionField = resolveOptionsObjectField(localName, optionParam.type, ctx);
+    const optionField = resolveOptionsObjectField(localName, optionParam.type, ctx, pathFieldMap);
     entries.push(`${optionField}: ${JSON.stringify(pathParamTestValue(param, localName))}`);
   }
 
@@ -882,10 +883,17 @@ function objectLiteralEntries(literal: string): string[] {
   return body ? body.split(',').map((entry) => entry.trim()) : [];
 }
 
-function resolveOptionsObjectField(localName: string, optionType: string, ctx?: EmitterContext): string {
+function resolveOptionsObjectField(
+  localName: string,
+  optionType: string,
+  ctx?: EmitterContext,
+  pathFieldMap?: Record<string, string>,
+): string {
   const fields = ctx?.apiSurface?.interfaces?.[optionType]?.fields;
   if (!fields) return localName;
   if (fields[localName]) return localName;
+  const mapped = pathFieldMap?.[localName];
+  if (mapped && fields[mapped]) return mapped;
   if (localName === 'omId' && fields.organizationMembershipId) return 'organizationMembershipId';
   return localName;
 }

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -24,7 +24,7 @@ import {
   wireInterfaceName,
 } from './naming.js';
 import { generateFixtures } from './fixtures.js';
-import { resolveResourceClassName, resolveResourceDir } from './resources.js';
+import { resolveResourceClassName, resolveResourceDir, ignoredResourceMethodNames } from './resources.js';
 import {
   assignModelsToServices,
   createServiceDirResolver,
@@ -35,7 +35,7 @@ import {
   modelHasNewFields,
   computeNonEventReachable,
 } from './utils.js';
-import { groupByMount } from '../shared/resolved-ops.js';
+import { groupByMount, buildResolvedLookup, lookupResolved } from '../shared/resolved-ops.js';
 import { isNodeOwnedService, nodeOptions } from './options.js';
 
 type BaselineMethod = {
@@ -161,6 +161,17 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     const isOwnedService = isNodeOwnedService(ctx, mountName, resolveResourceClassName(mergedService, ctx));
     const ops = isOwnedService ? operations : uncoveredOperations(mergedService, ctx);
     if (ops.length === 0) continue;
+    // Methods hand-owned inside an `@oagen-ignore` region of the resource
+    // file: resources.ts skips generating those methods, so a generated test
+    // would reference a shape that no longer matches the preserved hand-written
+    // signature (e.g. SSO's `getAuthorizationUrl` returns a string, not
+    // `{ url }`). Their `describe` blocks are skipped below, but the ops are
+    // still passed through so entity-assertion helpers their preserved
+    // hand-written test blocks rely on continue to be emitted.
+    const ignoredMethodNames = ignoredResourceMethodNames(
+      ctx,
+      `src/${resolveResourceDir(mergedService, ctx)}/${fileName(resolveResourceClassName(mergedService, ctx))}.ts`,
+    );
 
     // Skip tests for services without a WorkOS property in the baseline
     const propName = mountAccessors.get(mountName) ?? servicePropertyName(mountName);
@@ -176,7 +187,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     if (resourceClass !== mountName) continue;
 
     const testService = ops.length < operations.length ? { ...mergedService, operations: ops } : mergedService;
-    files.push(generateServiceTest(testService, spec, ctx, modelMap, mountAccessors));
+    files.push(generateServiceTest(testService, spec, ctx, modelMap, mountAccessors, ignoredMethodNames));
   }
 
   // Generate serializer round-trip tests
@@ -194,6 +205,7 @@ function generateServiceTest(
   ctx: EmitterContext,
   modelMap: Map<string, Model>,
   mountAccessors?: Map<string, string>,
+  ignoredMethodNames: Set<string> = new Set(),
 ): GeneratedFile {
   const resolvedName = resolveResourceClassName(service, ctx);
   const serviceDir = resolveResourceDir(service, ctx);
@@ -203,11 +215,31 @@ function generateServiceTest(
   const serviceProp = mountAccessors?.get(service.name) ?? servicePropertyName(resolveServiceName(service, ctx));
   const testPath = `src/${serviceDir}/${fileName(resolvedName)}.spec.ts`;
 
-  const plans = service.operations.map((op) => ({
+  const allPlans = service.operations.map((op) => ({
     op,
     plan: planOperation(op),
     method: resolveMethodName(op, service, ctx),
   }));
+  // `plans` drives everything that becomes generated text (fixture imports,
+  // test-util imports, `describe` blocks): exclude hand-owned methods so we
+  // don't emit broken tests against their preserved signatures. `allPlans`
+  // is retained only for entity-helper counting — a hand-owned method's
+  // preserved `@oagen-ignore` test block may still rely on an
+  // `expect<Model>()` helper that the generated tests would otherwise drop.
+  //
+  // URL-builder ops (e.g. `getLogoutUrl`) return a string synchronously and
+  // make no HTTP call, so the fetch-mock test shape (`fetchMethod()` etc.)
+  // throws at runtime. Skip them — like the hand-owned URL helpers.
+  const resolvedLookup = buildResolvedLookup(ctx);
+  const preservedScopes = methodsWithPreservedTestBlocks(ctx, testPath);
+  const plans = allPlans.filter((p) => {
+    // Keep the describe when a preserved hand-written `@oagen-ignore` test
+    // block is nested under it, so it isn't orphaned out of scope.
+    if (preservedScopes.has(p.method)) return true;
+    if (ignoredMethodNames.has(p.method)) return false;
+    if (lookupResolved(p.op, resolvedLookup)?.urlBuilder) return false;
+    return true;
+  });
 
   // Sort plans to match the existing file's method order (same as resources.ts).
   if (ctx.overlayLookup?.methodByOperation) {
@@ -294,8 +326,19 @@ function generateServiceTest(
 
   // Generate per-entity assertion helpers for models used in 2+ tests.
   // This deduplicates the field assertion blocks that would otherwise be
-  // copy-pasted across list/find/create/update test cases.
-  const { lines: helperLines, helpers: entityHelperNames } = generateEntityHelpers(plans, modelMap, ctx);
+  // copy-pasted across list/find/create/update test cases. Count across
+  // `allPlans` (incl. hand-owned methods) so a helper a preserved hand test
+  // block needs survives, but only emit one that an emitted `describe` or a
+  // preserved `@oagen-ignore` block actually references — otherwise it would
+  // be an unused function.
+  const ignoreRegionText = existingTestIgnoreText(ctx, testPath);
+  const { lines: helperLines, helpers: entityHelperNames } = generateEntityHelpers(
+    allPlans,
+    plans,
+    ignoreRegionText,
+    modelMap,
+    ctx,
+  );
   for (const line of helperLines) {
     lines.push(line);
   }
@@ -325,6 +368,24 @@ function generateServiceTest(
 
   lines.push('});');
 
+  // Inject imports for real TS enums referenced as member values (e.g.
+  // `ConnectionType.ADFSSAML`). Import each from its own source file so the
+  // value's enum is the same nominal declaration the field is typed with.
+  const body = lines.join('\n');
+  const enumImportLines: string[] = [];
+  for (const [name, info] of Object.entries(ctx.apiSurface?.enums ?? {})) {
+    if (!new RegExp(`\\b${name}\\.[A-Za-z_$]`).test(body)) continue;
+    if (new RegExp(`import\\b[^;]*\\b${name}\\b[^;]*from`).test(body)) continue;
+    const sourceFile = (info as { sourceFile?: string }).sourceFile;
+    const spec = sourceFile ? relativeImport(testPath, sourceFile).replace(/\.ts$/, '') : './interfaces';
+    enumImportLines.push(`import { ${name} } from '${spec}';`);
+  }
+  if (enumImportLines.length > 0) {
+    const anchor = lines.indexOf("import { WorkOS } from '../workos';");
+    const at = anchor >= 0 ? anchor + 1 : 0;
+    lines.splice(at, 0, ...enumImportLines);
+  }
+
   return { path: testPath, content: lines.join('\n'), overwriteExisting: true };
 }
 
@@ -342,16 +403,123 @@ function pathParamTestValue(param: { type: TypeRef; name?: string } | undefined,
   return 'test_id';
 }
 
-function queryParamTestValue(param: Parameter, modelMap?: Map<string, Model>): string {
-  if (param.example !== undefined) {
-    if (Array.isArray(param.example)) {
-      return `[${param.example.map((v: unknown) => (typeof v === 'string' ? `'${v}'` : String(v))).join(', ')}]`;
+/** Render an example value as a valid TS literal expression.
+ *  Objects and nested arrays go through JSON.stringify so map-typed params
+ *  (e.g. providerQueryParams) don't coerce to the literal text `[object Object]`.
+ */
+function renderExampleLiteral(value: unknown): string {
+  if (typeof value === 'string') return `'${value}'`;
+  if (Array.isArray(value)) {
+    return `[${value.map(renderExampleLiteral).join(', ')}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/** Resolve the enum members a query-param test value must satisfy. An enum is
+ *  expressed several ways: an inline `EnumRef` with `values`, an `enum`/`model`
+ *  ref by name, or — when the IR flattened the param to a bare string but the
+ *  hand-written options interface still types the field as an enum — the
+ *  baseline options field type (e.g. `ConnectionType`). */
+/** All valid values for an enum named `name`. The extracted SDK surface is
+ *  consulted first: when an options field is typed with a hand-written enum
+ *  (e.g. `ConnectionType` from `connection-type.enum.ts`), that enum — not a
+ *  same-named IR enum that may carry extra members like `Pending` — is what
+ *  the generated test must type-check against. Falls back to the IR spec. */
+function enumValuesByName(name: string, ctx?: EmitterContext): (string | number)[] | undefined {
+  const members = ctx?.apiSurface?.enums?.[name]?.members;
+  if (members && Object.keys(members).length > 0) return Object.values(members);
+  const specValues = ctx?.spec.enums.find((e) => e.name === name)?.values;
+  if (specValues?.length) return specValues.map((v) => v.value);
+  return undefined;
+}
+
+function resolveParamEnumValues(
+  param: Parameter,
+  optionFieldType: string | undefined,
+  ctx?: EmitterContext,
+): (string | number)[] | undefined {
+  // Prefer the enum the GENERATED options field is actually typed with — the
+  // operation's own IR enum can diverge from it (e.g. the connection_type
+  // query param resolves to `ConnectionsConnectionType` whose value
+  // 'GithubOAuth' is absent from the `ConnectionType` enum the hand-written
+  // options interface uses, where the member is 'GitHubOAuth').
+  if (optionFieldType) {
+    const bare = optionFieldType
+      .replace(/\[\]/g, '')
+      .replace(/\|\s*(undefined|null)/g, '')
+      .trim();
+    if (/^[A-Za-z_$][\w$]*$/.test(bare)) {
+      const values = enumValuesByName(bare, ctx);
+      if (values) return values;
     }
+  }
+  if ((param.type.kind === 'enum' || param.type.kind === 'model') && param.type.name) {
+    const values = enumValuesByName(param.type.name, ctx);
+    if (values) return values;
+  }
+  if (param.type.kind === 'enum' && param.type.values?.length) return param.type.values;
+  return undefined;
+}
+
+/** When an options field is typed with a real (nominal) TS `enum` from the SDK
+ *  surface, a string literal won't type-check — the value must be a member
+ *  reference (`ConnectionType.ADFSSAML`). Returns the enum's name + members so
+ *  the caller can both render the reference and import the right declaration. */
+function resolveRealEnum(
+  param: Parameter,
+  optionFieldType: string | undefined,
+  ctx?: EmitterContext,
+): { name: string; members: Record<string, string | number> } | null {
+  const candidates: string[] = [];
+  if (optionFieldType) {
+    const bare = optionFieldType
+      .replace(/\[\]/g, '')
+      .replace(/\|\s*(undefined|null)/g, '')
+      .trim();
+    if (/^[A-Za-z_$][\w$]*$/.test(bare)) candidates.push(bare);
+  }
+  if ((param.type.kind === 'enum' || param.type.kind === 'model') && param.type.name) candidates.push(param.type.name);
+  for (const name of candidates) {
+    const members = ctx?.apiSurface?.enums?.[name]?.members;
+    if (members && Object.keys(members).length > 0) return { name, members };
+  }
+  return null;
+}
+
+function queryParamTestValue(
+  param: Parameter,
+  modelMap?: Map<string, Model>,
+  ctx?: EmitterContext,
+  optionFieldType?: string,
+): string {
+  // Fields typed with a real TS enum need a member reference, not a string
+  // literal (string enums are nominal). Pick the member whose value matches the
+  // example, else the first member — `enumImportsToInject` later adds the import.
+  const realEnum = resolveRealEnum(param, optionFieldType, ctx);
+  if (realEnum) {
+    const entries = Object.entries(realEnum.members);
+    const match = typeof param.example === 'string' ? entries.find(([, v]) => v === param.example) : undefined;
+    const [memberKey] = match ?? entries[0];
+    return `${realEnum.name}.${memberKey}`;
+  }
+  // Otherwise (string-literal-union enums, inline enum refs) emit a value. A
+  // spec `example` can drift from the enum (e.g. connection_type example
+  // 'GithubOAuth' vs member 'GitHubOAuth'); prefer the example only when valid.
+  const enumValues = resolveParamEnumValues(param, optionFieldType, ctx);
+  if (enumValues?.length) {
+    const valid =
+      typeof param.example === 'string' && enumValues.includes(param.example) ? param.example : enumValues[0];
+    return typeof valid === 'string' ? `'${valid}'` : String(valid);
+  }
+  if (param.example !== undefined) {
     const isDateTime = param.type.kind === 'primitive' && param.type.format === 'date-time';
     if (isDateTime && typeof param.example === 'string') {
       return `new Date('${param.example}')`;
     }
-    return typeof param.example === 'string' ? `'${param.example}'` : String(param.example);
+    return renderExampleLiteral(param.example);
   }
   return fixtureValueForType(param.type, param.name, 'Options', modelMap) ?? "'test'";
 }
@@ -677,7 +845,8 @@ function buildOptionsObjectTestArg(
   ).filter((param) => !param.deprecated);
   for (const param of queryParams) {
     const localName = fieldName(param.name);
-    const value = queryParamTestValue(param, modelMap);
+    const optionFieldType = ctx?.apiSurface?.interfaces?.[optionParam.type]?.fields?.[localName]?.type;
+    const value = queryParamTestValue(param, modelMap, ctx, optionFieldType);
     entries.push(`${localName}: ${value}`);
   }
 
@@ -729,28 +898,92 @@ function resolveOptionsObjectField(localName: string, optionType: string, ctx?: 
  * Generate per-entity assertion helper functions for models used in 2+ tests.
  * Returns { lines, helpers } where helpers is a Set of helper function names.
  */
+/** Describe-scope names (i.e. method names) that have an `@oagen-ignore` block
+ *  nested inside them in the existing test file. Such a `describe` must keep
+ *  being emitted even when the method is hand-owned — otherwise the engine has
+ *  no `describe` to re-nest the preserved block under and orphans it to the top
+ *  of the file (out of `beforeEach` scope), which hangs at runtime. Mirrors the
+ *  engine's `findContainingDescribeScope`. */
+function methodsWithPreservedTestBlocks(ctx: EmitterContext, relPath: string): Set<string> {
+  const scopes = new Set<string>();
+  const root = ctx.outputDir ?? ctx.targetDir;
+  if (!root) return scopes;
+  let content: string;
+  try {
+    content = fs.readFileSync(path.join(root, relPath), 'utf8');
+  } catch {
+    return scopes;
+  }
+  const lines = content.split('\n');
+  const indentOf = (l: string) => l.length - l.trimStart().length;
+  for (let i = 0; i < lines.length; i++) {
+    if (!lines[i].includes('@oagen-ignore-start')) continue;
+    if (/^\S/.test(lines[i])) continue; // top-level block — no enclosing describe
+    const markerIndent = indentOf(lines[i]);
+    for (let j = i - 1; j >= 0; j--) {
+      if (indentOf(lines[j]) >= markerIndent) continue;
+      const m = lines[j].match(/^\s*describe\((['"`])(.+?)\1\s*,/);
+      if (m) {
+        scopes.add(m[2]);
+        break;
+      }
+      if (/^\s*(?:export\s+)?class\s+\w+/.test(lines[j])) break;
+    }
+  }
+  return scopes;
+}
+
+/** Concatenated text of the existing test file's `@oagen-ignore` regions, so
+ *  helper generation can see which `expect<Model>()` helpers preserved
+ *  hand-written test blocks still reference. */
+function existingTestIgnoreText(ctx: EmitterContext, relPath: string): string {
+  const root = ctx.outputDir ?? ctx.targetDir;
+  if (!root) return '';
+  let content: string;
+  try {
+    content = fs.readFileSync(path.join(root, relPath), 'utf8');
+  } catch {
+    return '';
+  }
+  return [...content.matchAll(/@oagen-ignore-start[\s\S]*?@oagen-ignore-end/g)].map((m) => m[0]).join('\n');
+}
+
 function generateEntityHelpers(
-  plans: { op: Operation; plan: any; method: string }[],
+  allPlans: { op: Operation; plan: any; method: string }[],
+  renderedPlans: { op: Operation; plan: any; method: string }[],
+  ignoreRegionText: string,
   modelMap: Map<string, Model>,
   ctx: EmitterContext,
 ): { lines: string[]; helpers: Set<string> } {
-  // Count how many tests reference each response model
-  const modelUsage = new Map<string, number>();
-  for (const { op, plan } of plans) {
-    let modelName: string | null = null;
+  const responseModelOf = (entry: { op: Operation; plan: any }): string | null => {
+    const { op, plan } = entry;
     if (plan.isPaginated && op.pagination?.itemType.kind === 'model') {
-      modelName = op.pagination.itemType.name;
+      let modelName = op.pagination.itemType.name;
       const rawModel = modelMap.get(modelName);
       if (rawModel) {
         const unwrapped = unwrapListModel(rawModel, modelMap);
         if (unwrapped) modelName = unwrapped.name;
       }
-    } else if (plan.responseModelName) {
-      modelName = plan.responseModelName;
+      return modelName;
     }
-    if (modelName) {
-      modelUsage.set(modelName, (modelUsage.get(modelName) ?? 0) + 1);
-    }
+    return plan.responseModelName ?? null;
+  };
+
+  // Count how many tests reference each response model — across ALL plans so a
+  // model that a hand-owned method's preserved test block asserts on still
+  // clears the 2-use threshold.
+  const modelUsage = new Map<string, number>();
+  for (const entry of allPlans) {
+    const modelName = responseModelOf(entry);
+    if (modelName) modelUsage.set(modelName, (modelUsage.get(modelName) ?? 0) + 1);
+  }
+  // Models an emitted `describe` will actually assert on. A helper only earns
+  // its place if an emitted test references it or a preserved `@oagen-ignore`
+  // block names it — otherwise it's an unused function.
+  const renderedModels = new Set<string>();
+  for (const entry of renderedPlans) {
+    const modelName = responseModelOf(entry);
+    if (modelName) renderedModels.add(modelName);
   }
 
   const lines: string[] = [];
@@ -765,6 +998,8 @@ function generateEntityHelpers(
     const domainName = resolveInterfaceName(modelName, ctx);
     const helperName = `expect${domainName}`;
     if (helpers.has(helperName)) continue;
+    const referenced = renderedModels.has(modelName) || ignoreRegionText.includes(`${helperName}(`);
+    if (!referenced) continue;
     helpers.add(helperName);
 
     lines.push(`function ${helperName}(result: any) {`);

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -57,8 +57,11 @@ function optionsObjectParam(method: BaselineMethod | undefined): { name: string;
   const [param] = method.params;
   if (param.name !== 'options') return undefined;
   if (param.passingStyle && param.passingStyle !== 'options_object') return undefined;
-  if (!param.type || /^(Record|object|any|unknown)\b/.test(param.type)) return undefined;
-  return { name: param.name, type: param.type };
+  // Strip the `| undefined` arm of an optional param's surface type so the
+  // bare type name is used (mirrors resources.ts optionsObjectParam).
+  const type = param.type?.replace(/(?:\s*\|\s*(?:undefined|null))+\s*$/, '').trim();
+  if (!type || /^(Record|object|any|unknown)\b/.test(type)) return undefined;
+  return { name: param.name, type };
 }
 
 function configuredOptionsMethod(ctx: EmitterContext, op: Operation): BaselineMethod | undefined {

--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -1,6 +1,6 @@
 import type { Model, TypeRef, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { mapTypeRef, mapTypeRefForPHPDoc } from './type-map.js';
-import { className, enumClassName, fieldName } from './naming.js';
+import { className, enumClassName, domainFieldName } from './naming.js';
 import { phpDocComment } from './utils.js';
 
 // Import and re-export shared model detection utilities
@@ -67,7 +67,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     // Deduplicate fields that map to the same PHP name
     const seenNames = new Set<string>();
     const allFields = [...requiredFields, ...optionalFields].filter((f) => {
-      const phpName = fieldName(f.name);
+      // DOMAIN identifier: the PHP property name (honors a `domainName` override).
+      const phpName = domainFieldName(f);
       if (seenNames.has(phpName)) return false;
       seenNames.add(phpName);
       return true;
@@ -75,7 +76,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
     for (let i = 0; i < allFields.length; i++) {
       const field = allFields[i];
-      const phpName = fieldName(field.name);
+      // DOMAIN identifier: the promoted constructor property name.
+      const phpName = domainFieldName(field);
       const phpType = mapTypeRef(field.type);
       const isOptional = !field.required;
       const comma = i < allFields.length - 1 ? ',' : ',';
@@ -108,7 +110,9 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push(`        return new self(`);
     for (let i = 0; i < allFields.length; i++) {
       const field = allFields[i];
-      const phpName = fieldName(field.name);
+      // DOMAIN identifier: the named constructor argument (PHP property).
+      const phpName = domainFieldName(field);
+      // WIRE key: the JSON key read from `$data[...]` (stays `field.name`).
       const wireName = field.name;
       const comma = i < allFields.length - 1 ? ',' : ',';
       const accessor = generateFromArrayAccessor(field.type, wireName, field.required);
@@ -124,7 +128,9 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push('    {');
     lines.push('        return [');
     for (const field of allFields) {
-      const phpName = fieldName(field.name);
+      // DOMAIN identifier: the `$this->...` property being serialized.
+      const phpName = domainFieldName(field);
+      // WIRE key: the JSON key emitted into the array (stays `field.name`).
       const wireName = field.name;
       const serialized = generateToArrayValue(field.type, `$this->${phpName}`, !field.required);
       lines.push(`            '${wireName}' => ${serialized},`);

--- a/src/php/naming.ts
+++ b/src/php/naming.ts
@@ -138,6 +138,16 @@ export function fieldName(name: string): string {
   return toCamelCase(name);
 }
 
+/**
+ * camelCase DOMAIN property name for a model field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier PHP property name. The wire key (see {@link wireName}) still
+ * derives from `field.name`. No-op when `domainName` is unset.
+ */
+export function domainFieldName(field: { name: string; domainName?: string }): string {
+  return fieldName(field.domainName ?? field.name);
+}
+
 /** snake_case name for fixtures and other snake_case contexts. */
 export function snakeName(name: string): string {
   return toSnakeCase(stripUrnPrefix(name));

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -8,7 +8,14 @@ import type {
   ResolvedOperation,
 } from '@workos/oagen';
 import { planOperation, toCamelCase, toPascalCase } from '@workos/oagen';
-import { className, enumClassName, resolveMethodName, snakeName, servicePropertyName } from './naming.js';
+import {
+  className,
+  enumClassName,
+  resolveMethodName,
+  snakeName,
+  servicePropertyName,
+  domainFieldName,
+} from './naming.js';
 import { isListWrapperModel } from './models.js';
 import { generateFixtures } from './fixtures.js';
 import {
@@ -503,7 +510,9 @@ function emitFieldHydrationAssertions(
 
   for (const f of assertFields) {
     if (!f) continue;
-    const phpProp = toCamelCase(f.name);
+    // DOMAIN identifier: the deserialized model's PHP property (honors `domainName`).
+    // The fixture key `f.name` is the WIRE key and stays unchanged.
+    const phpProp = domainFieldName(f);
     lines.push(`        $this->assertSame(${fixtureVar}['${f.name}'], ${resultVar}->${phpProp});`);
   }
 }

--- a/src/python/fixtures.ts
+++ b/src/python/fixtures.ts
@@ -1,6 +1,6 @@
 import type { Model, TypeRef, Enum } from '@workos/oagen';
 
-import { fileName, fieldName } from './naming.js';
+import { fileName, domainFieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
 import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
 
@@ -104,10 +104,11 @@ export function generateModelFixture(
 ): Record<string, any> {
   const fixture: Record<string, any> = {};
 
-  // Deduplicate fields by snake_case name (matching model generation in models.ts)
+  // Deduplicate fields by DOMAIN identifier (matching model generation in
+  // models.ts, which honors `domainName`); the wire key below stays `field.name`.
   const seenFieldNames = new Set<string>();
   const deduplicatedFields = model.fields.filter((f) => {
-    const pyName = fieldName(f.name);
+    const pyName = domainFieldName(f);
     if (seenFieldNames.has(pyName)) return false;
     seenFieldNames.add(pyName);
     return true;

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -1,7 +1,7 @@
 import type { Model, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { collectFieldDependencies, walkTypeRef } from '@workos/oagen';
 import { mapTypeRef } from './type-map.js';
-import { className, fieldName, fileName, buildMountDirMap, dirToModule } from './naming.js';
+import { className, domainFieldName, fileName, buildMountDirMap, dirToModule } from './naming.js';
 import { collectGeneratedEnumSymbolsByDir } from './enums.js';
 import { computeSchemaPlacement } from './shared-schemas.js';
 
@@ -232,7 +232,9 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     // Deduplicate fields that map to the same snake_case name
     const seenFieldNames = new Set<string>();
     const deduplicatedFields = model.fields.filter((f) => {
-      const pyName = fieldName(f.name);
+      // Dedup on the DOMAIN identifier (the dataclass attribute name), which
+      // honors a `domainName` override; the wire key stays `field.name`.
+      const pyName = domainFieldName(f);
       if (seenFieldNames.has(pyName)) return false;
       seenFieldNames.add(pyName);
       return true;
@@ -343,7 +345,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     };
 
     for (const field of requiredFields) {
-      const pyFieldName = fieldName(field.name);
+      // DOMAIN identifier: the dataclass attribute name (honors `domainName`).
+      const pyFieldName = domainFieldName(field);
       const pyType = rewriteDiscriminatorType(resolveModelFieldType(field.type));
       if (field.description || field.deprecated) {
         const parts: string[] = [];
@@ -357,7 +360,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     }
 
     for (const field of optionalFields) {
-      const pyFieldName = fieldName(field.name);
+      // DOMAIN identifier: the dataclass attribute name (honors `domainName`).
+      const pyFieldName = domainFieldName(field);
       const innerType =
         field.type.kind === 'nullable' ? resolveModelFieldType(field.type.inner) : resolveModelFieldType(field.type);
       const pyType = `Optional[${rewriteDiscriminatorType(innerType)}]`;
@@ -383,7 +387,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     const fieldAssignmentLines: string[] = [];
 
     for (const field of [...requiredFields, ...optionalFields]) {
-      const pyFieldName = fieldName(field.name);
+      // DOMAIN identifier (LHS of `cls(...)`); the wire key below stays `field.name`.
+      const pyFieldName = domainFieldName(field);
       const wireKey = field.name; // Wire keys are snake_case from the spec
       const isRequired = !isOptionalField(model.name, field, ctx);
 
@@ -424,7 +429,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push('        result: Dict[str, Any] = {}');
 
     for (const field of [...requiredFields, ...optionalFields]) {
-      const pyFieldName = fieldName(field.name);
+      // DOMAIN identifier (`self.<attr>`); the wire key below stays `field.name`.
+      const pyFieldName = domainFieldName(field);
       const wireKey = field.name;
       const isRequired = !isOptionalField(model.name, field, ctx);
 

--- a/src/python/naming.ts
+++ b/src/python/naming.ts
@@ -51,6 +51,16 @@ export function fieldName(name: string): string {
 }
 
 /**
+ * snake_case domain field name for a model field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier name. The wire name (still derived from `field.name`) is
+ * unaffected, so the API contract is preserved.
+ */
+export function domainFieldName(field: { name: string; domainName?: string }): string {
+  return toSnakeCase(field.domainName ?? field.name);
+}
+
+/**
  * Python builtins that should not be shadowed by parameter names.
  * When a path/query param name collides, suffix with underscore.
  */

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -13,6 +13,7 @@ import {
   className,
   fileName,
   fieldName,
+  domainFieldName,
   moduleName,
   resolveMethodName,
   buildMountDirMap,
@@ -1026,12 +1027,13 @@ function pickAssertableFields(
       // Skip strings containing characters that are hard to represent as Python literals
       if (val.includes('"') || val.includes("'") || val.includes('{') || val.includes('\\') || val.includes('\n'))
         continue;
-      results.push({ field: fieldName(f.name), value: `"${val}"` });
+      // DOMAIN identifier: asserted as `result.<attr>` (honors `domainName`).
+      results.push({ field: domainFieldName(f), value: `"${val}"` });
     } else if (typeof val === 'boolean') {
       // Use "is True/False" to satisfy ruff E712
-      results.push({ field: fieldName(f.name), value: val ? 'True' : 'False', isBool: true });
+      results.push({ field: domainFieldName(f), value: val ? 'True' : 'False', isBool: true });
     } else if (typeof val === 'number') {
-      results.push({ field: fieldName(f.name), value: String(val) });
+      results.push({ field: domainFieldName(f), value: String(val) });
     }
   }
   return results;
@@ -1114,7 +1116,9 @@ function buildTestArgs(op: Operation, spec: ApiSpec, hiddenParams?: Set<string>)
       if (plan.hasBody && op.requestBody?.kind === 'model') {
         const rbName = op.requestBody.name;
         const bodyModel = spec.models.find((m) => m.name === rbName);
-        if (bodyModel?.fields.some((f) => fieldName(f.name) === fieldName(param.name))) continue;
+        // Compare the body field's DOMAIN identifier (honors `domainName`)
+        // against the param kwarg name; the param has no domainName override.
+        if (bodyModel?.fields.some((f) => domainFieldName(f) === fieldName(param.name))) continue;
       }
       if (param.required && !pathParamNames.has(fieldName(param.name))) {
         args.push(`${fieldName(param.name)}=${generateTestValue(param.type, param.name)}`);
@@ -1511,10 +1515,11 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
     // don't have a to_dict() and their round-trip semantics differ.
     if (model.fields.length === 0) continue;
     if ((model as any).discriminator) continue;
-    // Deduplicate fields that map to the same snake_case name (mirrors models.ts)
+    // Deduplicate fields by DOMAIN identifier (mirrors models.ts, which honors
+    // `domainName`); the wire key stays `field.name`.
     const seenFieldNames = new Set<string>();
     const dedupFields = model.fields.filter((f) => {
-      const pyName = fieldName(f.name);
+      const pyName = domainFieldName(f);
       if (seenFieldNames.has(pyName)) return false;
       seenFieldNames.add(pyName);
       return true;

--- a/src/ruby/models.ts
+++ b/src/ruby/models.ts
@@ -1,6 +1,6 @@
 import type { Model, EmitterContext, GeneratedFile, TypeRef, Field } from '@workos/oagen';
 import { walkTypeRef, assignModelsToServices } from '@workos/oagen';
-import { className, fieldName, fileName, buildMountDirMap } from './naming.js';
+import { className, domainFieldName, fileName, buildMountDirMap } from './naming.js';
 import {
   isListWrapperModel,
   isListMetadataModel,
@@ -131,7 +131,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     // Deduplicate field names that collide after snake_case.
     const seenFieldNames = new Set<string>();
     const fields = model.fields.filter((f) => {
-      const n = fieldName(f.name);
+      // Dedup on the DOMAIN accessor name (honors fieldHints override).
+      const n = domainFieldName(f);
       if (seenFieldNames.has(n)) return false;
       seenFieldNames.add(n);
       return true;
@@ -151,7 +152,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push('    HASH_ATTRS = {');
     for (let i = 0; i < fields.length; i++) {
       const field = fields[i];
-      const fname = fieldName(field.name);
+      // DOMAIN attr symbol (honors fieldHints); the key below is the WIRE name.
+      const fname = domainFieldName(field);
       const sep = i === fields.length - 1 ? '' : ',';
       lines.push(`      ${rubyHashLiteralKey(field.name)} :${fname}${sep}`);
     }
@@ -162,14 +164,14 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     if (deprecatedFields.length > 0) {
       for (const f of deprecatedFields) {
         const desc = f.description ? ` ${f.description.split('\n')[0].trim()}` : '';
-        lines.push(`    # @!attribute ${fieldName(f.name)}`);
+        lines.push(`    # @!attribute ${domainFieldName(f)}`);
         lines.push(`    #   @deprecated${desc}`);
       }
       lines.push('');
     }
 
     if (accessorFields.length > 0) {
-      const attrs = accessorFields.map((f) => `:${fieldName(f.name)}`);
+      const attrs = accessorFields.map((f) => `:${domainFieldName(f)}`);
       if (attrs.length === 1) {
         lines.push(`    attr_accessor ${attrs[0]}`);
       } else {
@@ -184,7 +186,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
     // Emit deprecated field accessors with runtime warnings.
     for (const f of deprecatedFields) {
-      const fname = fieldName(f.name);
+      const fname = domainFieldName(f);
       lines.push(`    def ${fname}`);
       lines.push(
         `      warn "[DEPRECATION] \\\`${fname}\\\` is deprecated and will be removed in a future version.", uplevel: 1`,
@@ -202,7 +204,8 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push('    def initialize(json)');
     lines.push('      hash = self.class.normalize(json)');
     for (const field of fields) {
-      const fname = fieldName(field.name);
+      // DOMAIN ivar name (honors fieldHints); rawKey is the WIRE key read from the hash.
+      const fname = domainFieldName(field);
       const rawKey = field.name;
       lines.push(`      ${deserializeAssignment(fname, rawKey, field.type, field.required, enumNames, modelNames)}`);
     }

--- a/src/ruby/naming.ts
+++ b/src/ruby/naming.ts
@@ -58,6 +58,16 @@ export function fieldName(name: string): string {
 }
 
 /**
+ * snake_case domain field name for a model field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier name. The wire key (still derived from `field.name`) is what
+ * gets sent/received over the wire — only the domain attr/accessor name changes.
+ */
+export function domainFieldName(field: { name: string; domainName?: string }): string {
+  return toSnakeCase(field.domainName ?? field.name);
+}
+
+/**
  * Ruby reserved words that cannot be used as parameter names.
  * When a path/query param name collides, suffix with underscore.
  */

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -3,6 +3,7 @@ import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
 import {
   className,
   fieldName,
+  domainFieldName,
   fileName,
   safeParamName,
   scopedGroupVariantClassName,
@@ -92,7 +93,8 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
     // Field accessors
     const seenFieldNames = new Set<string>();
     for (const f of model.fields) {
-      const fname = fieldName(f.name);
+      // DOMAIN accessor name in the .rbi (honors fieldHints override).
+      const fname = domainFieldName(f);
       if (seenFieldNames.has(fname)) continue;
       seenFieldNames.add(fname);
       const sorbetType = f.required ? mapSorbetType(f.type) : wrapNilable(mapSorbetType(f.type));

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -3,6 +3,7 @@ import {
   className,
   fileName,
   fieldName,
+  domainFieldName,
   safeParamName,
   scopedGroupVariantClassName,
   servicePropertyName,
@@ -235,7 +236,9 @@ function generateModelRoundTripTest(spec: ApiSpec): GeneratedFile {
     const dedupFields = new Set<string>();
     for (const f of model.fields) {
       const wireName = f.name;
-      const rubyFieldName = fieldName(f.name);
+      // Dedup on the DOMAIN accessor name to mirror the model's field dedup
+      // (models.ts). The fixture/assertion keys below still use the WIRE name.
+      const rubyFieldName = domainFieldName(f);
       if (dedupFields.has(rubyFieldName)) continue;
       dedupFields.add(rubyFieldName);
       const stub = roundTripStub(f.type, enumNames);

--- a/src/rust/models.ts
+++ b/src/rust/models.ts
@@ -1,5 +1,5 @@
 import type { Model, EmitterContext, GeneratedFile, Field, TypeRef } from '@workos/oagen';
-import { typeName, fieldName, moduleName } from './naming.js';
+import { typeName, domainFieldName, moduleName } from './naming.js';
 import { mapTypeRef, makeOptional, UnionRegistry } from './type-map.js';
 import { applySecretRedaction } from './secret.js';
 
@@ -132,17 +132,20 @@ function renderModel(model: Model, registry: UnionRegistry, tagField?: string): 
 }
 
 /**
- * Resolve unique Rust identifiers for struct fields. Multiple wire names can
- * collide after `fieldName()` snake-cases them (e.g. `integration_type` and
- * `integrationType` both become `integration_type`). Subsequent collisions get
- * a numeric suffix so the struct compiles; serde `rename` preserves the
- * original wire name in every case.
+ * Resolve unique Rust identifiers for struct fields. The domain identifier
+ * honors a `fieldHints` override (`domainName`, e.g. wire `connection_type` →
+ * domain `type`); the wire name (and the `#[serde(rename = ...)]` key emitted
+ * in `renderField`) still derives from `f.name`. Multiple names can collide
+ * after snake-casing (e.g. `integration_type` and `integrationType` both
+ * become `integration_type`). Subsequent collisions get a numeric suffix so
+ * the struct compiles; serde `rename` preserves the original wire name in every
+ * case.
  */
 function resolveFieldNames(fields: Field[]): string[] {
   const used = new Set<string>();
   const out: string[] = [];
   for (const f of fields) {
-    const base = fieldName(f.name);
+    const base = domainFieldName(f);
     let candidate = base;
     let suffix = 2;
     while (used.has(candidate)) {

--- a/src/rust/models.ts
+++ b/src/rust/models.ts
@@ -1,4 +1,4 @@
-import type { Model, EmitterContext, GeneratedFile, Field } from '@workos/oagen';
+import type { Model, EmitterContext, GeneratedFile, Field, TypeRef } from '@workos/oagen';
 import { typeName, fieldName, moduleName } from './naming.js';
 import { mapTypeRef, makeOptional, UnionRegistry } from './type-map.js';
 import { applySecretRedaction } from './secret.js';
@@ -18,6 +18,13 @@ export function generateModels(models: Model[], ctx: EmitterContext, registry: U
   const moduleNames: string[] = [];
   const seen = new Set<string>();
 
+  // Map of variant-model name -> discriminator wire-property for every model
+  // that appears as an arm of an internally-tagged (`#[serde(tag = ...)]`)
+  // union. serde consumes that property as the enum tag and strips it from the
+  // variant body during deserialization, so a *required* field of the same
+  // name can never be satisfied ("missing field `type`"). See renderField.
+  const taggedVariantFields = collectTaggedVariantFields(models);
+
   for (const model of models) {
     // Empty-field, non-discriminator models still need to be emitted as an
     // empty struct so request bodies that reference them (e.g. an empty
@@ -29,7 +36,11 @@ export function generateModels(models: Model[], ctx: EmitterContext, registry: U
 
     const hintPath = ctx.overlayLookup?.fileBySymbol?.get(model.name);
     const path = hintPath ?? `src/models/${mod}.rs`;
-    files.push({ path, content: renderModel(model, registry), overwriteExisting: true });
+    files.push({
+      path,
+      content: renderModel(model, registry, taggedVariantFields.get(model.name)),
+      overwriteExisting: true,
+    });
   }
 
   // Always include the unions module in the barrel so downstream stages
@@ -47,7 +58,48 @@ export function generateModels(models: Model[], ctx: EmitterContext, registry: U
   return files;
 }
 
-function renderModel(model: Model, registry: UnionRegistry): string {
+/**
+ * Walk every model field and record which models are arms of an
+ * internally-tagged union, mapped to that union's discriminator property.
+ */
+function collectTaggedVariantFields(models: Model[]): Map<string, string> {
+  const out = new Map<string, string>();
+  const visit = (ref: TypeRef): void => {
+    switch (ref.kind) {
+      case 'union':
+        if (ref.discriminator?.property) {
+          for (const variant of ref.variants) {
+            const name = variantModelName(variant);
+            if (name) out.set(name, ref.discriminator.property);
+          }
+        }
+        ref.variants.forEach(visit);
+        break;
+      case 'array':
+        visit(ref.items);
+        break;
+      case 'nullable':
+        visit(ref.inner);
+        break;
+      case 'map':
+        visit(ref.valueType);
+        break;
+      default:
+        break;
+    }
+  };
+  for (const model of models) for (const field of model.fields) visit(field.type);
+  return out;
+}
+
+/** Resolve the underlying model name of a union arm, unwrapping a nullable. */
+function variantModelName(ref: TypeRef): string | null {
+  if (ref.kind === 'model') return ref.name;
+  if (ref.kind === 'nullable') return variantModelName(ref.inner);
+  return null;
+}
+
+function renderModel(model: Model, registry: UnionRegistry, tagField?: string): string {
   const lines: string[] = [];
   lines.push(HEADER_PLACEHOLDER);
   // Match rustfmt's canonical grouping: keyword-rooted paths (`super`,
@@ -65,7 +117,7 @@ function renderModel(model: Model, registry: UnionRegistry): string {
   lines.push('#[derive(Debug, Clone, Serialize, Deserialize)]');
 
   const resolvedNames = resolveFieldNames(model.fields);
-  const fieldLines = model.fields.map((f, i) => renderField(f, resolvedNames[i]!, model.name, registry));
+  const fieldLines = model.fields.map((f, i) => renderField(f, resolvedNames[i]!, model.name, registry, tagField));
 
   // rustfmt collapses zero-field structs to `pub struct Foo {}` on a single
   // line. Match that shape so `cargo fmt --check` passes.
@@ -103,7 +155,13 @@ function resolveFieldNames(fields: Field[]): string[] {
   return out;
 }
 
-function renderField(field: Field, rustField: string, modelName: string, registry: UnionRegistry): string {
+function renderField(
+  field: Field,
+  rustField: string,
+  modelName: string,
+  registry: UnionRegistry,
+  tagField?: string,
+): string {
   const lines: string[] = [];
   const hasDescription = !!field.description;
   if (hasDescription) {
@@ -128,9 +186,20 @@ function renderField(field: Field, rustField: string, modelName: string, registr
   // the value is a credential or token. Wire format is unchanged.
   baseType = applySecretRedaction(baseType, field.name);
 
-  if (rename) lines.push(`    #[serde(rename = "${rename}")]`);
-  if (baseType.startsWith('Option<')) {
-    lines.push('    #[serde(skip_serializing_if = "Option::is_none", default)]');
+  if (tagField === field.name) {
+    // This field is the discriminator of an internally-tagged union it belongs
+    // to. serde reads it as the enum tag and strips it from the variant body,
+    // so `default` lets the struct deserialize without it; `skip_serializing`
+    // stops the struct from re-emitting it (serde injects the tag itself,
+    // which would otherwise produce a duplicate key). Standalone uses of the
+    // struct still deserialize the value normally because the key is present.
+    const args = rename ? `rename = "${rename}", default, skip_serializing` : 'default, skip_serializing';
+    lines.push(`    #[serde(${args})]`);
+  } else {
+    if (rename) lines.push(`    #[serde(rename = "${rename}")]`);
+    if (baseType.startsWith('Option<')) {
+      lines.push('    #[serde(skip_serializing_if = "Option::is_none", default)]');
+    }
   }
   if (field.deprecated) lines.push('    #[deprecated]');
   lines.push(`    pub ${rustField}: ${baseType},`);

--- a/src/rust/naming.ts
+++ b/src/rust/naming.ts
@@ -77,6 +77,16 @@ export function fieldName(name: string): string {
   return escapeKeyword(toSnakeCase(name));
 }
 
+/**
+ * snake_case domain field name for a model field, honoring a `domainName`
+ * override (set via the `fieldHints` config) so a wire field can surface under
+ * a friendlier identifier. The wire name (and thus the `#[serde(rename = ...)]`
+ * key) still derives from `field.name`.
+ */
+export function domainFieldName(field: { name: string; domainName?: string }): string {
+  return escapeKeyword(toSnakeCase(field.domainName ?? field.name));
+}
+
 /** PascalCase enum variant. */
 export function variantName(value: string | number): string {
   const s = String(value);

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -10,7 +10,7 @@ import type {
   TypeRef,
 } from '@workos/oagen';
 import { planOperation } from '@workos/oagen';
-import { fieldName, methodName, typeName, moduleName, variantName } from './naming.js';
+import { fieldName, domainFieldName, methodName, typeName, moduleName, variantName } from './naming.js';
 import { mapTypeRef, makeOptional, UnionRegistry } from './type-map.js';
 import { applySecretRedaction } from './secret.js';
 import { parsePathTemplate } from '../shared/path-template.js';
@@ -617,7 +617,11 @@ function registerSyntheticBody(
       if (!f.required && !rust.startsWith('Option<')) rust = makeOptional(rust);
       rust = applySecretRedaction(rust, f.name);
       return {
-        rustName: fieldName(f.name),
+        // Domain identifier honors a `fieldHints` override (e.g. wire
+        // `connection_type` → domain `type`); `wireName` keeps `f.name`, and
+        // the `#[serde(rename = wireName)]` emitted in GroupEmitter.render
+        // fires whenever the two differ.
+        rustName: domainFieldName(f),
         wireName: f.name,
         rustType: rust,
         required: !!f.required && !rust.startsWith('Option<'),

--- a/test/rust/models.test.ts
+++ b/test/rust/models.test.ts
@@ -119,6 +119,55 @@ describe('rust/models', () => {
     expect(unions.content).toContain('pub enum EventPayloadOneOf {');
   });
 
+  it('relaxes the discriminator field on internally-tagged union variants', () => {
+    // Mirrors the ApiKey `owner` union: serde's `#[serde(tag = "type")]`
+    // consumes `type` as the enum tag and strips it from the variant body, so
+    // a *required* `type` field on the variant struct can never be satisfied
+    // ("missing field `type`"). The emitter must mark it default+skip_serializing.
+    const owner = (name: string, extra: Model['fields'] = []): Model => ({
+      name,
+      fields: [
+        { name: 'type', type: { kind: 'primitive', type: 'string' }, required: true },
+        { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+        ...extra,
+      ],
+    });
+    const models: Model[] = [
+      {
+        name: 'ApiKey',
+        fields: [
+          {
+            name: 'owner',
+            type: {
+              kind: 'union',
+              variants: [
+                { kind: 'model', name: 'ApiKeyOwner' },
+                { kind: 'model', name: 'UserApiKeyOwner' },
+              ],
+              discriminator: {
+                property: 'type',
+                mapping: { organization: 'ApiKeyOwner', user: 'UserApiKeyOwner' },
+              },
+            },
+            required: true,
+          },
+        ],
+      },
+      owner('ApiKeyOwner'),
+      owner('UserApiKeyOwner', [
+        { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+      ]),
+    ];
+    const files = generateModels(models, ctx, new UnionRegistry());
+    for (const mod of ['api_key_owner', 'user_api_key_owner']) {
+      const f = files.find((x) => x.path === `src/models/${mod}.rs`)!;
+      expect(f.content).toContain('#[serde(rename = "type", default, skip_serializing)]');
+      expect(f.content).toContain('pub type_: String,');
+      // The non-discriminator field is untouched.
+      expect(f.content).toContain('pub id: String,');
+    }
+  });
+
   it('documents Field.default as a "Defaults to" doc comment', () => {
     const models: Model[] = [
       {


### PR DESCRIPTION
## Summary
- **Cross-emitter `Field.domainName`** — extends the domainName/fieldHints override (previously Node-only) to every emitter (Python, Go, Ruby, Kotlin, PHP, Rust, .NET). Each derives the domain-facing identifier from `domainName ?? name`; wire/serialization keys still derive from `field.name`, so e.g. Connection exposes `type` in the domain while serializing `connection_type`. No-op when domainName is unset.
- **Node owned-service support** — fixes emitter gaps surfaced while owning the Authorization, FeatureFlags, and SSO services: options-object void mutations (body-less path-param POST/PUT/PATCH now match the options-object surface), a Node-scoped `pathFieldMap` override to rename path params without a global spec rewrite, per-op `responseModel` remapping, and stable options-type names across regenerations.
- **Node test-emitter correctness** — render object/array examples as real TS literals, skip describe blocks for `@oagen-ignore`/urlBuilder methods while preserving nested hand-written blocks, resolve enum-typed query params to valid members, and only emit referenced entity-assertion helpers.
- **Rust tagged-union discriminator** — mark the discriminator field on internally-tagged variant structs as `default, skip_serializing` so variants whose body also declares the tag (e.g. API key `owner`) deserialize without "missing field \`type\`" (refs workos/workos-rust#108).

## Test plan
- [ ] \`script/ci\` passes in oagen-emitters (build + unit tests, incl. new test/rust/models.test.ts)
- [ ] Regenerate workos-node; owned Authorization/FeatureFlags/SSO modules type-check and their tests pass
- [ ] Regenerate python/go/ruby/kotlin/php/rust/dotnet; domainName changes are no-ops where unset, correct where set
- [ ] workos-rust API key responses deserialize (owner union)