### PR TITLE
fix(scoped): complete the scoped-generation orphan fixes (rust client/manifest, ruby rbi/manifest)

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -821,11 +821,20 @@ export const nodeEmitter: Emitter = {
   generateClient(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
     const nodeCtx = withNodeOperationOverrides(ctx);
     const surface = getSurface(nodeCtx);
-    // `nodeCtx.spec` has the synthetic models that `enrichModelsFromSpec`
-    // produced (e.g. inline-object item types like `ConnectApplicationRedirectUri`).
-    // The `spec` param is the engine's pre-enrichment spec, so the barrel
-    // generator would miss those synthetic interfaces. Use the enriched one.
-    return applyLiveSurface(generateClient(nodeCtx.spec, nodeCtx), nodeCtx, surface);
+    // Use `nodeCtx.spec`'s enriched MODELS (synthetic inline-object item types
+    // like `ConnectApplicationRedirectUri` that the engine's pre-enrichment
+    // `spec` lacks), but restrict SERVICES to the emit surface the engine
+    // resolved (`spec.services` = selected ∪ already-on-disk). Passing
+    // nodeCtx.spec's FULL service list made workos.ts wire `readonly agents =
+    // new Agents(this)` (and the barrel export it) for a spec service this SDK
+    // never generated → dangling reference (TS2304); the import got scrubbed by
+    // the emitted-import invariant but the accessor did not.
+    const surfaceNames = new Set(spec.services.map((s) => s.name));
+    const clientSpec: ApiSpec = {
+      ...nodeCtx.spec,
+      services: nodeCtx.spec.services.filter((s) => surfaceNames.has(s.name)),
+    };
+    return applyLiveSurface(generateClient(clientSpec, nodeCtx), nodeCtx, surface);
   },
 
   // workos-node ships its own exception hierarchy under src/common/exceptions/.

--- a/src/ruby/manifest.ts
+++ b/src/ruby/manifest.ts
@@ -1,5 +1,6 @@
-import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
+import type { ApiSpec, EmitterContext, OperationsMap, Service } from '@workos/oagen';
 import { servicePropertyName } from './naming.js';
+import { getMountTarget } from '../shared/resolved-ops.js';
 
 /**
  * Build operation-to-SDK-method mapping for the manifest.
@@ -13,11 +14,15 @@ import { servicePropertyName } from './naming.js';
  * on collision.
  */
 export function buildOperationsMap(spec: ApiSpec, ctx: EmitterContext): OperationsMap {
-  void spec;
-  void ctx;
   const manifest: OperationsMap = {};
 
+  // Restrict to the emit surface (`spec` is the core's surfaceSpec = selected ∪
+  // on-disk). Recording a never-generated service here persists it into the
+  // merged manifest, so the next scoped run reads it back as present and re-wires
+  // it — the same recurrence the rust manifest fix prevents.
+  const surfaceMounts = new Set((spec.services as Service[]).map((s) => getMountTarget(s, ctx)));
   for (const r of ctx.resolvedOperations ?? []) {
+    if (!surfaceMounts.has(r.mountOn)) continue;
     const op = r.operation;
     const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
     const propName = servicePropertyName(r.mountOn);

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -1,4 +1,4 @@
-import type { ApiSpec, EmitterContext, GeneratedFile, TypeRef, Model } from '@workos/oagen';
+import type { ApiSpec, EmitterContext, GeneratedFile, TypeRef, Model, Service } from '@workos/oagen';
 import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
 import {
   className,
@@ -15,6 +15,7 @@ import {
 import {
   buildResolvedLookup,
   groupByMount,
+  getMountTarget,
   isMountInScope,
   isModelInScope,
   lookupResolved,
@@ -304,7 +305,15 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
     lines.push('module WorkOS');
     lines.push('  class Client < BaseClient');
 
+    // Restrict the client.rbi accessor sigs to the emit surface (`spec` is the
+    // core's surfaceSpec = selected ∪ on-disk). A present service keeps its sig
+    // (its .rbi stays on disk); a service the spec has but this SDK never
+    // generated is dropped — otherwise `sig { returns(WorkOS::Agents) }` names a
+    // constant with no class file → Sorbet "unable to resolve constant" under
+    // `# typed: strong`.
+    const surfaceMounts = new Set((spec.services as Service[]).map((s) => getMountTarget(s, ctx)));
     for (const [mountTarget] of groups) {
+      if (!surfaceMounts.has(mountTarget)) continue;
       const resolvedTarget = resolveServiceTarget(mountTarget, exportedClasses);
       const cls = className(resolvedTarget);
       const prop = servicePropertyName(mountTarget);

--- a/src/rust/client.ts
+++ b/src/rust/client.ts
@@ -1,7 +1,7 @@
 import type { ApiSpec, EmitterContext, GeneratedFile } from '@workos/oagen';
 import type { UnionRegistry } from './type-map.js';
 import { moduleName } from './naming.js';
-import { groupByMount } from '../shared/resolved-ops.js';
+import { groupByMount, getMountTarget } from '../shared/resolved-ops.js';
 import { mountStructName } from './resources.js';
 
 /**
@@ -20,7 +20,7 @@ import { mountStructName } from './resources.js';
  * accessors in a generated file lets `src/client.rs` remain hand-maintained
  * without drifting as services mount/unmount.
  */
-export function generateClient(_spec: ApiSpec, ctx: EmitterContext, registry: UnionRegistry): GeneratedFile[] {
+export function generateClient(spec: ApiSpec, ctx: EmitterContext, registry: UnionRegistry): GeneratedFile[] {
   const files: GeneratedFile[] = [];
 
   // _unions.rs — emitted unconditionally so the models barrel reference
@@ -28,17 +28,22 @@ export function generateClient(_spec: ApiSpec, ctx: EmitterContext, registry: Un
   const unionsContent = registry.size() > 0 ? registry.render() : '// No oneOf-style unions registered.\n';
   files.push({ path: 'src/models/_unions.rs', content: unionsContent, overwriteExisting: true });
 
-  // resources_api.rs — `impl Client { fn user_management() -> ... }`.
-  files.push({ path: 'src/resources_api.rs', content: renderResourcesApi(ctx), overwriteExisting: true });
+  // resources_api.rs — `impl Client { fn user_management() -> ... }`. Scoped to
+  // the emit surface (`spec` is the core's surfaceSpec = selected ∪ on-disk), so
+  // it never wires an accessor to a resource this run doesn't emit and isn't on
+  // disk — the same orphan class as the resources barrel.
+  files.push({ path: 'src/resources_api.rs', content: renderResourcesApi(spec, ctx), overwriteExisting: true });
 
   return files;
 }
 
-function renderResourcesApi(ctx: EmitterContext): string {
+function renderResourcesApi(spec: ApiSpec, ctx: EmitterContext): string {
+  const surfaceMounts = new Set(spec.services.map((s) => getMountTarget(s, ctx)));
   const groups = groupByMount(ctx);
   const targets: { accessor: string; struct: string }[] = [];
   for (const [mountName, group] of groups) {
     if (group.operations.length === 0) continue;
+    if (!surfaceMounts.has(mountName)) continue;
     targets.push({ accessor: moduleName(mountName), struct: mountStructName(mountName) });
   }
   targets.sort((a, b) => a.accessor.localeCompare(b.accessor));

--- a/src/rust/manifest.ts
+++ b/src/rust/manifest.ts
@@ -1,6 +1,6 @@
 import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
 import { methodName, moduleName } from './naming.js';
-import { groupByMount } from '../shared/resolved-ops.js';
+import { groupByMount, getMountTarget } from '../shared/resolved-ops.js';
 
 /**
  * Build the operation→SDK-method map written into `.oagen-manifest.json`,
@@ -11,10 +11,17 @@ import { groupByMount } from '../shared/resolved-ops.js';
  * one entry per wrapper (the wrapper name takes precedence over the raw op
  * name since the raw method does not exist in the generated SDK).
  */
-export function buildOperationsMap(_spec: ApiSpec, ctx: EmitterContext): OperationsMap {
+export function buildOperationsMap(spec: ApiSpec, ctx: EmitterContext): OperationsMap {
   const map: OperationsMap = {};
 
+  // Restrict to the emit surface (`spec` is the core's surfaceSpec = selected ∪
+  // on-disk). Recording a never-generated, out-of-scope service here would
+  // persist it into the merged manifest, so the NEXT scoped run reads it back as
+  // present (presentServiceKeys) and re-wires it into mod.rs / resources_api.rs —
+  // re-opening the orphan the barrel/client fixes prevent.
+  const surfaceMounts = new Set(spec.services.map((s) => getMountTarget(s, ctx)));
   for (const [mountName, group] of groupByMount(ctx)) {
+    if (!surfaceMounts.has(mountName)) continue;
     const accessor = moduleName(mountName);
     for (const r of group.resolvedOps) {
       const httpKey = `${r.operation.httpMethod.toUpperCase()} ${r.operation.path}`;

--- a/test/rust/client.test.ts
+++ b/test/rust/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { EmitterContext, ApiSpec, Model } from '@workos/oagen';
+import type { EmitterContext, ApiSpec, Model, Service } from '@workos/oagen';
 import { defaultSdkBehavior } from '@workos/oagen';
 import { generateClient } from '../../src/rust/client.js';
 import { generateModels } from '../../src/rust/models.js';
@@ -27,6 +27,53 @@ describe('rust/client', () => {
     expect(unions.content).toContain('No oneOf-style unions registered');
     const api = files.find((f) => f.path === 'src/resources_api.rs')!;
     expect(api.content).toContain('impl Client {');
+  });
+
+  it('scoped run: resources_api wires only surface accessors (no orphan for a never-generated service)', () => {
+    const svc = (name: string): Service => ({
+      name,
+      operations: [
+        {
+          name: `list${name}`,
+          httpMethod: 'get',
+          path: `/${name.toLowerCase()}`,
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    });
+    const pipes = svc('Pipes');
+    const agents = svc('Agents');
+    // ctx resolves the FULL spec (both mounts); the run's surface is Pipes only.
+    const ctx: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec: { ...emptySpec, services: [pipes, agents] },
+      scopedServices: new Set(['Pipes']),
+      resolvedOperations: [pipes, agents].flatMap((s) =>
+        s.operations.map((operation) => ({
+          service: s,
+          operation,
+          methodName: operation.name,
+          mountOn: s.name,
+          defaults: {},
+          inferFromClient: [],
+          urlBuilder: false,
+        })),
+      ),
+    };
+    // The core passes surfaceSpec (services = selected ∪ on-disk = [Pipes]).
+    const surfaceSpec: ApiSpec = { ...emptySpec, services: [pipes] };
+    const api = generateClient(surfaceSpec, ctx, new UnionRegistry()).find((f) => f.path === 'src/resources_api.rs')!;
+    expect(api.content).toContain('pub fn pipes');
+    // Pre-fix: `resources_api.rs` wired `pub fn agents() -> AgentsApi` for a
+    // resource never emitted → compile break.
+    expect(api.content).not.toContain('AgentsApi');
+    expect(api.content).not.toContain('pub fn agents');
   });
 
   it('renders unions registered earlier in the emit run', () => {

--- a/test/rust/manifest.test.ts
+++ b/test/rust/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { EmitterContext, ApiSpec } from '@workos/oagen';
+import type { EmitterContext, ApiSpec, Service } from '@workos/oagen';
 import { defaultSdkBehavior } from '@workos/oagen';
 import { buildOperationsMap } from '../../src/rust/manifest.js';
 
@@ -69,5 +69,51 @@ describe('rust/manifest', () => {
       sdkMethod: 'get_organization',
       service: 'organizations',
     });
+  });
+
+  it('scoped run: omits a never-generated (out-of-scope, not present) service', () => {
+    const mk = (name: string): Service => ({
+      name,
+      operations: [
+        {
+          name: `list${name}`,
+          httpMethod: 'get',
+          path: `/${name.toLowerCase()}`,
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'primitive', type: 'unknown' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    });
+    const pipes = mk('Pipes');
+    const agents = mk('Agents');
+    // ctx resolves the FULL spec (both); scope = Pipes. The core passes the
+    // surfaceSpec (services = [Pipes]) — Agents is a spec service never generated.
+    const fullCtx: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec: { ...spec, services: [pipes, agents] },
+      scopedServices: new Set(['Pipes']),
+      resolvedOperations: [pipes, agents].flatMap((s) =>
+        s.operations.map((operation) => ({
+          service: s,
+          operation,
+          methodName: operation.name,
+          mountOn: s.name,
+          defaults: {},
+          inferFromClient: [],
+          urlBuilder: false,
+        })),
+      ),
+    };
+    const surfaceSpec: ApiSpec = { ...spec, services: [pipes] };
+    const map = buildOperationsMap(surfaceSpec, fullCtx);
+    expect(map['GET /pipes']).toEqual({ sdkMethod: 'list_pipes', service: 'pipes' });
+    // Pre-fix: recorded `service: 'agents'`, which re-entered presentServiceKeys
+    // next run and re-opened the barrel/client orphan.
+    expect(map['GET /agents']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Completes the scoped-generation **orphan** fixes started in #170 (which fixed only the rust resources *barrel*). In a scoped `--services` run the engine hands each emitter the emit **surface** (selected ∪ already-on-disk services), but several aggregate emitters built their member list from the **full spec** instead — emitting a reference to a service the SDK never generated → a dangling module / import / accessor / type.

Four remaining instances, each fixed by restricting the aggregate to the surface (`getMountTarget` over the passed `services`/`spec`):

- **rust `resources_api.rs`** — wired `pub fn agents() -> AgentsApi` for an unemitted resource → won't compile. **Without this, #170's barrel-only fix still leaves scoped rust broken.**
- **rust `manifest.ts`** — recorded a never-generated service in `.oagen-manifest.json`, which re-enters `presentServiceKeys` on the next run and re-opens the orphan.
- **ruby `client.rbi`** — `sig { returns(WorkOS::<Svc>) }` for a class with no file → Sorbet unresolved-constant under `# typed: strong`.
- **ruby `manifest.ts`** — same manifest recurrence as rust (surfaced by the new cross-language invariant test).

Full runs pass every service, so their output is byte-identical. Regression tests included; full emitter suite (589) green.

Pairs with the node fix (`fix-node-client-surface`) and the guard (`test-scoped-orphan-invariant`). Target a 0.19.5 release once these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)