### PR TITLE
fix(python): no empty models barrel for out-of-scope new services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.23.0"
+        "@workos/oagen": "^0.24.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.23.0.tgz",
-      "integrity": "sha512-9eB6OnGr29VxPg/tBWKEI5B6C39v+lrqZpBZXbO5E2hEl+3hHUXAOrtGlMbZh4nLrXiwo16meDryEny1LDvjPw==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.24.1.tgz",
+      "integrity": "sha512-75DUcAr5Rfqgv/7XkvjjHG14nO1EwIoDh6KU+yJ2FDoSE6gIGeltZu1/dcc8qaGpE3/yCvj3Vzd/B5ErIgVWMw==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.23.0"
+    "@workos/oagen": "^0.24.1"
   }
 }

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -4,7 +4,14 @@ import { mapTypeRef } from './type-map.js';
 import { className, domainFieldName, fileName, buildMountDirMap, dirToModule } from './naming.js';
 import { collectGeneratedEnumSymbolsByDir, collectCompatEnumAliases } from './enums.js';
 import { computeSchemaPlacement } from './shared-schemas.js';
-import { isModelInScope, isEnumInScope, fileExistsAfterRun, priorManifestBasenames } from '../shared/resolved-ops.js';
+import {
+  isModelInScope,
+  isEnumInScope,
+  fileExistsAfterRun,
+  priorManifestBasenames,
+  isMountInScope,
+  getMountTarget,
+} from '../shared/resolved-ops.js';
 
 /**
  * Generate Python dataclass model files from IR Model definitions.
@@ -605,10 +612,19 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
 
   // Build set of service directory model paths — these get their parent __init__.py
   // from generateServiceInits in client.ts, so we must not create a competing one here.
+  // `inScopeServiceDirModelPaths` is the subset the current run is generating: in a
+  // scoped (`--services`) run it excludes services not selected, so a brand-new
+  // out-of-scope service the spec just added does not get a stray empty barrel.
+  // (Inactive scoping ⇒ isMountInScope is always true ⇒ the two sets match.)
   const serviceDirModelPaths = new Set<string>();
+  const inScopeServiceDirModelPaths = new Set<string>();
   for (const service of ctx.spec.services) {
     const dirName = mountDirMap.get(service.name) ?? resolveDir(service.name);
-    serviceDirModelPaths.add(`src/${ctx.namespace}/${dirName}/models`);
+    const modelsPath = `src/${ctx.namespace}/${dirName}/models`;
+    serviceDirModelPaths.add(modelsPath);
+    if (isMountInScope(getMountTarget(service, ctx), ctx)) {
+      inScopeServiceDirModelPaths.add(modelsPath);
+    }
   }
 
   // Emit an empty barrel for every service-models dir that has no symbols of
@@ -617,8 +633,9 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   // `__init__.py` from a previous spec revision — when the underlying module
   // gets pruned the dangling re-export survives and breaks pyright. Done here
   // (not in client.ts) so a subsequent emission for the same path with real
-  // content always wins last-write-wins.
-  for (const dirPath of serviceDirModelPaths) {
+  // content always wins last-write-wins. Skipped for services outside a scoped
+  // run's selection — we don't manage their tree this run.
+  for (const dirPath of inScopeServiceDirModelPaths) {
     if (!symbolsByDir.has(dirPath)) {
       files.push({
         path: `${dirPath}/__init__.py`,

--- a/test/python/scoped-aggregates.test.ts
+++ b/test/python/scoped-aggregates.test.ts
@@ -202,4 +202,76 @@ describe('python scoped aggregates', () => {
       expect(testFiles.find((f) => f.path === 'tests/fixtures/gadget_brand_new.json')).toBeDefined();
     });
   });
+
+  // A service the spec just added that the SDK has never generated (no files in
+  // the prior manifest) and that this scoped run did not select must not get a
+  // stray empty `<svc>/models/__init__.py`. Without the guard the empty-barrel
+  // pass — which walks the full spec — would materialize one, leaving an "Agents"
+  // package in a Pipes-only PR.
+  describe('brand-new out-of-scope service gets no empty models barrel', () => {
+    const localServices: Service[] = [
+      {
+        name: 'Widgets',
+        operations: [
+          {
+            name: 'getWidget',
+            httpMethod: 'get',
+            path: '/widgets/{id}',
+            pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'WidgetA' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+      {
+        name: 'Agents',
+        operations: [
+          {
+            name: 'getAgent',
+            httpMethod: 'get',
+            path: '/agents/{id}',
+            pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'AgentThing' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const localModels: Model[] = [
+      { name: 'WidgetA', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      { name: 'AgentThing', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const localSpec: ApiSpec = {
+      name: 'TestAPI',
+      version: '1.0.0',
+      baseUrl: 'https://api.workos.com',
+      services: localServices,
+      models: localModels,
+      enums: [],
+      sdk: defaultSdkBehavior(),
+    };
+    // Scoped to Widgets; the prior manifest has no record of Agents at all.
+    const ctx = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec: localSpec,
+      scopedServices: new Set(['Widgets']),
+      scopedModelNames: new Set(['WidgetA']),
+      scopedEnumNames: new Set<string>(),
+      priorTargetManifestPaths: new Set(['src/workos/widgets/models/widget_a.py']),
+    } as EmitterContext;
+
+    it('skips the empty barrel for the never-generated, out-of-scope service', () => {
+      const files = generateModels(localModels, ctx);
+      expect(files.find((f) => f.path === 'src/workos/agents/models/__init__.py')).toBeUndefined();
+      // The selected service's barrel is still produced.
+      expect(files.find((f) => f.path === 'src/workos/widgets/models/__init__.py')).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- In a scoped (`--services`) run, the empty service-models barrel pass walked the full spec, so a brand-new out-of-scope service the spec just added got a stray empty `<svc>/models/__init__.py` with no resource/models behind it (e.g. an `agents/` package surfacing in a Pipes-only PR).
- Build the empty-barrel candidate set from in-scope service dirs only, gated on `isMountInScope(getMountTarget(service, ctx), ctx)`.
- Because `isMountInScope` is always true when scoping is inactive, a full (non-scoped) run is unchanged and in-scope services still refresh their barrels.
- Adds a regression test in `test/python/scoped-aggregates.test.ts` covering the scoped out-of-scope-service case.

## Test plan
- [ ] `npm test` (or `script/ci`) passes, including the new scoped-aggregates test
- [ ] Scoped `--services` run on a spec adding a new out-of-scope service produces no stray empty `<svc>/models/__init__.py`
- [ ] Full (non-scoped) run output is unchanged
- [ ] In-scope services still get their refreshed empty barrels

🤖 Generated with [Claude Code](https://claude.com/claude-code)