### PR TITLE
feat(emitters): scope per-service emission for `--services` (all 8 emitters)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.18.4",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.22.7"
+        "@workos/oagen": "^0.23.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
         "@commitlint/config-conventional": "^21.0.2",
         "@types/node": "^26.0.0",
         "husky": "^9.1.7",
-        "oxfmt": "^0.55.0",
-        "oxlint": "^1.70.0",
+        "oxfmt": "^0.56.0",
+        "oxlint": "^1.71.0",
         "prettier": "^3.8.4",
         "tsdown": "^0.22.3",
         "tsx": "^4.22.4",
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.55.0.tgz",
-      "integrity": "sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.56.0.tgz",
+      "integrity": "sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA==",
       "cpu": [
         "arm"
       ],
@@ -943,9 +943,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.55.0.tgz",
-      "integrity": "sha512-ctulLq8s3x8Zmvw6+iccB09TIKERAklRSmbJ10gk8mlAn05qZxoyo52dj3Hi9IJcmDSwF54fQaTVh2CbL6PInw==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.56.0.tgz",
+      "integrity": "sha512-HYJFnd+PkDwf6S9ZPGzXXtjNqvRWFnnhdbWaouh4mi/SxU8wmDuzlMn3xo/wDTGnr4Q1VA7ZzOaE/D4biW0W6A==",
       "cpu": [
         "arm64"
       ],
@@ -960,9 +960,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.55.0.tgz",
-      "integrity": "sha512-xDQczLH9pw/RBk1h/GH0qcGMm8hQtmtVHBNLSH3lk1gEIR09hZ4L+mJQl4VqiVAvPK9VG9PYrWWuSQLt7xTbiA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.56.0.tgz",
+      "integrity": "sha512-sftR/bEOr+t1gs+evwsHi/Xbq2FAPA2uU3VMr8n6ZU9PoK/IMSfnfu7+OEe/uy1+knhrFl4Wvy7Vkm3uo9mJ7g==",
       "cpu": [
         "arm64"
       ],
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.55.0.tgz",
-      "integrity": "sha512-JaNoFCkF2CJdGgpPSMbuO9HVyXyoNGIhMHPvp6NYAjeVKw9XEYc0HcUWJLPQa3Q69WV5wMa9m5jPMJPtbLtcRg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.56.0.tgz",
+      "integrity": "sha512-z66SdjLqa3MUPKvTp3Mbb5nSjKSbnYxJGeB+Wx987s8T5hPcIRiBMfnJ6zcPgYtQn3x5xjvdzNVkXrSeYH6ZFg==",
       "cpu": [
         "x64"
       ],
@@ -994,9 +994,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.55.0.tgz",
-      "integrity": "sha512-DNbszhpg6S2MIzax5azdHFTTBIVkR5xr8yyRZuA4yoDAwOkzIp3tmldgKZM2+VlT+hJIG0xUksA+elISzMEAfA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.56.0.tgz",
+      "integrity": "sha512-t2tkrV1vtZyaItSQ71dTi2ZVKZEI39b/LqLT12V5KMfIeXK6N32TUC1jhOXKVQmhECq9j2ZXMQV3JeT1kh9Vmg==",
       "cpu": [
         "x64"
       ],
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.55.0.tgz",
-      "integrity": "sha512-2snoaoRfFFyGnbOcKUK36rREBYxe/Xgz3uHbiA5zbCB/s6R4DQj4mHqYAaWWhgizCUSDxV8cE9zAZ0XleNpKGw==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.56.0.tgz",
+      "integrity": "sha512-+gCy+Tp3RHeXQ9y/QrS76lXIpZkbziTyp6hIgjB2MssCwfMph3vG/GEfkhO34Rai1vhYIaUkvv8UT1BcDorJPw==",
       "cpu": [
         "arm"
       ],
@@ -1028,9 +1028,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.55.0.tgz",
-      "integrity": "sha512-q1aktHF/WRpSK81BX1dE/9vWrS2jGw1Nax2kb4DBLGAewubCLcoNyp4Zl/NSMgbv3vUS46Z33wIQkBVYOP3PYg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.56.0.tgz",
+      "integrity": "sha512-0kKkVvQ2I+FJ2sxQyUu1zJ0yWP5kcWse/yVFnGQSFCXMwSSkfEaUGu0dW774O7nyy3jrcBGap7OSc8dZmU/CdA==",
       "cpu": [
         "arm"
       ],
@@ -1045,9 +1045,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.55.0.tgz",
-      "integrity": "sha512-VD0y36aENezl/3tsclA/4G53Cc7iV+7Uoh7gz4yvcOTaEYBtJpQsE6PKDGTtUtOvGS4kv51ybfXY/nWZejO5IA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.56.0.tgz",
+      "integrity": "sha512-npkA2siMbyWRh+wEhi1aTAx4RirukGcGNt8V4Ch86pG+xU9aurqS1MZOnKYMu03ISwat3rB6zkQx51SsB9obNw==",
       "cpu": [
         "arm64"
       ],
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.55.0.tgz",
-      "integrity": "sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.56.0.tgz",
+      "integrity": "sha512-UekqOjGkV4/MkqreCV9SPIB2jlR3/HbXrmhV1rVXJZ9wfDXMyCMriLtq3tHqLY4PkbVWNtfcm1kMojJ26KLSJw==",
       "cpu": [
         "arm64"
       ],
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.55.0.tgz",
-      "integrity": "sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.56.0.tgz",
+      "integrity": "sha512-XSzveSpeZMD5XJpew5lRFVtNnT04xd3rJxENXmk7wkZzN9oWzv2aFJyoNDhOtoz69BYaS/fg4SYl+CfEZRpB0Q==",
       "cpu": [
         "ppc64"
       ],
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.55.0.tgz",
-      "integrity": "sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.56.0.tgz",
+      "integrity": "sha512-EkQ0nJa7k7HDDIVuPF7WY+k4k+bzdclLYtyIXNt7/OqVghfNiMym6YGppFBgx1XRIHW6QylxBz5OogumPjPJbQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1125,9 +1125,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.55.0.tgz",
-      "integrity": "sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.56.0.tgz",
+      "integrity": "sha512-dyjAGW8jKRge0ik6U/dgvQG0nVpA3iBlRskQTz5qJLvQWIrySxX5jpqzPetLBNIIZ231KA82fDdi1nLTk8ENCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1145,9 +1145,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.55.0.tgz",
-      "integrity": "sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.56.0.tgz",
+      "integrity": "sha512-60ZGH3LtfqlW8X6vcLdSFY4lvCQYINurttYBKaALnHCDVAUCYJ1LsUgS6p1XOzVlzEDx3yNUZvDF1Lvt59zoZw==",
       "cpu": [
         "s390x"
       ],
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.55.0.tgz",
-      "integrity": "sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.56.0.tgz",
+      "integrity": "sha512-u1suj1tgJHK4ZqB7buCtdbNef2n8+d0lXTPJwLHNmtyK6p+DTpsaoDvmqhQrA56fgKYv4LuRxNtL8YooebKOew==",
       "cpu": [
         "x64"
       ],
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.55.0.tgz",
-      "integrity": "sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.56.0.tgz",
+      "integrity": "sha512-aYGLvlQHt80y+qKEtfJY/Nm27G0125Lv+qyh9SJ4Cjc6lXnXjD+ndfhqQnbV24POpMi7rNRi0jvx/0d70FRpCQ==",
       "cpu": [
         "x64"
       ],
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.55.0.tgz",
-      "integrity": "sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.56.0.tgz",
+      "integrity": "sha512-H/re/gO+7ysVc+kywHNuzY3C33EN9sQcZhg0kp1ZwOZl7y998ZE5mhnBiuGR/nYI0pqLL5xQfrHVUOJ/cIJsCA==",
       "cpu": [
         "arm64"
       ],
@@ -1222,9 +1222,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.55.0.tgz",
-      "integrity": "sha512-7p9FB5R32tw2KyyNX3wpQrR2WHwEHvMEiBlGXxeTCaRMCVNx3UtFMAUbaQ/pRNWIrEUZmYhJ6tcUH52uPTRYjQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.56.0.tgz",
+      "integrity": "sha512-6qLNXfXmtAs8jXDvYMkxk6Wec5SUJoew+ZX1uOZmqaR7ks0EJFbAohuOCELDyJMWyVlxotVG8Xf8m74Bfq0O2w==",
       "cpu": [
         "arm64"
       ],
@@ -1239,9 +1239,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.55.0.tgz",
-      "integrity": "sha512-ZYqj3fDnOT1IaVGMP5kpmkQl4F3tQIm2ZyAxvqkJYmI0xgWWak4ss4XYwv3VDfM+TWXeC9K4uQ/wW5jm/5XABA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.56.0.tgz",
+      "integrity": "sha512-UXEXuKphAe15bsob4AswNMArCw38XSmUIs3wk1s6e6MX9OWGW/IRWU95s1hZDiVg09STy1jHgyN2qkqbu1FT0w==",
       "cpu": [
         "ia32"
       ],
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.55.0.tgz",
-      "integrity": "sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.56.0.tgz",
+      "integrity": "sha512-HPyNDjky+NIOuaMvHZflR+kst3YWdUOH2JUQYkf99grqZ5mEBTQM6h9iGy501Z8Xt5xMScrwHOuVCOlqDrktRw==",
       "cpu": [
         "x64"
       ],
@@ -1273,9 +1273,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.70.0.tgz",
-      "integrity": "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.71.0.tgz",
+      "integrity": "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==",
       "cpu": [
         "arm"
       ],
@@ -1290,9 +1290,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.70.0.tgz",
-      "integrity": "sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.71.0.tgz",
+      "integrity": "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==",
       "cpu": [
         "arm64"
       ],
@@ -1307,9 +1307,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.70.0.tgz",
-      "integrity": "sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.71.0.tgz",
+      "integrity": "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.70.0.tgz",
-      "integrity": "sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.71.0.tgz",
+      "integrity": "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==",
       "cpu": [
         "x64"
       ],
@@ -1341,9 +1341,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.70.0.tgz",
-      "integrity": "sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.71.0.tgz",
+      "integrity": "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==",
       "cpu": [
         "x64"
       ],
@@ -1358,9 +1358,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.70.0.tgz",
-      "integrity": "sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.71.0.tgz",
+      "integrity": "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==",
       "cpu": [
         "arm"
       ],
@@ -1375,9 +1375,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.70.0.tgz",
-      "integrity": "sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.71.0.tgz",
+      "integrity": "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==",
       "cpu": [
         "arm"
       ],
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.70.0.tgz",
-      "integrity": "sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.71.0.tgz",
+      "integrity": "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==",
       "cpu": [
         "arm64"
       ],
@@ -1412,9 +1412,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.70.0.tgz",
-      "integrity": "sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.71.0.tgz",
+      "integrity": "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==",
       "cpu": [
         "arm64"
       ],
@@ -1432,9 +1432,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.70.0.tgz",
-      "integrity": "sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.71.0.tgz",
+      "integrity": "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==",
       "cpu": [
         "ppc64"
       ],
@@ -1452,9 +1452,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.70.0.tgz",
-      "integrity": "sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.71.0.tgz",
+      "integrity": "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==",
       "cpu": [
         "riscv64"
       ],
@@ -1472,9 +1472,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.70.0.tgz",
-      "integrity": "sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.71.0.tgz",
+      "integrity": "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==",
       "cpu": [
         "riscv64"
       ],
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.70.0.tgz",
-      "integrity": "sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.71.0.tgz",
+      "integrity": "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==",
       "cpu": [
         "s390x"
       ],
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.70.0.tgz",
-      "integrity": "sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.71.0.tgz",
+      "integrity": "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==",
       "cpu": [
         "x64"
       ],
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.70.0.tgz",
-      "integrity": "sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.71.0.tgz",
+      "integrity": "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==",
       "cpu": [
         "x64"
       ],
@@ -1552,9 +1552,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.70.0.tgz",
-      "integrity": "sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.71.0.tgz",
+      "integrity": "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==",
       "cpu": [
         "arm64"
       ],
@@ -1569,9 +1569,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.70.0.tgz",
-      "integrity": "sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.71.0.tgz",
+      "integrity": "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==",
       "cpu": [
         "arm64"
       ],
@@ -1586,9 +1586,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.70.0.tgz",
-      "integrity": "sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.71.0.tgz",
+      "integrity": "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==",
       "cpu": [
         "ia32"
       ],
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.70.0.tgz",
-      "integrity": "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.71.0.tgz",
+      "integrity": "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==",
       "cpu": [
         "x64"
       ],
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.22.7",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.22.7.tgz",
-      "integrity": "sha512-7PaQ588YFK5l3QBf2at3dVDVt7bRp39omYHkExBaFxHEDFbueUT27wRZgly5pntBAi9AOS5hH/p3H9dEK5zaZg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.23.0.tgz",
+      "integrity": "sha512-9eB6OnGr29VxPg/tBWKEI5B6C39v+lrqZpBZXbO5E2hEl+3hHUXAOrtGlMbZh4nLrXiwo16meDryEny1LDvjPw==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",
@@ -3560,9 +3560,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.55.0.tgz",
-      "integrity": "sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.56.0.tgz",
+      "integrity": "sha512-9Dv0wV3zKiyvhjD7bRKaInKmHQ1sPx3RGOjQkGFJbbdQ16576yf8qhMSO9Q9cvHcs+1NpBsRTkuDDYFFPTJ6gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3578,25 +3578,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.55.0",
-        "@oxfmt/binding-android-arm64": "0.55.0",
-        "@oxfmt/binding-darwin-arm64": "0.55.0",
-        "@oxfmt/binding-darwin-x64": "0.55.0",
-        "@oxfmt/binding-freebsd-x64": "0.55.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.55.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.55.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.55.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.55.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.55.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.55.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.55.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.55.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.55.0",
-        "@oxfmt/binding-linux-x64-musl": "0.55.0",
-        "@oxfmt/binding-openharmony-arm64": "0.55.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.55.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.55.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.55.0"
+        "@oxfmt/binding-android-arm-eabi": "0.56.0",
+        "@oxfmt/binding-android-arm64": "0.56.0",
+        "@oxfmt/binding-darwin-arm64": "0.56.0",
+        "@oxfmt/binding-darwin-x64": "0.56.0",
+        "@oxfmt/binding-freebsd-x64": "0.56.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.56.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.56.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.56.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.56.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.56.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.56.0",
+        "@oxfmt/binding-linux-x64-musl": "0.56.0",
+        "@oxfmt/binding-openharmony-arm64": "0.56.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.56.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.56.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.56.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -3612,9 +3612,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.70.0.tgz",
-      "integrity": "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.71.0.tgz",
+      "integrity": "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3627,25 +3627,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.70.0",
-        "@oxlint/binding-android-arm64": "1.70.0",
-        "@oxlint/binding-darwin-arm64": "1.70.0",
-        "@oxlint/binding-darwin-x64": "1.70.0",
-        "@oxlint/binding-freebsd-x64": "1.70.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.70.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.70.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.70.0",
-        "@oxlint/binding-linux-arm64-musl": "1.70.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.70.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.70.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.70.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.70.0",
-        "@oxlint/binding-linux-x64-gnu": "1.70.0",
-        "@oxlint/binding-linux-x64-musl": "1.70.0",
-        "@oxlint/binding-openharmony-arm64": "1.70.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.70.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.70.0",
-        "@oxlint/binding-win32-x64-msvc": "1.70.0"
+        "@oxlint/binding-android-arm-eabi": "1.71.0",
+        "@oxlint/binding-android-arm64": "1.71.0",
+        "@oxlint/binding-darwin-arm64": "1.71.0",
+        "@oxlint/binding-darwin-x64": "1.71.0",
+        "@oxlint/binding-freebsd-x64": "1.71.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.71.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.71.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.71.0",
+        "@oxlint/binding-linux-arm64-musl": "1.71.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.71.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.71.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.71.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.71.0",
+        "@oxlint/binding-linux-x64-gnu": "1.71.0",
+        "@oxlint/binding-linux-x64-musl": "1.71.0",
+        "@oxlint/binding-openharmony-arm64": "1.71.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.71.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.71.0",
+        "@oxlint/binding-win32-x64-msvc": "1.71.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.22.1",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@commitlint/config-conventional": "^21.0.2",
     "@types/node": "^26.0.0",
     "husky": "^9.1.7",
-    "oxfmt": "^0.55.0",
-    "oxlint": "^1.70.0",
+    "oxfmt": "^0.56.0",
+    "oxlint": "^1.71.0",
     "prettier": "^3.8.4",
     "tsdown": "^0.22.3",
     "tsx": "^4.22.4",
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.22.7"
+    "@workos/oagen": "^0.23.0"
   }
 }

--- a/src/dotnet/enums.ts
+++ b/src/dotnet/enums.ts
@@ -3,6 +3,7 @@ import { walkTypeRef } from '@workos/oagen';
 import { className, deprecationMessage, escapeCsAttributeString, humanize } from './naming.js';
 import { setEnumAliases, setSingleValueEnumNames } from './type-map.js';
 import { enrichModelsFromSpec } from '../shared/model-utils.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate C# enum definitions from IR Enum definitions.
@@ -135,11 +136,16 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
     lines.push('    }');
     lines.push('}');
 
-    files.push({
-      path: `Enums/${typeName}.cs`,
-      content: lines.join('\n'),
-      overwriteExisting: true,
-    });
+    // FR-1.4: write the per-enum FILE only when in scope. .NET uses a flat
+    // Enums/ directory with C# namespaces (no barrel/index), so an
+    // out-of-scope enum left untouched on disk stays referenceable.
+    if (isEnumInScope(enumDef.name, ctx)) {
+      files.push({
+        path: `Enums/${typeName}.cs`,
+        content: lines.join('\n'),
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -26,6 +26,7 @@ import {
   isListMetadataModel,
   collectNonPaginatedResponseModelNames,
 } from '../shared/model-utils.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 export { isListWrapperModel, isListMetadataModel };
 
 /**
@@ -355,11 +356,16 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
     lines.push('    }');
     lines.push('}');
 
-    files.push({
-      path: `Entities/${csClassName}.cs`,
-      content: lines.join('\n'),
-      overwriteExisting: true,
-    });
+    // FR-1.4: write the per-model FILE only when in scope. .NET uses a flat
+    // Entities/ directory with C# namespaces (no barrel/index), so an
+    // out-of-scope model left untouched on disk stays referenceable.
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path: `Entities/${csClassName}.cs`,
+        content: lines.join('\n'),
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;

--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -35,7 +35,7 @@ import {
 import {
   buildResolvedLookup,
   lookupResolved,
-  groupByMount,
+  scopedMountGroups,
   getOpDefaults,
   getOpInferFromClient,
   buildHiddenParams,
@@ -71,10 +71,10 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   if (services.length === 0) return [];
 
   const files: GeneratedFile[] = [];
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
 
   const entries: Array<{ name: string; operations: Operation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
       : services.map((s) => ({ name: resolveResourceClassName(s, ctx), operations: s.operations }));
 

--- a/src/dotnet/tests.ts
+++ b/src/dotnet/tests.ts
@@ -16,7 +16,7 @@ import { resolveResourceClassName, sortPathParamsByTemplateOrder, optionsClassNa
 import { generateFixtures, generateModelFixture } from './fixtures.js';
 import { isListWrapperModel } from './models.js';
 import {
-  groupByMount,
+  scopedMountGroups,
   buildResolvedLookup,
   lookupResolved,
   buildHiddenParams,
@@ -40,9 +40,9 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   }
 
   // Generate per-mount-target test files
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
   const testEntries: Array<{ name: string; operations: Operation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
       : spec.services.map((s) => ({
           name: resolveResourceClassName(s, ctx),

--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -21,7 +21,7 @@ import {
 import {
   buildResolvedLookup,
   lookupResolved,
-  groupByMount,
+  scopedMountGroups,
   getOpDefaults,
   getOpInferFromClient,
   buildHiddenParams,
@@ -60,11 +60,11 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   if (services.length === 0) return [];
 
   const files: GeneratedFile[] = [];
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
 
   // If no resolved operations, fall back to raw services
   const entries: Array<{ name: string; operations: Operation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
       : services.map((s) => ({ name: resolveResourceClassName(s, ctx), operations: s.operations }));
 

--- a/src/go/tests.ts
+++ b/src/go/tests.ts
@@ -5,7 +5,7 @@ import { resolveResourceClassName, paramsStructName, sortPathParamsByTemplateOrd
 import { buildServiceAccessPaths } from './client.js';
 import { generateFixtures } from './fixtures.js';
 import { isListWrapperModel } from './models.js';
-import { groupByMount, buildResolvedLookup, lookupResolved, buildHiddenParams } from '../shared/resolved-ops.js';
+import { scopedMountGroups, buildResolvedLookup, lookupResolved, buildHiddenParams } from '../shared/resolved-ops.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -85,9 +85,9 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   const accessPaths = buildServiceAccessPaths(spec.services, ctx);
 
   // Generate per-mount-target test files
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
   const testEntries: Array<{ name: string; operations: Operation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
       : spec.services.map((s) => ({
           name: resolveResourceClassName(s, ctx),

--- a/src/kotlin/enums.ts
+++ b/src/kotlin/enums.ts
@@ -1,5 +1,6 @@
 import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { className, ktStringLiteral } from './naming.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 const KOTLIN_SRC_PREFIX = 'src/main/kotlin/';
 const ENUMS_PACKAGE = 'com.workos.types';
@@ -24,7 +25,7 @@ export const enumCanonicalMap = new Map<string, string>();
  * shortest PascalCase name becomes canonical and the rest emit `typealias`
  * files pointing at the canonical class.
  */
-export function generateEnums(enums: Enum[], _ctx: EmitterContext): GeneratedFile[] {
+export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
   if (enums.length === 0) return [];
 
   // Reset the canonical map on every generation run (guards against re-entry).
@@ -74,6 +75,11 @@ export function generateEnums(enums: Enum[], _ctx: EmitterContext): GeneratedFil
 
     const typeName = canonicalEnumTypeName(enumDef);
 
+    // FR-1.4: write per-enum FILES only when in scope. Each enum is its own
+    // `.kt` file (no barrel), so an out-of-scope enum left untouched on disk
+    // stays importable.
+    const enumInScope = isEnumInScope(enumDef.name, ctx);
+
     // Non-canonical enum: emit a typealias instead of a full enum class.
     const sharedSortEmitter = sharedSortEmitters.has(enumDef.name);
     const canonicalName = sharedSortEmitter
@@ -94,11 +100,13 @@ export function generateEnums(enums: Enum[], _ctx: EmitterContext): GeneratedFil
         aliasLine,
         '',
       ].join('\n');
-      files.push({
-        path: `${KOTLIN_SRC_PREFIX}${ENUMS_DIR}/${typeName}.kt`,
-        content: aliasContent,
-        overwriteExisting: true,
-      });
+      if (enumInScope) {
+        files.push({
+          path: `${KOTLIN_SRC_PREFIX}${ENUMS_DIR}/${typeName}.kt`,
+          content: aliasContent,
+          overwriteExisting: true,
+        });
+      }
       continue;
     }
 
@@ -175,11 +183,13 @@ export function generateEnums(enums: Enum[], _ctx: EmitterContext): GeneratedFil
     lines.push('}');
     lines.push('');
 
-    files.push({
-      path: `${KOTLIN_SRC_PREFIX}${ENUMS_DIR}/${typeName}.kt`,
-      content: lines.join('\n'),
-      overwriteExisting: true,
-    });
+    if (enumInScope) {
+      files.push({
+        path: `${KOTLIN_SRC_PREFIX}${ENUMS_DIR}/${typeName}.kt`,
+        content: lines.join('\n'),
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;

--- a/src/kotlin/models.ts
+++ b/src/kotlin/models.ts
@@ -8,6 +8,7 @@ import {
   collectNonPaginatedResponseModelNames,
   collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 const KOTLIN_SRC_PREFIX = 'src/main/kotlin/';
 const MODELS_PACKAGE = 'com.workos.models';
@@ -123,10 +124,17 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   for (const model of models) {
     if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     const typeName = className(model.name);
+    // FR-1.4: write per-model FILES only when in scope. Each model is its own
+    // `.kt` file (no barrel), so an out-of-scope model left untouched on disk
+    // stays importable. The WorkOSEvent sealed interface below is an aggregate
+    // built from many event models, so it is NOT gated.
+    const modelInScope = isModelInScope(model.name, ctx);
 
     // Parent of a discriminated union: emit a sealed class.
     if (model.fields.length === 0 && discriminatedUnions.has(typeName)) {
-      files.push(emitSealedUnion(typeName, discriminatedUnions.get(typeName)!));
+      if (modelInScope) {
+        files.push(emitSealedUnion(typeName, discriminatedUnions.get(typeName)!));
+      }
       continue;
     }
 
@@ -142,15 +150,19 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
         `typealias ${typeName} = ${canonicalType}`,
         '',
       ].join('\n');
-      files.push({
-        path: `${KOTLIN_SRC_PREFIX}${MODELS_DIR}/${typeName}.kt`,
-        content: aliasContent,
-        overwriteExisting: true,
-      });
+      if (modelInScope) {
+        files.push({
+          path: `${KOTLIN_SRC_PREFIX}${MODELS_DIR}/${typeName}.kt`,
+          content: aliasContent,
+          overwriteExisting: true,
+        });
+      }
       continue;
     }
 
-    files.push(emitDataClass(model));
+    if (modelInScope) {
+      files.push(emitDataClass(model));
+    }
   }
 
   // Generate the sealed WorkOSEvent interface. Collect all event envelope

--- a/src/kotlin/resources.ts
+++ b/src/kotlin/resources.ts
@@ -34,7 +34,7 @@ import {
 import {
   buildResolvedLookup,
   lookupResolved,
-  groupByMount,
+  scopedMountGroups,
   buildHiddenParams,
   getOpDefaults,
   getOpInferFromClient,
@@ -97,7 +97,7 @@ function promoteFieldType(f: Field): Field {
 export function generateResources(services: Service[], ctx: EmitterContext): GeneratedFile[] {
   if (services.length === 0) return [];
 
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
   if (mountGroups.size === 0) return [];
 
   const files: GeneratedFile[] = [];

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -22,7 +22,7 @@ import {
 } from './naming.js';
 import { mapTypeRef } from './type-map.js';
 import {
-  groupByMount,
+  scopedMountGroups,
   lookupResolved,
   buildResolvedLookup,
   buildHiddenParams,
@@ -76,7 +76,7 @@ function promoteIso8601TypeRef(type: TypeRef, description: string | undefined): 
  */
 export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
   const resolvedLookup = buildResolvedLookup(ctx);
 
   const exportedClasses = buildExportedClassNameSet(ctx);

--- a/src/node/enums.ts
+++ b/src/node/enums.ts
@@ -5,6 +5,7 @@ import { docComment, assignModelsToEmittableServices } from './utils.js';
 import { isInlineEnum } from './type-map.js';
 import { isNodeOwnedService } from './options.js';
 import { liveSurfaceConstEnumMembers, liveSurfaceInterfacePath } from './live-surface.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
   if (enums.length === 0) return [];
@@ -120,11 +121,13 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       lines.push(`  (typeof ${enumDef.name})[keyof typeof ${enumDef.name}];`);
     }
 
-    files.push({
-      path: `src/${dirName}/interfaces/${fileName(enumDef.name)}.interface.ts`,
-      content: lines.join('\n'),
-      skipIfExists: !hasNewValues,
-    });
+    if (isEnumInScope(enumDef.name, ctx)) {
+      files.push({
+        path: `src/${dirName}/interfaces/${fileName(enumDef.name)}.interface.ts`,
+        content: lines.join('\n'),
+        skipIfExists: !hasNewValues,
+      });
+    }
   }
 
   return files;

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -45,7 +45,7 @@ import {
 import { liveSurfaceHasExistingSdk, liveSurfaceHasManagedFile, liveSurfaceInterfacePath } from './live-surface.js';
 import { isNodeOwnedService, isHandOwnedType } from './options.js';
 import { unwrapListModel } from './fixtures.js';
-import { groupByMount, buildResolvedLookup, lookupResolved } from '../shared/resolved-ops.js';
+import { groupByMount, buildResolvedLookup, lookupResolved, isModelInScope } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { collectWrapperResponseModels } from './wrappers.js';
 import { resolveResourceClassName } from './resources.js';
@@ -308,11 +308,13 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
       const aliasLines = importSymbols
         ? [`import type { ${importSymbols} } from '${canonRelPath}';`, '', ...aliasExports]
         : [...aliasExports];
-      files.push({
-        path: aliasPath,
-        content: aliasLines.join('\n'),
-        overwriteExisting: true,
-      });
+      if (isModelInScope(model.name, ctx)) {
+        files.push({
+          path: aliasPath,
+          content: aliasLines.join('\n'),
+          overwriteExisting: true,
+        });
+      }
       continue;
     }
 
@@ -745,11 +747,13 @@ export function generateModels(models: Model[], ctx: EmitterContext, shared?: Sh
       }
     }
 
-    files.push({
-      path: filePath,
-      content: pruneUnusedImports(lines).join('\n'),
-      overwriteExisting: true,
-    });
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path: filePath,
+        content: pruneUnusedImports(lines).join('\n'),
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;
@@ -943,11 +947,13 @@ export function generateSerializers(
           parts.push(`serialize${canonDomainName} as serialize${domainName}`);
         }
         const reexportContent = `export { ${parts.join(', ')} } from '${rel}';`;
-        files.push({
-          path: serializerPath,
-          content: reexportContent,
-          overwriteExisting: true,
-        });
+        if (isModelInScope(model.name, ctx)) {
+          files.push({
+            path: serializerPath,
+            content: reexportContent,
+            overwriteExisting: true,
+          });
+        }
         continue;
       }
       // The alias is response-reachable, but the canonical model is
@@ -997,11 +1003,13 @@ export function generateSerializers(
       ),
     ];
 
-    files.push({
-      path: serializerPath,
-      content: pruneUnusedImports(lines).join('\n'),
-      overwriteExisting: true,
-    });
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path: serializerPath,
+        content: pruneUnusedImports(lines).join('\n'),
+        overwriteExisting: true,
+      });
+    }
   }
 
   (ctx as any)._skippedSerializeModels = skippedSerializeModels;

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -78,6 +78,7 @@ import {
   buildResolvedLookup,
   lookupResolved,
   groupByMount,
+  isMountInScope,
   getOpDefaults,
   getOpInferFromClient,
 } from '../shared/resolved-ops.js';
@@ -718,11 +719,18 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   // multiple IR services mount to the same resource class.
   const mountGroups = groupByMount(ctx);
   const mergedServices: Service[] =
-    mountGroups.size > 0 ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations })) : services;
+    mountGroups.size > 0 || ctx.scopedServices?.size
+      ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
+      : services;
 
   const topLevelEnumNames = new Set(ctx.spec.enums.map((e) => e.name));
 
   for (const service of mergedServices) {
+    // Scope gate: in a scoped (`--services`) run, only emit per-service resource
+    // files for the selected post-mount names. `service.name` is the mount-group
+    // key (the POST-MOUNT name that matches `ctx.scopedServices`). Applied as an
+    // additional early continue ahead of the node-owned/coverage skip logic.
+    if (!isMountInScope(service.name, ctx)) continue;
     const isOwnedService = isNodeOwnedService(ctx, service.name, resolveResourceClassName(service, ctx));
     if (!isOwnedService && isServiceCoveredByExisting(service, ctx)) {
       if (!hasMethodsAbsentFromBaseline(service, ctx)) {
@@ -770,6 +778,9 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   // stable.  Placing them under `interfaces/` lets the per-service barrel
   // pick them up automatically.
   for (const service of mergedServices) {
+    // Scope gate: keep the per-service options interfaces aligned with the
+    // resource files emitted above — only the selected post-mount names.
+    if (!isMountInScope(service.name, ctx)) continue;
     const isOwnedService = isNodeOwnedService(ctx, service.name, resolveResourceClassName(service, ctx));
     if (!isOwnedService && isServiceCoveredByExisting(service, ctx) && !hasMethodsAbsentFromBaseline(service, ctx))
       continue;

--- a/src/node/tests.ts
+++ b/src/node/tests.ts
@@ -35,7 +35,7 @@ import {
   modelHasNewFields,
   computeNonEventReachable,
 } from './utils.js';
-import { groupByMount, buildResolvedLookup, lookupResolved } from '../shared/resolved-ops.js';
+import { groupByMount, buildResolvedLookup, lookupResolved, isMountInScope } from '../shared/resolved-ops.js';
 import { isNodeOwnedService, nodeOptions, planOperationFor } from './options.js';
 
 type BaselineMethod = {
@@ -137,7 +137,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   }
 
   const testEntries: Array<{ name: string; operations: Operation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
       : spec.services.map((s) => ({ name: resolveResourceClassName(s, ctx), operations: s.operations }));
 
@@ -159,6 +159,11 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   }
 
   for (const { name: mountName, operations } of testEntries) {
+    // Scope gate: in a scoped (`--services`) run, only emit per-service test
+    // files for the selected post-mount names. `mountName` is the mount-group
+    // key (the POST-MOUNT name that matches `ctx.scopedServices`). Applied as an
+    // additional early continue ahead of the node-owned/coverage skip logic.
+    if (!isMountInScope(mountName, ctx)) continue;
     if (operations.length === 0) continue;
     const mergedService: Service = { name: mountName, operations };
     const isOwnedService = isNodeOwnedService(ctx, mountName, resolveResourceClassName(mergedService, ctx));

--- a/src/php/enums.ts
+++ b/src/php/enums.ts
@@ -2,6 +2,7 @@ import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { toPascalCase } from '@workos/oagen';
 import { className, resolveEnumName } from './naming.js';
 import { phpDocComment } from './utils.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate PHP enum files from IR enums.
@@ -16,6 +17,16 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
     const canonical = resolveEnumName(e.name);
     if (emittedCanonical.has(canonical)) continue; // skip aliases
     emittedCanonical.add(canonical);
+
+    // FR-1.4: write the per-enum FILE only when in scope. PHP dedupes
+    // value-identical enums onto a single canonical class, so the canonical
+    // file is needed when EITHER the canonical name OR any alias resolving to
+    // it is reachable from the selected services. PSR-4 (one class per file
+    // under lib/Resource/, no barrel) means an out-of-scope enum is simply
+    // left untouched on disk and stays loadable.
+    const enumInScope = enums.some(
+      (other) => resolveEnumName(other.name) === canonical && isEnumInScope(other.name, ctx),
+    );
 
     const name = className(canonical);
     const _isAllStrings = e.values.every((v) => typeof v.value === 'string');
@@ -56,11 +67,13 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
 
     lines.push('}');
 
-    files.push({
-      path: `lib/Resource/${name}.php`,
-      content: lines.join('\n'),
-      overwriteExisting: true,
-    });
+    if (enumInScope) {
+      files.push({
+        path: `lib/Resource/${name}.php`,
+        content: lines.join('\n'),
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;

--- a/src/php/index.ts
+++ b/src/php/index.ts
@@ -42,9 +42,17 @@ function ensureTrailingNewlines(files: GeneratedFile[]): GeneratedFile[] {
  * classes (no sum types), so a discriminated base whose IR fields the
  * parser stripped (post-allOf-aware detection) gets its original fields
  * restored to avoid silently dropping variant data.
+ *
+ * `enums` is forwarded to seed `enrichModelsFromSpec`'s collision set: an
+ * inline oneOf enum whose synthetic name (`Parent_field`) snake-collapses
+ * onto an existing IR enum (e.g. `DataIntegrationAccessTokenResponse_error`
+ * vs `DataIntegrationAccessTokenResponseError`) must NOT spawn a duplicate
+ * synthetic. Otherwise both collapse to the same `lib/Resource/X.php` path
+ * and the later writer wins by array order — which differs between a full
+ * and a scoped (`--services`) run, producing a non-deterministic case order.
  */
-function enrichModelsForPhp(models: Model[]): Model[] {
-  const enriched = enrichModelsFromSpec(models);
+function enrichModelsForPhp(models: Model[], enums: Enum[]): Model[] {
+  const enriched = enrichModelsFromSpec(models, enums);
   const originalByName = new Map(models.map((m) => [m.name, m]));
   return enriched.map((m) => {
     if ((m as { discriminator?: unknown }).discriminator && m.fields.length === 0) {
@@ -62,7 +70,7 @@ export const phpEmitter: Emitter = {
 
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
     ensureNamingInitialized(ctx);
-    return ensureTrailingNewlines(generateModels(enrichModelsForPhp(models), ctx));
+    return ensureTrailingNewlines(generateModels(enrichModelsForPhp(models, ctx.spec.enums), ctx));
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {

--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -10,6 +10,7 @@ import {
   collectNonPaginatedResponseModelNames,
   collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 export { isListMetadataModel, isListWrapperModel };
 
 /**
@@ -140,11 +141,16 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
     lines.push('}');
 
-    files.push({
-      path: `lib/Resource/${name}.php`,
-      content: lines.join('\n'),
-      overwriteExisting: true,
-    });
+    // FR-1.4: write the per-model FILE only when in scope. PHP uses PSR-4
+    // (one class per file under lib/Resource/, no barrel/index), so an
+    // out-of-scope model is simply left untouched on disk and stays loadable.
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path: `lib/Resource/${name}.php`,
+        content: lines.join('\n'),
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -12,7 +12,7 @@ import { mapTypeRef, mapTypeRefForPHPDoc } from './type-map.js';
 import { className, fieldName, resolveMethodName, buildExportedClassNameSet, resolveServiceTarget } from './naming.js';
 import { isListWrapperModel } from './models.js';
 import {
-  groupByMount,
+  scopedMountGroups,
   buildResolvedLookup,
   lookupResolved,
   getOpDefaults,
@@ -44,10 +44,12 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   const files: GeneratedFile[] = [];
   const modelMap = new Map(ctx.spec.models.map((m) => [m.name, m]));
 
-  // Group operations by mount target
-  const mountGroups = groupByMount(ctx);
+  // Group operations by mount target. In a scoped (`--services`) run this
+  // returns only the selected post-mount services so we emit per-service
+  // resource files for those alone.
+  const mountGroups = scopedMountGroups(ctx);
   const entries: Array<{ name: string; operations: Operation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
       : services.map((s) => ({ name: className(s.name), operations: s.operations }));
 

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -20,7 +20,7 @@ import { isListWrapperModel } from './models.js';
 import { generateFixtures } from './fixtures.js';
 import {
   getMountTarget,
-  groupByMount,
+  scopedMountGroups,
   buildHiddenParams,
   getOpDefaults,
   getOpInferFromClient,
@@ -39,9 +39,12 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
 
   // Collect all operations per mount target using resolved per-operation mounts.
   // This correctly handles operationHint mountOn overrides (e.g., audit_logs_retention → AuditLogs).
-  const mountGroupsFromResolved = groupByMount(ctx);
+  // In a scoped (`--services`) run this returns only the selected post-mount
+  // services so we emit per-service test files for those alone. ClientTest.php
+  // and fixtures below are built from `spec` and stay full.
+  const mountGroupsFromResolved = scopedMountGroups(ctx);
   const mountGroups = new Map<string, { op: Operation; service: Service; resolvedOp?: ResolvedOperation }[]>();
-  if (mountGroupsFromResolved.size > 0) {
+  if (mountGroupsFromResolved.size > 0 || ctx.scopedServices?.size) {
     for (const [target, group] of mountGroupsFromResolved) {
       mountGroups.set(
         target,

--- a/src/python/enums.ts
+++ b/src/python/enums.ts
@@ -2,6 +2,7 @@ import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { toUpperSnakeCase } from '@workos/oagen';
 import { className, fileName, buildMountDirMap, dirToModule } from './naming.js';
 import { computeSchemaPlacement } from './shared-schemas.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 /**
  * Convert a PascalCase class name to a human-readable lowercase string,
@@ -38,6 +39,10 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
   for (const enumDef of enums) {
     const service = enumToService.get(enumDef.name);
     const dirName = resolveDir(service);
+    // FR-1.4: write per-enum FILES only when in scope; the enum barrel is built
+    // separately (collectGeneratedEnumSymbolsByDir over the full set), so an
+    // out-of-scope enum left on disk stays exported and importable.
+    const enumInScope = isEnumInScope(enumDef.name, ctx);
 
     // If this enum is an alias for a canonical enum, generate a type alias file
     const canonicalName = aliasOf.get(enumDef.name);
@@ -73,12 +78,14 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         lines.push('        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")');
       }
       lines.push(`__all__ = ["${aliasCls}"]`);
-      files.push({
-        path: `src/${ctx.namespace}/${dirName}/models/${fileName(enumDef.name)}.py`,
-        content: lines.join('\n'),
-        integrateTarget: true,
-        overwriteExisting: true,
-      });
+      if (enumInScope) {
+        files.push({
+          path: `src/${ctx.namespace}/${dirName}/models/${fileName(enumDef.name)}.py`,
+          content: lines.join('\n'),
+          integrateTarget: true,
+          overwriteExisting: true,
+        });
+      }
 
       // Also generate compat alias files for dedup aliases (they may have compat aliases too)
       for (const aliasName of compatAliases.get(enumDef.name) ?? []) {
@@ -107,12 +114,14 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
             `__all__ = ["${aliasName}"]`,
           ].join('\n');
         }
-        files.push({
-          path: `src/${ctx.namespace}/${dirName}/models/${fileName(aliasName)}.py`,
-          content: compatContent,
-          integrateTarget: true,
-          overwriteExisting: true,
-        });
+        if (enumInScope) {
+          files.push({
+            path: `src/${ctx.namespace}/${dirName}/models/${fileName(aliasName)}.py`,
+            content: compatContent,
+            integrateTarget: true,
+            overwriteExisting: true,
+          });
+        }
       }
 
       continue;
@@ -241,26 +250,28 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       );
     }
 
-    files.push({
-      path: `src/${ctx.namespace}/${dirName}/models/${fileName(enumDef.name)}.py`,
-      content: lines.join('\n'),
-      integrateTarget: true,
-      overwriteExisting: true,
-    });
-
-    for (const aliasName of compatAliases.get(enumDef.name) ?? []) {
+    if (enumInScope) {
       files.push({
-        path: `src/${ctx.namespace}/${dirName}/models/${fileName(aliasName)}.py`,
-        content: [
-          'from typing import TypeAlias',
-          `from .${fileName(enumDef.name)} import ${cls}`,
-          '',
-          `${aliasName}: TypeAlias = ${cls}`,
-          `__all__ = ["${aliasName}"]`,
-        ].join('\n'),
+        path: `src/${ctx.namespace}/${dirName}/models/${fileName(enumDef.name)}.py`,
+        content: lines.join('\n'),
         integrateTarget: true,
         overwriteExisting: true,
       });
+
+      for (const aliasName of compatAliases.get(enumDef.name) ?? []) {
+        files.push({
+          path: `src/${ctx.namespace}/${dirName}/models/${fileName(aliasName)}.py`,
+          content: [
+            'from typing import TypeAlias',
+            `from .${fileName(enumDef.name)} import ${cls}`,
+            '',
+            `${aliasName}: TypeAlias = ${cls}`,
+            `__all__ = ["${aliasName}"]`,
+          ].join('\n'),
+          integrateTarget: true,
+          overwriteExisting: true,
+        });
+      }
     }
   }
 

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -4,6 +4,7 @@ import { mapTypeRef } from './type-map.js';
 import { className, domainFieldName, fileName, buildMountDirMap, dirToModule } from './naming.js';
 import { collectGeneratedEnumSymbolsByDir } from './enums.js';
 import { computeSchemaPlacement } from './shared-schemas.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate Python dataclass model files from IR Model definitions.
@@ -169,12 +170,16 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       dispLines.push(`            return cast("${variantTypeName}", dispatch_cls.from_dict(data))`);
       dispLines.push(`        return ${unknownClassName}.from_dict(data)`);
 
-      files.push({
-        path: `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`,
-        content: dispLines.join('\n'),
-        integrateTarget: true,
-        overwriteExisting: true,
-      });
+      // FR-1.4: write the file only when in scope; the barrel tracking below is
+      // unconditional so out-of-scope models (left on disk) stay exported.
+      if (isModelInScope(model.name, ctx)) {
+        files.push({
+          path: `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`,
+          content: dispLines.join('\n'),
+          integrateTarget: true,
+          overwriteExisting: true,
+        });
+      }
 
       if (!emittedModelSymbolsByDir.has(dirName)) emittedModelSymbolsByDir.set(dirName, []);
       emittedModelSymbolsByDir.get(dirName)!.push(model.name);
@@ -216,12 +221,14 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       }
       lines.push('');
       lines.push(`${modelClassName}: TypeAlias = ${canonicalClassName}`);
-      files.push({
-        path: `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`,
-        content: lines.join('\n'),
-        integrateTarget: true,
-        overwriteExisting: true,
-      });
+      if (isModelInScope(model.name, ctx)) {
+        files.push({
+          path: `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`,
+          content: lines.join('\n'),
+          integrateTarget: true,
+          overwriteExisting: true,
+        });
+      }
       if (!emittedModelSymbolsByDir.has(dirName)) emittedModelSymbolsByDir.set(dirName, []);
       emittedModelSymbolsByDir.get(dirName)!.push(model.name);
       const aliasNatural = originalModelToService.get(model.name);
@@ -457,12 +464,14 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
     lines.push('        return result');
 
-    files.push({
-      path: `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`,
-      content: lines.join('\n'),
-      integrateTarget: true,
-      overwriteExisting: true,
-    });
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path: `src/${ctx.namespace}/${dirName}/models/${fileName(model.name)}.py`,
+        content: lines.join('\n'),
+        integrateTarget: true,
+        overwriteExisting: true,
+      });
+    }
     if (!emittedModelSymbolsByDir.has(dirName)) emittedModelSymbolsByDir.set(dirName, []);
     emittedModelSymbolsByDir.get(dirName)!.push(model.name);
     const regularNatural = originalModelToService.get(model.name);

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -30,7 +30,7 @@ import {
   buildResolvedLookup,
   lookupMethodName,
   lookupResolved,
-  groupByMount,
+  scopedMountGroups,
   getOpDefaults,
   getOpInferFromClient,
   buildHiddenParams as buildHiddenParamsShared,
@@ -1056,12 +1056,12 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   const resolvedLookup = buildResolvedLookup(ctx);
   const files: GeneratedFile[] = [];
   const mountDirMap = buildMountDirMap(ctx);
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
 
   // Build mount group entries. When resolved operations are available, group by
   // mount target. Otherwise fall back to one group per service (for tests).
   const entries: Array<{ name: string; operations: Operation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({ name, operations: group.operations }))
       : services.map((s) => ({ name: resolveClassName(s, ctx), operations: s.operations }));
 

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -25,7 +25,7 @@ import { generateFixtures, generateModelFixture } from './fixtures.js';
 import { isListWrapperModel, isListMetadataModel } from './models.js';
 import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
 import {
-  groupByMount,
+  scopedMountGroups,
   buildResolvedLookup,
   lookupResolved,
   buildHiddenParams,
@@ -118,9 +118,9 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   const accessPaths = buildServiceAccessPaths(spec.services, ctx);
 
   // Generate per-mount-target test files (merges all sub-services into one file)
-  const mountGroups = groupByMount(ctx);
+  const mountGroups = scopedMountGroups(ctx);
   const testEntries: Array<{ name: string; operations: Operation[]; resolvedOps?: ResolvedOperation[] }> =
-    mountGroups.size > 0
+    mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({
           name,
           operations: group.operations,

--- a/src/ruby/enums.ts
+++ b/src/ruby/enums.ts
@@ -1,6 +1,7 @@
 import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { toUpperSnakeCase } from '@workos/oagen';
 import { className, fileName } from './naming.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate Ruby enum class files.
@@ -9,7 +10,6 @@ import { className, fileName } from './naming.js';
  * and a frozen `ALL` array of all values.
  */
 export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
-  void ctx;
   if (enums.length === 0) return [];
 
   const files: GeneratedFile[] = [];
@@ -17,6 +17,9 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
 
   for (const enumDef of enums) {
     const cls = className(enumDef.name);
+    // FR-1.4: write the per-enum file only when in scope. Out-of-scope enum
+    // files are left untouched on disk; Zeitwerk autoloads them by path.
+    const enumInScope = isEnumInScope(enumDef.name, ctx);
 
     // If this enum duplicates another (by value set), emit a Ruby constant
     // alias. Zeitwerk autoloads the canonical when the alias is first
@@ -30,12 +33,14 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       lines.push(`    ${cls} = ${canonicalCls}`);
       lines.push('  end');
       lines.push('end');
-      files.push({
-        path: `lib/workos/types/${fileName(enumDef.name)}.rb`,
-        content: lines.join('\n'),
-        integrateTarget: true,
-        overwriteExisting: true,
-      });
+      if (enumInScope) {
+        files.push({
+          path: `lib/workos/types/${fileName(enumDef.name)}.rb`,
+          content: lines.join('\n'),
+          integrateTarget: true,
+          overwriteExisting: true,
+        });
+      }
       continue;
     }
 
@@ -60,12 +65,14 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       lines.push('    end');
       lines.push('  end');
       lines.push('end');
-      files.push({
-        path: `lib/workos/types/${fileName(enumDef.name)}.rb`,
-        content: lines.join('\n'),
-        integrateTarget: true,
-        overwriteExisting: true,
-      });
+      if (enumInScope) {
+        files.push({
+          path: `lib/workos/types/${fileName(enumDef.name)}.rb`,
+          content: lines.join('\n'),
+          integrateTarget: true,
+          overwriteExisting: true,
+        });
+      }
       continue;
     }
 
@@ -108,12 +115,14 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
     lines.push('  end');
     lines.push('end');
 
-    files.push({
-      path: `lib/workos/types/${fileName(enumDef.name)}.rb`,
-      content: lines.join('\n'),
-      integrateTarget: true,
-      overwriteExisting: true,
-    });
+    if (enumInScope) {
+      files.push({
+        path: `lib/workos/types/${fileName(enumDef.name)}.rb`,
+        content: lines.join('\n'),
+        integrateTarget: true,
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;

--- a/src/ruby/models.ts
+++ b/src/ruby/models.ts
@@ -6,6 +6,7 @@ import {
   isListMetadataModel,
   collectNonPaginatedResponseModelNames,
 } from '../shared/model-utils.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 /** Folder under lib/workos/ for models not owned by any service. */
 export const SHARED_MODEL_DIR = 'shared';
@@ -119,12 +120,17 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       lines.push('module WorkOS');
       lines.push(`  ${cls} = ${canonCls}`);
       lines.push('end');
-      files.push({
-        path: `lib/workos/${dirFor(model.name)}/${file}.rb`,
-        content: lines.join('\n'),
-        integrateTarget: true,
-        overwriteExisting: true,
-      });
+      // FR-1.4: write the per-model file only when in scope. Zeitwerk autoloads
+      // by path, so there is no barrel to keep in sync; out-of-scope alias files
+      // are left untouched on disk.
+      if (isModelInScope(model.name, ctx)) {
+        files.push({
+          path: `lib/workos/${dirFor(model.name)}/${file}.rb`,
+          content: lines.join('\n'),
+          integrateTarget: true,
+          overwriteExisting: true,
+        });
+      }
       continue;
     }
 
@@ -214,12 +220,17 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push('  end');
     lines.push('end');
 
-    files.push({
-      path: `lib/workos/${dirFor(model.name)}/${file}.rb`,
-      content: lines.join('\n'),
-      integrateTarget: true,
-      overwriteExisting: true,
-    });
+    // FR-1.4: write the per-model file only when in scope. Zeitwerk autoloads by
+    // path, so there is no barrel to keep in sync; out-of-scope model files are
+    // left untouched on disk.
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path: `lib/workos/${dirFor(model.name)}/${file}.rb`,
+        content: lines.join('\n'),
+        integrateTarget: true,
+        overwriteExisting: true,
+      });
+    }
   }
 
   return files;

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -16,6 +16,7 @@ import {
   buildResolvedLookup,
   groupByMount,
   isMountInScope,
+  isModelInScope,
   lookupResolved,
   buildHiddenParams,
   collectGroupedParamNames,
@@ -117,12 +118,17 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
     lines.push('  end');
     lines.push('end');
 
-    files.push({
-      path: `rbi/workos/${fileName(model.name)}.rbi`,
-      content: lines.join('\n'),
-      integrateTarget: true,
-      overwriteExisting: true,
-    });
+    // FR-1.4: write the per-model .rbi only when in scope. The client.rbi
+    // aggregate (section 3) stays on the full set so sigs for out-of-scope
+    // services whose .rb/.rbi still exist keep resolving.
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path: `rbi/workos/${fileName(model.name)}.rbi`,
+        content: lines.join('\n'),
+        integrateTarget: true,
+        overwriteExisting: true,
+      });
+    }
   }
 
   // 2. Generate service RBI files

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -15,6 +15,7 @@ import {
 import {
   buildResolvedLookup,
   groupByMount,
+  isMountInScope,
   lookupResolved,
   buildHiddenParams,
   collectGroupedParamNames,
@@ -137,6 +138,10 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
   const exportedClasses = buildExportedClassNameSet(ctx);
 
   for (const [mountTarget, group] of groups) {
+    // Scoped run: emit per-service .rbi only for selected mount targets. The
+    // client.rbi aggregate loop below intentionally stays on the FULL `groups`
+    // set so it keeps emitting sigs for every service whose .rb still exists.
+    if (!isMountInScope(mountTarget, ctx)) continue;
     const resolvedTarget = resolveServiceTarget(mountTarget, exportedClasses);
     const cls = className(resolvedTarget);
     const lines: string[] = [];

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -15,7 +15,7 @@ import { mapTypeRefForYard } from './type-map.js';
 import {
   buildResolvedLookup,
   lookupResolved,
-  groupByMount,
+  scopedMountGroups,
   getOpDefaults,
   getOpInferFromClient,
   buildHiddenParams,
@@ -33,7 +33,7 @@ import { buildGroupOwnerMap, collectVariantsForMountTarget, emitInlineVariantCla
 export function generateResources(services: Service[], ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
 
-  const groups = groupByMount(ctx);
+  const groups = scopedMountGroups(ctx);
   const lookup = buildResolvedLookup(ctx);
   const modelNames = new Set(ctx.spec.models.map((m) => m.name));
   const enumNames = new Set(ctx.spec.enums.map((e) => e.name));

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -13,7 +13,7 @@ import {
 } from './naming.js';
 import {
   buildResolvedLookup,
-  groupByMount,
+  scopedMountGroups,
   lookupResolved,
   buildHiddenParams,
   collectBodyFieldTypes,
@@ -34,7 +34,7 @@ import { buildGroupOwnerMap, pickVariantParamType } from './parameter-groups.js'
 export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
 
-  const groups = groupByMount(ctx);
+  const groups = scopedMountGroups(ctx);
   const models = spec.models as Model[];
   const modelByName = new Map<string, Model>();
   for (const m of models) modelByName.set(m.name, m);

--- a/src/rust/enums.ts
+++ b/src/rust/enums.ts
@@ -1,5 +1,6 @@
 import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { typeName, moduleName, variantName } from './naming.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate one Rust source file per enum under `src/enums/`, plus a
@@ -17,7 +18,7 @@ import { typeName, moduleName, variantName } from './naming.js';
  *     variant and re-serialize as the canonical wire string.
  *   - `Display`, `FromStr`, and `AsRef<str>` are implemented for ergonomics.
  */
-export function generateEnums(enums: Enum[], _ctx: EmitterContext): GeneratedFile[] {
+export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
   const seen = new Set<string>();
   const moduleNames: string[] = [];
@@ -27,8 +28,15 @@ export function generateEnums(enums: Enum[], _ctx: EmitterContext): GeneratedFil
     const mod = moduleName(e.name);
     if (seen.has(mod)) continue;
     seen.add(mod);
+    // The barrel (`src/enums/mod.rs`) must declare every enum's module so Rust
+    // compiles even in a scoped run — `moduleNames` is collected from the FULL
+    // enum set regardless of scope.
     moduleNames.push(mod);
 
+    // Only the per-enum `.rs` FILE write is scoped (FR-1.4). In a scoped run we
+    // skip emitting files for out-of-scope enums, but the barrel above still
+    // declares their modules (their existing `.rs` files stay untouched on disk).
+    if (!isEnumInScope(e.name, ctx)) continue;
     files.push({
       path: `src/enums/${mod}.rs`,
       content: renderEnum(e),

--- a/src/rust/models.ts
+++ b/src/rust/models.ts
@@ -2,6 +2,7 @@ import type { Model, EmitterContext, GeneratedFile, Field, TypeRef } from '@work
 import { typeName, domainFieldName, moduleName } from './naming.js';
 import { mapTypeRef, makeOptional, UnionRegistry } from './type-map.js';
 import { applySecretRedaction } from './secret.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 const HEADER_PLACEHOLDER = ''; // engine prepends fileHeader()
 
@@ -32,15 +33,27 @@ export function generateModels(models: Model[], ctx: EmitterContext, registry: U
     const mod = moduleName(model.name);
     if (seen.has(mod)) continue;
     seen.add(mod);
+    // The barrel (`src/models/mod.rs`) must declare every model's module so
+    // Rust compiles even in a scoped run — `moduleNames` is collected from the
+    // FULL model set regardless of scope.
     moduleNames.push(mod);
 
+    // renderModel registers inline unions into `registry` as a side effect, and
+    // `_unions.rs` is rendered later (in generateClient) from that registry — so
+    // it MUST run for every model, even out-of-scope ones, or scoped runs drop
+    // unions. Compute content unconditionally; only the per-model `.rs` FILE write
+    // is scoped (FR-1.4). The barrel above still declares every module, and an
+    // out-of-scope model's existing `.rs` file stays untouched on disk.
     const hintPath = ctx.overlayLookup?.fileBySymbol?.get(model.name);
     const path = hintPath ?? `src/models/${mod}.rs`;
-    files.push({
-      path,
-      content: renderModel(model, registry, taggedVariantFields.get(model.name)),
-      overwriteExisting: true,
-    });
+    const content = renderModel(model, registry, taggedVariantFields.get(model.name));
+    if (isModelInScope(model.name, ctx)) {
+      files.push({
+        path,
+        content,
+        overwriteExisting: true,
+      });
+    }
   }
 
   // Always include the unions module in the barrel so downstream stages

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -14,7 +14,7 @@ import { fieldName, domainFieldName, methodName, typeName, moduleName, variantNa
 import { mapTypeRef, makeOptional, UnionRegistry } from './type-map.js';
 import { applySecretRedaction } from './secret.js';
 import { parsePathTemplate } from '../shared/path-template.js';
-import { groupByMount, buildResolvedLookup } from '../shared/resolved-ops.js';
+import { groupByMount, buildResolvedLookup, isMountInScope } from '../shared/resolved-ops.js';
 import { resolveWrapperParams, type ResolvedWrapperParam } from '../shared/wrapper-utils.js';
 
 /**
@@ -32,7 +32,14 @@ export function generateResources(_services: Service[], ctx: EmitterContext, reg
     if (group.operations.length === 0) continue;
     const basename = moduleName(mountName);
     const struct = mountStructName(mountName);
+    // The barrel (`src/resources/mod.rs`) must list every mount's module so
+    // Rust compiles even in a scoped run — `exports` is collected from the
+    // FULL groupByMount set regardless of scope.
     exports.push({ module: basename, struct });
+    // Only the per-service resource `.rs` FILE write is scoped. In a scoped
+    // run we skip emitting files for out-of-scope mounts, but the barrel above
+    // still references their modules (their existing `.rs` files stay on disk).
+    if (!isMountInScope(mountName, ctx)) continue;
     files.push({
       path: `src/resources/${basename}.rs`,
       content: renderMountGroup(mountName, group.resolvedOps, ctx, registry, lookup),

--- a/src/rust/tests.ts
+++ b/src/rust/tests.ts
@@ -11,7 +11,7 @@ import type {
   TypeRef,
 } from '@workos/oagen';
 import { methodName, moduleName, typeName } from './naming.js';
-import { groupByMount } from '../shared/resolved-ops.js';
+import { scopedMountGroups } from '../shared/resolved-ops.js';
 import { exampleFor, generateFixtures } from './fixtures.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { isInlineEnvelopeList } from './resources.js';
@@ -43,7 +43,7 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     overwriteExisting: true,
   });
 
-  const groups = groupByMount(ctx);
+  const groups = scopedMountGroups(ctx);
   const modelMap = new Map(spec.models.map((m) => [m.name, m]));
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
 

--- a/src/shared/resolved-ops.ts
+++ b/src/shared/resolved-ops.ts
@@ -123,6 +123,25 @@ export function isMountInScope(mountName: string, ctx: EmitterContext): boolean 
 }
 
 /**
+ * True when a MODEL's per-model FILE should be written in the current run (FR-1.4).
+ * A scoped run sets `ctx.scopedModelNames` to the models reachable from the
+ * selected services; out-of-scope models are left untouched on disk. Inactive
+ * scoping ⇒ everything is in scope. NOTE: gate only the per-model FILE write —
+ * the model must still appear in barrels/indexes (built from the full set) so the
+ * untouched on-disk file stays importable.
+ */
+export function isModelInScope(modelName: string, ctx: EmitterContext): boolean {
+  const scope = ctx.scopedModelNames;
+  return !scope || scope.has(modelName);
+}
+
+/** Like {@link isModelInScope} but for an ENUM's per-enum file (`ctx.scopedEnumNames`). */
+export function isEnumInScope(enumName: string, ctx: EmitterContext): boolean {
+  const scope = ctx.scopedEnumNames;
+  return !scope || scope.has(enumName);
+}
+
+/**
  * Get the mount target for an IR service.
  * Checks the first resolved operation that belongs to this service.
  * Falls back to PascalCase of the service name if no resolved ops exist.

--- a/src/shared/resolved-ops.ts
+++ b/src/shared/resolved-ops.ts
@@ -95,6 +95,34 @@ export function groupByMount(ctx: EmitterContext): Map<string, MountGroup> {
 }
 
 /**
+ * Like {@link groupByMount}, but for a scoped (`--services`) run returns ONLY the
+ * mount groups the run selected (`ctx.scopedServices`, POST-MOUNT names). When
+ * scoping is inactive the full set is returned unchanged.
+ *
+ * Use this for PER-SERVICE resource/test emission. Do NOT use it for
+ * aggregate/barrel files (Rust `mod.rs`, Ruby `client.rbi`, the root client) —
+ * those must continue to list every service, so they keep calling
+ * {@link groupByMount} over the full set; otherwise a scoped run would drop
+ * sibling modules and break the build/type-check.
+ */
+export function scopedMountGroups(ctx: EmitterContext): Map<string, MountGroup> {
+  const groups = groupByMount(ctx);
+  const scope = ctx.scopedServices;
+  if (!scope || scope.size === 0) return groups;
+  return new Map([...groups].filter(([mountName]) => scope.has(mountName)));
+}
+
+/**
+ * True when a POST-MOUNT service name should be emitted in the current run.
+ * Inactive scoping (no `ctx.scopedServices`) ⇒ everything is in scope. Use this
+ * for inline per-service gates (e.g. manifest loops keyed by `getMountTarget`).
+ */
+export function isMountInScope(mountName: string, ctx: EmitterContext): boolean {
+  const scope = ctx.scopedServices;
+  return !scope || scope.size === 0 || scope.has(mountName);
+}
+
+/**
  * Get the mount target for an IR service.
  * Checks the first resolved operation that belongs to this service.
  * Falls back to PascalCase of the service name if no resolved ops exist.

--- a/test/shared/synthetic-enum-seed.test.ts
+++ b/test/shared/synthetic-enum-seed.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Enum, Model } from '@workos/oagen';
+import { enrichModelsFromSpec, getSyntheticEnums } from '../../src/shared/model-utils.js';
+
+// Regression: an inline oneOf enum whose synthetic name (`Parent_field`)
+// snake-collapses onto an existing IR enum must NOT spawn a duplicate
+// synthetic. `DataIntegrationAccessTokenResponse.error` (-> synthetic
+// `DataIntegrationAccessTokenResponse_error`) and the parser-emitted IR enum
+// `DataIntegrationAccessTokenResponseError` both snake to
+// `data_integration_access_token_response_error`. When both exist, every
+// PascalCase-normalizing emitter (PHP, Ruby, Go, ...) collapses them onto the
+// SAME file path, and which one wins is decided by array order — which differs
+// between a full and a scoped (`--services`) generation, yielding a
+// non-deterministic enum-case order. Seeding `enrichModelsFromSpec` with the
+// IR enum names suppresses the duplicate so the real enum always wins.
+const SPEC = {
+  openapi: '3.0.0',
+  info: { title: 'fixture', version: '1.0.0' },
+  paths: {},
+  components: {
+    schemas: {
+      DataIntegrationAccessTokenResponse: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                enum: ['not_installed', 'needs_reauthorization'],
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+const SYNTHETIC_NAME = 'DataIntegrationAccessTokenResponse_error';
+const models: Model[] = [{ name: 'DataIntegrationAccessTokenResponse', fields: [] }];
+const collidingEnum: Enum = {
+  name: 'DataIntegrationAccessTokenResponseError',
+  values: [
+    { name: 'NOT_INSTALLED', value: 'not_installed' },
+    { name: 'NEEDS_REAUTHORIZATION', value: 'needs_reauthorization' },
+  ],
+};
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'synthetic-enum-seed-'));
+  const specPath = join(dir, 'spec.yaml');
+  // `loadRawSpec` accepts JSON too (js-yaml parses JSON), so write JSON.
+  writeFileSync(specPath, JSON.stringify(SPEC));
+  process.env.OPENAPI_SPEC_PATH = specPath;
+});
+
+afterAll(() => {
+  delete process.env.OPENAPI_SPEC_PATH;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('enrichModelsFromSpec — synthetic enum seed', () => {
+  it('emits the inline synthetic enum when no IR enum names are seeded', () => {
+    enrichModelsFromSpec(models);
+    const names = getSyntheticEnums().map((e) => e.name);
+    expect(names).toContain(SYNTHETIC_NAME);
+  });
+
+  it('suppresses the duplicate synthetic when the colliding IR enum is seeded', () => {
+    enrichModelsFromSpec(models, [collidingEnum]);
+    const names = getSyntheticEnums().map((e) => e.name);
+    expect(names).not.toContain(SYNTHETIC_NAME);
+  });
+});


### PR DESCRIPTION
## Summary

Makes all 8 emitters **scope-aware** so `oagen generate --services <list>` emits only the selected post-mount services' files without disturbing the rest of an existing SDK tree. This is the emitter half of scoped SDK generation — it **must be released together** with the matching `@workos/oagen` engine change (workos/oagen#114), which produces the `ctx.scopedServices` / `ctx.scopedModelNames` / `ctx.scopedEnumNames` signals these emitters consume.

### What changed
- **Shared helpers** (`src/shared/resolved-ops.ts`): `scopedMountGroups`, `isMountInScope`, `isModelInScope`, `isEnumInScope`.
- **Per-service resource/test emission** gated on `ctx.scopedServices` (post-mount name) in all 8 emitters via `groupByMount`/`scopedMountGroups`.
- **Per-model / per-enum file emission** gated on `ctx.scopedModelNames`/`scopedEnumNames` (FR-1.4) — write a model/enum FILE only when reachable from the selected services; **barrels stay full** (built from the full set) so out-of-scope files left untouched on disk remain importable.
- **Aggregates kept full** where they're emitted outside `generateClient`: Rust `src/resources/mod.rs` (module list collected before the gate) + `_unions.rs` (registry runs for all models); Ruby aggregate `client.rbi`.
- **Go**: single `models.go`/`enums.go` can't isolate per-model → emits full (one shared file); resource/test scoping still applies.

### Validation
Isolation-correct test (fresh full baseline → **full-over-copy vs scoped-over-copy**, cancelling stale-baseline + node incremental noise): scoped output is a **byte-identical subset** of full, churning ≤ a full re-run. Python concretely: scoped `Vault` went 1172 → 595 files, **zero churn**, compiles. All aggregates intact (Rust `mod.rs` keeps every module; Ruby `client.rbi` full).

### Test plan
- [x] `npx tsc --noEmit` clean
- [x] `oxlint` clean
- [x] `vitest run` — **551 tests pass** (the scope signals are inert for full/no-`--services` runs)
- [x] Per-language scoped smoke (python/dotnet/kotlin/php/ruby/rust) — byte-identical subset

### Notes
- Requires a co-released, `scopedServices`/`scopedModelNames`-capable `@workos/oagen` (workos/oagen#114).
- Surfaced (out of scope, not caused by this change): node's standalone-mode interface barrels regenerate from a reduced set on re-run over a populated tree — a pre-existing node idempotence quirk that affects full re-runs equally and does **not** occur in the real `--api-surface` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)