### PR TITLE
fix(node): scope the WorkOS client to the emit surface

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -821,11 +821,20 @@ export const nodeEmitter: Emitter = {
   generateClient(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
     const nodeCtx = withNodeOperationOverrides(ctx);
     const surface = getSurface(nodeCtx);
-    // `nodeCtx.spec` has the synthetic models that `enrichModelsFromSpec`
-    // produced (e.g. inline-object item types like `ConnectApplicationRedirectUri`).
-    // The `spec` param is the engine's pre-enrichment spec, so the barrel
-    // generator would miss those synthetic interfaces. Use the enriched one.
-    return applyLiveSurface(generateClient(nodeCtx.spec, nodeCtx), nodeCtx, surface);
+    // Use `nodeCtx.spec`'s enriched MODELS (synthetic inline-object item types
+    // like `ConnectApplicationRedirectUri` that the engine's pre-enrichment
+    // `spec` lacks), but restrict SERVICES to the emit surface the engine
+    // resolved (`spec.services` = selected ∪ already-on-disk). Passing
+    // nodeCtx.spec's FULL service list made workos.ts wire `readonly agents =
+    // new Agents(this)` (and the barrel export it) for a spec service this SDK
+    // never generated → dangling reference (TS2304); the import got scrubbed by
+    // the emitted-import invariant but the accessor did not.
+    const surfaceNames = new Set(spec.services.map((s) => s.name));
+    const clientSpec: ApiSpec = {
+      ...nodeCtx.spec,
+      services: nodeCtx.spec.services.filter((s) => surfaceNames.has(s.name)),
+    };
+    return applyLiveSurface(generateClient(clientSpec, nodeCtx), nodeCtx, surface);
   },
 
   // workos-node ships its own exception hierarchy under src/common/exceptions/.


### PR DESCRIPTION
## Summary

Same scoped-generation **orphan** class as #170 / #172, in the node emitter.

The node plugin's `generateClient` handed the **full** enriched `nodeCtx.spec` to the internal client generator (to keep synthetic inline-object models), so `src/workos.ts` wired `readonly agents = new Agents(this)` — and the barrel exported it — for a service this SDK never generated. The companion `import` is scrubbed by the emitted-import invariant, but the **accessor is not** → dangling reference (TS2304).

Fix: keep the enriched models, but restrict **services** to the surface the engine passes (`spec.services` = selected ∪ on-disk). Full runs pass every service, so output is unchanged.

Part of the 0.19.5 orphan-fix set (#172 + this). The cross-language guard in `test-scoped-orphan-invariant` covers this end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)