### PR TITLE
fix: emitter compile failures in Go enums and PHP unions

### DIFF
--- a/src/go/enums.ts
+++ b/src/go/enums.ts
@@ -40,8 +40,19 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
   // renamed/removed ones still referenced by un-regenerated code). A full run
   // emits every block unchanged.
   const enumBlocks: NamedBlock[] = [];
+  // Go declares every enum in this one file, so the same Go type name must
+  // never be written twice — a second `type X` / `type X = Y` is a hard
+  // "redeclared in this block" compile error. The input list can contain
+  // same-named entries when a synthetic enum (from enrichModelsFromSpec)
+  // duplicates an inline enum the parser already emitted. Dedup by the final
+  // Go type name as a backstop, independent of how the list was assembled.
+  const emittedTypeNames = new Set<string>();
 
   for (const enumDef of enums) {
+    const goTypeName = className(enumDef.name);
+    if (emittedTypeNames.has(goTypeName)) continue;
+    emittedTypeNames.add(goTypeName);
+
     // If this enum is an alias, emit a simple type alias
     const canonicalName = aliasOf.get(enumDef.name);
     if (canonicalName) {

--- a/src/go/index.ts
+++ b/src/go/index.ts
@@ -32,8 +32,13 @@ export const goEmitter: Emitter = {
   language: 'go',
 
   generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
-    // Enrich models by flattening oneOf/allOf+oneOf variant fields from the raw spec
-    const enriched = enrichModelsFromSpec(models);
+    // Enrich models by flattening oneOf/allOf+oneOf variant fields from the raw
+    // spec. Pass the IR enums so enrichment seeds their names and does NOT mint a
+    // synthetic enum that duplicates one the parser already emitted (e.g. an
+    // inline `error` enum). Go writes every enum into a single enums.go, so a
+    // duplicate name becomes a `type X = Y` redeclaration and fails to compile.
+    // Ruby and PHP already pass `enums` here for the same reason.
+    const enriched = enrichModelsFromSpec(models, ctx.spec.enums);
     // Go has no sum types, so discriminated union base models (e.g. EventSchema)
     // need their base fields preserved. enrichModelsFromSpec clears fields for
     // discriminated models so dispatcher-capable languages can generate sealed

--- a/src/php/type-map.ts
+++ b/src/php/type-map.ts
@@ -89,16 +89,48 @@ function joinUnionVariants(ref: UnionType, variants: string[]): string {
   if (ref.compositionKind === 'allOf') {
     return variants[0] ?? 'mixed';
   }
-  const unique = [...new Set(variants)];
-  if (unique.length === 1) return unique[0];
-  return unique.join('|');
+  // PHP type declarations forbid the `?T` nullable shorthand inside a `|`
+  // union — `string|?string` is a parse error. Hoist nullability out of the
+  // variants: strip a leading `?`, drop a bare `null`, then re-attach it as a
+  // single `?T` (one non-null type) or trailing `|null` (several). A union of
+  // `string` + nullable-`string` (e.g. from a `oneOf: [string, {string|null}]`
+  // spec shape) thus collapses to `?string` instead of invalid `string|?string`.
+  const { nonNull, nullable } = splitNullable(variants);
+  if (nonNull.includes('mixed')) return 'mixed'; // `mixed` already permits null
+  if (nonNull.length === 0) return 'null';
+  if (nonNull.length === 1) return nullable ? `?${nonNull[0]}` : nonNull[0];
+  return nullable ? `${nonNull.join('|')}|null` : nonNull.join('|');
 }
 
 function joinDocUnionVariants(ref: UnionType, variants: string[]): string {
   if (ref.compositionKind === 'allOf') {
     return variants[0] ?? 'mixed';
   }
-  const unique = [...new Set(variants)];
-  if (unique.length === 1) return unique[0];
-  return unique.join('|');
+  // PHPDoc tolerates `?T`, but normalize the same way for consistency and to
+  // avoid redundant members (the doc nullable form is `T|null`, so split on `|`).
+  const { nonNull, nullable } = splitNullable(variants.flatMap((v) => v.split('|')));
+  if (nonNull.includes('mixed')) return 'mixed';
+  if (nonNull.length === 0) return 'null';
+  return nullable ? `${nonNull.join('|')}|null` : nonNull.join('|');
+}
+
+/**
+ * Partition rendered union variants into their non-null types plus a single
+ * nullability flag. Recognizes both the `?T` shorthand and a bare `null`/`'null'`
+ * variant. Deduplicates the non-null types while preserving first-seen order.
+ */
+function splitNullable(variants: string[]): { nonNull: string[]; nullable: boolean } {
+  let nullable = false;
+  const nonNull: string[] = [];
+  for (const v of variants) {
+    if (v === 'null' || v === "'null'") {
+      nullable = true;
+    } else if (v.startsWith('?')) {
+      nullable = true;
+      nonNull.push(v.slice(1));
+    } else {
+      nonNull.push(v);
+    }
+  }
+  return { nonNull: [...new Set(nonNull)], nullable };
 }

--- a/test/go/enums.test.ts
+++ b/test/go/enums.test.ts
@@ -61,6 +61,37 @@ describe('go/enums', () => {
     expect(content).toContain('type Beta = Alpha');
   });
 
+  it('never declares the same Go type twice when the enum list contains duplicates', () => {
+    // Reproduces the enums.go "redeclared in this block" failure: the Go
+    // emitter feeds generateEnums `[...enums, ...syntheticEnums]`, and a
+    // synthetic enum (from enrichModelsFromSpec) can duplicate an inline enum
+    // the parser already emitted. Both collapse to the same Go type name, so a
+    // naive emit writes two `type X = Y` / `type X` lines into the single
+    // enums.go — a hard compile error.
+    const dup: Enum = {
+      name: 'DataIntegrationCredentialsResponseError',
+      values: [
+        { name: 'NOT_INSTALLED', value: 'not_installed' },
+        { name: 'NEEDS_REAUTHORIZATION', value: 'needs_reauthorization' },
+      ],
+    };
+    const enums: Enum[] = [
+      {
+        name: 'DataIntegrationAccessTokenResponseError',
+        values: [
+          { name: 'NOT_INSTALLED', value: 'not_installed' },
+          { name: 'NEEDS_REAUTHORIZATION', value: 'needs_reauthorization' },
+        ],
+      },
+      dup,
+      // Same name appears a second time (IR enum + synthetic enum).
+      { ...dup },
+    ];
+    const content = generateEnums(enums, ctx)[0].content;
+    const declarations = content.match(/^type DataIntegrationCredentialsResponseError\b/gm) ?? [];
+    expect(declarations).toHaveLength(1);
+  });
+
   it('handles empty enums as type aliases to string', () => {
     const enums: Enum[] = [{ name: 'UnknownType', values: [] }];
     const files = generateEnums(enums, ctx);

--- a/test/php/type-map.test.ts
+++ b/test/php/type-map.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import type { TypeRef } from '@workos/oagen';
+import { mapTypeRef } from '../../src/php/type-map.js';
+
+const STRING: TypeRef = { kind: 'primitive', type: 'string' };
+const NULLABLE_STRING: TypeRef = { kind: 'nullable', inner: STRING };
+
+describe('php/type-map mapTypeRef', () => {
+  it('maps a plain nullable as the `?T` shorthand', () => {
+    expect(mapTypeRef(NULLABLE_STRING)).toBe('?string');
+  });
+
+  it('never emits the invalid `?T` shorthand inside a union', () => {
+    // Regression: a `oneOf: [string, {string|null}]` spec shape parses into a
+    // union of `string` + nullable-`string`. The naive join produced
+    // `string|?string`, which is a PHP parse error (php-cs-fixer exit 4).
+    const ref: TypeRef = {
+      kind: 'union',
+      compositionKind: 'oneOf',
+      variants: [STRING, NULLABLE_STRING],
+    };
+    const result = mapTypeRef(ref);
+    expect(result).not.toContain('|?');
+    expect(result).toBe('?string');
+  });
+
+  it('hoists nullability to a trailing `|null` for multi-type unions', () => {
+    const ref: TypeRef = {
+      kind: 'union',
+      compositionKind: 'oneOf',
+      variants: [STRING, { kind: 'nullable', inner: { kind: 'primitive', type: 'integer' } }],
+    };
+    // `string` + `?int` must become `string|int|null`, not `string|?int`.
+    const result = mapTypeRef(ref);
+    expect(result).not.toContain('|?');
+    expect(result).toBe('string|int|null');
+  });
+
+  it('leaves a genuine non-nullable union unchanged', () => {
+    const ref: TypeRef = {
+      kind: 'union',
+      compositionKind: 'oneOf',
+      variants: [
+        { kind: 'model', name: 'Foo' },
+        { kind: 'model', name: 'Bar' },
+      ],
+    };
+    expect(mapTypeRef(ref)).toBe('Foo|Bar');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix Go `redeclared in this block` compile error: the Go emitter writes every enum into a single enums.go, and a synthetic enum from `enrichModelsFromSpec` could duplicate an inline enum the parser already emitted, collapsing to the same Go type name.
- Pass the IR enums into `enrichModelsFromSpec` (matching Ruby and PHP) so it stops minting the duplicate, plus a name-based dedup backstop in `generateEnums`.
- Fix invalid PHP `string|?string`: a `oneOf: [string, {string|null}]` spec shape rendered the `?T` shorthand inside a `|` union, which php-cs-fixer rejects (exit 4).
- Hoist nullability out of union variants to a single `?T` or trailing `|null`, leaving genuine non-nullable unions unchanged.

## Test plan
- [ ] `npm test` (new regression tests in `test/go/enums.test.ts` and `test/php/type-map.test.ts` pass)
- [ ] Regenerate workos-go; enums.go compiles (no redeclared type)
- [ ] Regenerate workos-php; php-cs-fixer passes on union types