### PR TITLE
fix(rust): barrel must list the emit surface, not the full spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.24.1"
+        "@workos/oagen": "^0.24.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.24.1.tgz",
-      "integrity": "sha512-75DUcAr5Rfqgv/7XkvjjHG14nO1EwIoDh6KU+yJ2FDoSE6gIGeltZu1/dcc8qaGpE3/yCvj3Vzd/B5ErIgVWMw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.24.2.tgz",
+      "integrity": "sha512-Sb+yPtxoniXm4l3FciP/8NgWuKXDEQDLLNYqXEJW6BREl6OfZpVfj5PL0mv5FzoJDtjidbojfPQnfWvi7CLtUQ==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.25.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.24.1"
+    "@workos/oagen": "^0.24.2"
   }
 }

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -14,7 +14,7 @@ import { fieldName, domainFieldName, methodName, typeName, moduleName, variantNa
 import { mapTypeRef, makeOptional, UnionRegistry } from './type-map.js';
 import { applySecretRedaction } from './secret.js';
 import { parsePathTemplate } from '../shared/path-template.js';
-import { groupByMount, buildResolvedLookup, isMountInScope } from '../shared/resolved-ops.js';
+import { groupByMount, buildResolvedLookup, isMountInScope, getMountTarget } from '../shared/resolved-ops.js';
 import { resolveWrapperParams, type ResolvedWrapperParam } from '../shared/wrapper-utils.js';
 
 /**
@@ -22,23 +22,35 @@ import { resolveWrapperParams, type ResolvedWrapperParam } from '../shared/wrapp
  * `src/resources/mod.rs` barrel. Each file collapses every IR service that
  * mounts on the same target into a single `Api` struct.
  */
-export function generateResources(_services: Service[], ctx: EmitterContext, registry: UnionRegistry): GeneratedFile[] {
+export function generateResources(services: Service[], ctx: EmitterContext, registry: UnionRegistry): GeneratedFile[] {
   const groups = groupByMount(ctx);
   const lookup = buildResolvedLookup(ctx);
   const files: GeneratedFile[] = [];
   const exports: { module: string; struct: string }[] = [];
 
+  // The emit surface the core resolved for this run: in a scoped run, the
+  // selected services PLUS every service already on disk — but NOT a service the
+  // spec has that this SDK never generated. The barrel must list exactly these.
+  // Listing every spec mount instead (the old behaviour) emitted `pub mod agents;`
+  // for a service whose `agents.rs` is neither emitted now nor present on disk —
+  // an orphaned module that fails to compile. Full runs pass every service here,
+  // so their barrels are unchanged.
+  const surfaceMounts = new Set(services.map((s) => getMountTarget(s, ctx)));
+
   for (const [mountName, group] of groups) {
     if (group.operations.length === 0) continue;
+    // Skip mounts outside the emit surface entirely — no barrel entry (would
+    // dangle) and no file. Present-but-not-selected mounts stay in surfaceMounts,
+    // so their existing `.rs` keeps a barrel entry below.
+    if (!surfaceMounts.has(mountName)) continue;
     const basename = moduleName(mountName);
     const struct = mountStructName(mountName);
-    // The barrel (`src/resources/mod.rs`) must list every mount's module so
-    // Rust compiles even in a scoped run — `exports` is collected from the
-    // FULL groupByMount set regardless of scope.
+    // The barrel (`src/resources/mod.rs`) lists every in-surface mount so Rust
+    // compiles even in a scoped run (on-disk siblings keep their entry).
     exports.push({ module: basename, struct });
-    // Only the per-service resource `.rs` FILE write is scoped. In a scoped
-    // run we skip emitting files for out-of-scope mounts, but the barrel above
-    // still references their modules (their existing `.rs` files stay on disk).
+    // Only the per-service resource `.rs` FILE write is scoped. In a scoped run
+    // we skip emitting files for out-of-scope-but-present mounts; the barrel
+    // above still references their modules (their existing `.rs` stays on disk).
     if (!isMountInScope(mountName, ctx)) continue;
     files.push({
       path: `src/resources/${basename}.rs`,

--- a/test/rust/resources.test.ts
+++ b/test/rust/resources.test.ts
@@ -50,6 +50,52 @@ describe('rust/resources', () => {
     expect(files.find((f) => f.path.startsWith('src/resources/empty'))).toBeUndefined();
   });
 
+  const svc = (name: string): Service => ({
+    name,
+    operations: [
+      {
+        name: `list${name}`,
+        httpMethod: 'get',
+        path: `/${name.toLowerCase()}`,
+        pathParams: [],
+        queryParams: [],
+        headerParams: [],
+        response: { kind: 'model', name },
+        errors: [],
+        injectIdempotencyKey: false,
+      },
+    ],
+  });
+
+  it('scoped run: barrel omits a spec mount that is neither selected nor on disk (no orphan `pub mod`)', () => {
+    const pipes = svc('Pipes');
+    const agents = svc('Agents');
+    // ctx resolves the FULL spec (both mounts), but the run's emit surface is
+    // Pipes only — Agents is a spec service this SDK never generated (not
+    // selected, not on disk), so the core does not include it in `services`.
+    const scopedCtx: EmitterContext = { ...ctxWithResolved([pipes, agents]), scopedServices: new Set(['Pipes']) };
+    const files = generateResources([pipes], scopedCtx, new UnionRegistry());
+    const barrel = files.find((f) => f.path === 'src/resources/mod.rs');
+    expect(barrel?.content).toContain('pub mod pipes;');
+    // The orphan: pre-fix the barrel listed `pub mod agents;` while agents.rs was
+    // never emitted → rust won't compile.
+    expect(barrel?.content).not.toContain('pub mod agents;');
+    expect(files.find((f) => f.path === 'src/resources/agents.rs')).toBeUndefined();
+  });
+
+  it('scoped run: barrel keeps an on-disk sibling (present, not selected) without re-emitting its file', () => {
+    const pipes = svc('Pipes');
+    const radar = svc('Radar');
+    // Surface = selected ∪ already-on-disk = [Pipes, Radar]; scope = Pipes only.
+    const scopedCtx: EmitterContext = { ...ctxWithResolved([pipes, radar]), scopedServices: new Set(['Pipes']) };
+    const files = generateResources([pipes, radar], scopedCtx, new UnionRegistry());
+    const barrel = files.find((f) => f.path === 'src/resources/mod.rs');
+    expect(barrel?.content).toContain('pub mod pipes;');
+    expect(barrel?.content).toContain('pub mod radar;'); // sibling stays referenced
+    expect(files.find((f) => f.path === 'src/resources/pipes.rs')).toBeDefined();
+    expect(files.find((f) => f.path === 'src/resources/radar.rs')).toBeUndefined(); // present, not selected → not re-emitted
+  });
+
   it('emits a resource struct with async methods', () => {
     const services: Service[] = [
       {


### PR DESCRIPTION
## Summary
- In a scoped (`--services`) run, `generateResources` ignored the resolved `services` arg and rebuilt the resources barrel from the FULL spec via `groupByMount(ctx)`. So `src/resources/mod.rs` emitted `pub mod agents;` for a service the spec has but this SDK never generated.
- `agents.rs` was neither emitted nor present on disk → orphaned module → the crate failed to compile.
- Fix: restrict the barrel to mounts in the emit surface (the passed `services`, mapped via `getMountTarget`). Present-but-not-selected siblings stay in the surface, so their on-disk `.rs` keeps a barrel entry; only never-generated spec services are dropped.
- Full runs pass every service, so their barrels are unchanged.

## Test plan
- [ ] Regression test: scoped run drops the orphan `pub mod agents;` when no `agents.rs` is emitted
- [ ] Regression test: an on-disk sibling keeps its barrel entry without re-emitting its file
- [ ] `script/ci` passes (fmt, build, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)