### PR TITLE
fix: minimal scoped generation across all languages (fixtures + round-trip/forward-compat tests)

### DIFF
--- a/src/dotnet/fixtures.ts
+++ b/src/dotnet/fixtures.ts
@@ -2,15 +2,7 @@ import type { Model, TypeRef, Enum, EmitterContext } from '@workos/oagen';
 import { fixtureFileName, domainFieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
 import { collectNonPaginatedResponseModelNames } from '../shared/model-utils.js';
-import { isModelInScope, fileExistsAfterRun } from '../shared/resolved-ops.js';
-
-/**
- * Prefix the per-model fixture path with the .NET test project layout so the
- * scoped-run gate can compare it against the prefixed paths recorded in the
- * prior manifest. Must mirror `TEST_PREFIX` in index.ts; the fixture path
- * itself (`testdata/<name>.json`) is what `prefixTestPaths` later prepends to.
- */
-const TEST_PREFIX = 'test/WorkOSTests/';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 /**
  * Prefix mapping for generating realistic ID fixture values.
@@ -62,14 +54,17 @@ export function generateFixtures(
     if (isListMetadataModel(model)) continue;
     if (isListWrapperModel(model) && !nonPaginatedWrapperRefs.has(model.name)) continue;
 
-    // Scoped-run gate: only emit a per-model fixture whose file will exist on
-    // disk after the run (in-scope, or already present from a prior manifest).
-    // A brand-new out-of-scope model's fixture would be a stray file for a
-    // model no in-scope test can reference; a renamed/removed-but-on-disk one
-    // is retained. Full runs emit everything. `relPath` carries the
-    // `test/WorkOSTests/` prefix so it matches the prefixed prior-manifest paths.
+    // Minimal-scoped-generation gate (FR: byte-for-byte untouched siblings):
+    // emit a per-model fixture ONLY for a SELECTED (in-scope) model. Under a
+    // scoped (`--services X`) run `isModelInScope` is true only for models
+    // reachable from service X, so out-of-scope services' fixtures are never
+    // (re)written and stay byte-for-byte identical on disk. This is
+    // deliberately SELECTED-only, not the SURFACE `fileExistsAfterRun` gate:
+    // re-emitting an already-on-disk out-of-scope fixture would rewrite a file
+    // outside the requested scope (and drift it if that model's shape changed
+    // upstream). Full runs (`ctx.scopedModelNames` unset) emit everything.
     const fixturePath = `testdata/${fixtureFileName(model.name)}.json`;
-    if (!fileExistsAfterRun(`${TEST_PREFIX}${fixturePath}`, isModelInScope(model.name, ctx), ctx)) continue;
+    if (!isModelInScope(model.name, ctx)) continue;
 
     const fixture = model.fields.length === 0 ? {} : generateModelFixture(model, modelMap, enumMap);
 

--- a/src/go/fixtures.ts
+++ b/src/go/fixtures.ts
@@ -2,7 +2,7 @@ import type { Model, TypeRef, Enum, EmitterContext } from '@workos/oagen';
 import { fileName, domainFieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
 import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
-import { isModelInScope, fileExistsAfterRun } from '../shared/resolved-ops.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 /**
  * Prefix mapping for generating realistic ID fixture values.
@@ -26,12 +26,19 @@ export const ID_PREFIXES: Record<string, string> = {
 /**
  * Generate JSON fixture files for test data.
  *
- * Scoped runs only emit a fixture for a model whose per-model fixture FILE will
- * exist on disk after the run (in-scope, or already present from a prior run —
- * the fixture path is per-model so the prior manifest records it directly).
- * This drops brand-new out-of-scope fixtures (the round-trip ADDITION case) and
- * keeps prior fixtures untouched, mirroring the Rust fixtures fix. `ctx` is
- * optional so unit tests that assert raw content can call it for a full run.
+ * Minimal-scoped-generation gate (byte-for-byte untouched siblings): each
+ * fixture is a standalone per-model JSON file under `testdata/` with no
+ * barrel/index — a test reads it by path via `os.ReadFile`. Under a scoped
+ * (`--services X`) run we therefore emit a fixture ONLY for a SELECTED model
+ * (reachable from service X), gating on {@link isModelInScope}. Out-of-scope
+ * services' fixtures are never (re)written and stay BYTE-FOR-BYTE identical on
+ * disk. This is deliberately SELECTED-only, NOT the SURFACE `fileExistsAfterRun`
+ * gate: re-emitting an already-on-disk out-of-scope fixture would rewrite a file
+ * outside the requested scope (and drift it if that model's shape changed
+ * upstream), whereas a barrel entry needs the surface so its declaration stays
+ * valid — a standalone fixture has no such dependent. Full runs
+ * (`ctx.scopedModelNames` unset) emit everything. `ctx` is optional so unit
+ * tests that assert raw content can call it for a full run.
  */
 export function generateFixtures(
   spec: { models: Model[]; enums: Enum[]; services: any[] },
@@ -49,16 +56,16 @@ export function generateFixtures(
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(spec.services);
   const listMetadataNeeded = collectReferencedListMetadataModels(spec.models, nonPaginatedRefs);
 
-  // Full run (no ctx / no scoping): every fixture is in scope.
-  const fixtureInScope = (relPath: string, modelName: string): boolean =>
-    !ctx || fileExistsAfterRun(relPath, isModelInScope(modelName, ctx), ctx);
+  // Scoped run: emit only the SELECTED models' fixtures. Full run (no ctx / no
+  // scoping): every fixture is in scope.
+  const fixtureInScope = (modelName: string): boolean => !ctx || isModelInScope(modelName, ctx);
 
   for (const model of spec.models) {
     if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
     if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
 
     const path = `testdata/${fileName(model.name)}.json`;
-    if (!fixtureInScope(path, model.name)) continue;
+    if (!fixtureInScope(model.name)) continue;
 
     const fixture = model.fields.length === 0 ? {} : generateModelFixture(model, modelMap, enumMap);
 
@@ -85,10 +92,10 @@ export function generateFixtures(
           const path = `testdata/list_${fileName(itemModel.name)}.json`;
           if (seenListPaths.has(path)) continue;
           seenListPaths.add(path);
-          // Scoped run: only emit a list fixture whose file will exist after the
-          // run (in-scope item model, or already on disk). Keyed on the item
-          // model so an out-of-scope paginated endpoint doesn't add a new file.
-          if (!fixtureInScope(path, itemModel.name)) continue;
+          // Scoped run: emit a list fixture only when its item model is SELECTED.
+          // Keyed on the item model so an out-of-scope paginated endpoint doesn't
+          // add a new file (and doesn't rewrite an on-disk out-of-scope one).
+          if (!fixtureInScope(itemModel.name)) continue;
           const fixture = generateModelFixture(itemModel, modelMap, enumMap);
           const listFixture = {
             data: [fixture],

--- a/src/go/tests.ts
+++ b/src/go/tests.ts
@@ -72,8 +72,8 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   });
 
   // Generate fixture JSON files. Pass ctx so a scoped run only emits fixtures
-  // for in-scope models (or ones already on disk), dropping brand-new
-  // out-of-scope fixtures while leaving prior fixtures untouched.
+  // for SELECTED (in-scope) models, leaving every out-of-scope service's
+  // fixtures byte-for-byte untouched on disk (see generateFixtures).
   const { files: fixtures, pathRewrites: fixtureRewrites } = generateFixtures(spec, ctx);
   for (const fixture of fixtures) {
     files.push({

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -30,6 +30,7 @@ import {
   isModelInScope,
   isEnumInScope,
   fileExistsAfterRun,
+  isScopedRun,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
@@ -111,8 +112,18 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     });
   }
 
-  const roundTripFile = generateModelRoundTripTest(spec, ctx);
-  if (roundTripFile) files.push(roundTripFile);
+  // MINIMAL SCOPED GENERATION: the model round-trip suite is a single
+  // whole-suite AGGREGATE file (`GeneratedModelRoundTripTest.kt`) that covers
+  // every model. A scoped (`--services`) run must regenerate ONLY the selected
+  // service's files and leave every other on-disk service byte-for-byte
+  // untouched, so we skip emitting this monolithic file entirely under scoping
+  // (leaving the existing on-disk copy in place). Full runs (scoping inert)
+  // keep emitting it. The per-service test classes above stay scoped via
+  // `scopedMountGroups` and are unaffected.
+  if (!isScopedRun(ctx)) {
+    const roundTripFile = generateModelRoundTripTest(spec, ctx);
+    if (roundTripFile) files.push(roundTripFile);
+  }
 
   const forwardCompatFile = generateForwardCompatTest(spec, ctx);
   if (forwardCompatFile) files.push(forwardCompatFile);

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -112,21 +112,20 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     });
   }
 
-  // MINIMAL SCOPED GENERATION: the model round-trip suite is a single
-  // whole-suite AGGREGATE file (`GeneratedModelRoundTripTest.kt`) that covers
-  // every model. A scoped (`--services`) run must regenerate ONLY the selected
-  // service's files and leave every other on-disk service byte-for-byte
-  // untouched, so we skip emitting this monolithic file entirely under scoping
-  // (leaving the existing on-disk copy in place). Full runs (scoping inert)
-  // keep emitting it. The per-service test classes above stay scoped via
+  // MINIMAL SCOPED GENERATION: BOTH whole-suite AGGREGATE files under
+  // `com/workos/models` — `GeneratedModelRoundTripTest.kt` and
+  // `GeneratedForwardCompatTest.kt` — cover every model. A scoped (`--services`)
+  // run must regenerate ONLY the selected service's files and leave every other
+  // on-disk service byte-for-byte untouched, so we skip emitting BOTH monolithic
+  // files under scoping (leaving the on-disk copies in place). Full runs (scoping
+  // inert) keep emitting them. The per-service test classes above stay scoped via
   // `scopedMountGroups` and are unaffected.
   if (!isScopedRun(ctx)) {
     const roundTripFile = generateModelRoundTripTest(spec, ctx);
     if (roundTripFile) files.push(roundTripFile);
+    const forwardCompatFile = generateForwardCompatTest(spec, ctx);
+    if (forwardCompatFile) files.push(forwardCompatFile);
   }
-
-  const forwardCompatFile = generateForwardCompatTest(spec, ctx);
-  if (forwardCompatFile) files.push(forwardCompatFile);
 
   return files;
 }

--- a/src/php/fixtures.ts
+++ b/src/php/fixtures.ts
@@ -1,6 +1,7 @@
-import type { Model, TypeRef, Enum } from '@workos/oagen';
+import type { Model, TypeRef, Enum, EmitterContext } from '@workos/oagen';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
 import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 import { snakeName } from './naming.js';
 
 /**
@@ -24,13 +25,31 @@ export const ID_PREFIXES: Record<string, string> = {
 
 /**
  * Generate JSON fixture files for test data.
+ *
+ * FR-1.4: fixtures are per-model standalone JSON files under `tests/Fixtures/`
+ * with no barrel/index (they are loaded by name via TestHelper::loadFixture).
+ * Under a scoped (`--services`) run we therefore emit a fixture ONLY for a model
+ * that is in scope (SELECTED — reachable from the chosen services), gating on
+ * {@link isModelInScope}. Out-of-scope fixtures are left untouched on disk so a
+ * scoped run leaves every other service's fixtures BYTE-FOR-BYTE unchanged.
+ * `isModelInScope` (selected-only) — NOT `fileExistsAfterRun` (surface) — is the
+ * right gate here because a fixture is standalone: nothing references it that we
+ * must keep declared, unlike a barrel entry.
+ *
+ * `ctx` is optional so callers without a context (older tests) keep the full
+ * behavior; scoping is inert when `ctx` is absent or unscoped.
  */
-export function generateFixtures(spec: {
-  models: Model[];
-  enums: Enum[];
-  services: any[];
-}): { path: string; content: string }[] {
+export function generateFixtures(
+  spec: {
+    models: Model[];
+    enums: Enum[];
+    services: any[];
+  },
+  ctx?: EmitterContext,
+): { path: string; content: string }[] {
   if (spec.models.length === 0) return [];
+
+  const inScope = (modelName: string): boolean => (ctx ? isModelInScope(modelName, ctx) : true);
 
   const modelMap = new Map(spec.models.map((m) => [m.name, m]));
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
@@ -41,6 +60,8 @@ export function generateFixtures(spec: {
   for (const model of spec.models) {
     if (isListMetadataModel(model) && !listMetadataNeeded.has(model.name)) continue;
     if (isListWrapperModel(model)) continue;
+    // Scoped run: emit only the selected models' fixtures.
+    if (!inScope(model.name)) continue;
 
     const fixture = generateModelFixture(model, modelMap, enumMap);
 
@@ -59,6 +80,8 @@ export function generateFixtures(spec: {
           const unwrapped = unwrapListModel(itemModel, modelMap);
           if (unwrapped) itemModel = unwrapped;
           if (itemModel.fields.length === 0) continue;
+          // Scoped run: emit the list fixture only when its item model is selected.
+          if (!inScope(itemModel.name)) continue;
           const fixture = generateModelFixture(itemModel, modelMap, enumMap);
           const listFixture = {
             data: [fixture],

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -41,7 +41,8 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   // This correctly handles operationHint mountOn overrides (e.g., audit_logs_retention → AuditLogs).
   // In a scoped (`--services`) run this returns only the selected post-mount
   // services so we emit per-service test files for those alone. ClientTest.php
-  // and fixtures below are built from `spec` and stay full.
+  // is a trivial constructor test (no per-model deps) and always emits. Fixtures
+  // below are scoped per-model via `generateFixtures(spec, ctx)`.
   const mountGroupsFromResolved = scopedMountGroups(ctx);
   const mountGroups = new Map<string, { op: Operation; service: Service; resolvedOp?: ResolvedOperation }[]>();
   if (mountGroupsFromResolved.size > 0 || ctx.scopedServices?.size) {
@@ -80,8 +81,13 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     overwriteExisting: true,
   });
 
-  // Generate fixture JSON files
-  const fixtures = generateFixtures(spec);
+  // Generate fixture JSON files. Pass `ctx` so a scoped (`--services`) run only
+  // (re)emits fixtures for SELECTED (in-scope) models; out-of-scope fixtures are
+  // left untouched on disk (byte-for-byte), matching the per-model file gate in
+  // models.ts. PHP has no monolithic model round-trip test — model round-trips
+  // are exercised inline in the per-service `*Test.php` files (already scoped via
+  // `scopedMountGroups`) — so there is no whole-suite aggregate to skip here.
+  const fixtures = generateFixtures(spec, ctx);
   for (const fixture of fixtures) {
     files.push({
       path: fixture.path,

--- a/src/python/fixtures.ts
+++ b/src/python/fixtures.ts
@@ -3,7 +3,7 @@ import type { Model, TypeRef, Enum, EmitterContext } from '@workos/oagen';
 import { fileName, domainFieldName } from './naming.js';
 import { isListMetadataModel, isListWrapperModel } from './models.js';
 import { collectNonPaginatedResponseModelNames, collectReferencedListMetadataModels } from '../shared/model-utils.js';
-import { isModelInScope, fileExistsAfterRun } from '../shared/resolved-ops.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 /**
  * Prefix mapping for generating realistic ID fixture values.
@@ -28,11 +28,14 @@ export const ID_PREFIXES: Record<string, string> = {
  * Generate JSON fixture files for test data.
  *
  * `ctx` is optional so unit tests can call with a bare spec; when supplied, a
- * scoped (`--services`) run only emits a fixture for a model whose per-model
- * file will exist on disk after the run (in-scope, or already present from a
- * prior manifest). Brand-new out-of-scope models are skipped: the round-trip
- * test that consumes these fixtures is gated the same way, and the per-service
- * tests only reference fixtures for their (in-scope) models.
+ * scoped (`--services`) run only emits a fixture for a SELECTED (in-scope)
+ * model — `isModelInScope` alone, NOT `fileExistsAfterRun`. Minimal scoped
+ * generation regenerates ONLY the selected service's files: every other
+ * on-disk service's fixtures must be left BYTE-FOR-BYTE untouched, so we must
+ * not re-emit a fixture just because the model already sits on disk (from the
+ * prior manifest). The monolithic round-trip test that consumed the wider set
+ * of fixtures is skipped entirely on a scoped run, and the per-service tests
+ * only reference fixtures for their (in-scope) models.
  */
 export function generateFixtures(
   spec: {
@@ -48,15 +51,15 @@ export function generateFixtures(
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
   const files: { path: string; content: string }[] = [];
 
-  // Gate a fixture by ITS OWN path (recorded verbatim in the prior manifest),
-  // scoped on the owning model. A base-model fixture and its `list_*` fixture
-  // are distinct files, so each must be checked against its own path — keying a
-  // list fixture off the base path would leak a brand-new `list_*` fixture for
-  // an out-of-scope model that merely already had its base fixture on disk.
-  // When ctx is absent (unit tests) every fixture is in scope.
-  const fixtureEmitted = (path: string, modelName: string): boolean => {
+  // A fixture is emitted only for a SELECTED (in-scope) model. `isModelInScope`
+  // is selected-only under a scoped run and true for everything on a full run,
+  // so this leaves every out-of-scope service's fixtures untouched on disk.
+  // The `path` arg is retained for call-site symmetry (base vs. `list_*`) but
+  // scoping keys purely off the owning model. When ctx is absent (unit tests)
+  // every fixture is in scope.
+  const fixtureEmitted = (_path: string, modelName: string): boolean => {
     if (!ctx) return true;
-    return fileExistsAfterRun(path, isModelInScope(modelName, ctx), ctx);
+    return isModelInScope(modelName, ctx);
   };
 
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(spec.services);

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -30,8 +30,7 @@ import {
   lookupResolved,
   buildHiddenParams,
   collectGroupedParamNames,
-  isModelInScope,
-  fileExistsAfterRun,
+  isScopedRun,
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { pythonLiteral } from './wrappers.js';
@@ -137,9 +136,16 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     if (testFile) files.push(testFile);
   }
 
-  // Generate model round-trip tests (P3-7)
-  const modelTests = generateModelRoundTripTests(spec, ctx);
-  if (modelTests) files.push(modelTests);
+  // Generate model round-trip tests (P3-7).
+  // This is ONE monolithic file (tests/test_models_round_trip.py) covering ALL
+  // models. Under minimal scoped generation a scoped `--services X` run must not
+  // touch it: it would otherwise be rewritten to reference only the selected
+  // service's models, mutating a file that belongs to the whole SDK. Skip
+  // emitting it entirely on a scoped run so the on-disk file is left untouched.
+  if (!isScopedRun(ctx)) {
+    const modelTests = generateModelRoundTripTests(spec, ctx);
+    if (modelTests) files.push(modelTests);
+  }
 
   return files;
 }
@@ -1467,32 +1473,21 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
   // The round-trip test imports models from their *natural* (pre-relocation)
   // service so existing callers keep working — those imports resolve via the
   // BC re-exports that the model emitter writes into each service barrel.
+  // This wholesale test only runs on a FULL (non-scoped) generation — a scoped
+  // run skips emitting it entirely (see generateTests → isScopedRun) — so no
+  // per-model on-disk gate is needed here: every non-request-only model file is
+  // freshly emitted by the same full run.
   const placement = computeSchemaPlacement(spec, ctx);
   const modelToService = placement.originalModelToService;
-  // The per-model FILE is written to the RELOCATED dir; use it to compute the
-  // gate's relPath so it lines up with the prior manifest.
-  const relocatedModelToService = placement.modelToService;
   const roundTripDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (roundTripDirMap.get(irService) ?? 'common') : 'common';
-
-  // Scoped runs: the round-trip test must only reference a model whose per-model
-  // file exists on disk after the run (in-scope, or already present from the
-  // prior manifest). A brand-new out-of-scope model is excluded — its file is
-  // never emitted, so importing it would raise ModuleNotFoundError. A full run
-  // keeps every model (fileExistsAfterRun ⇒ true).
-  const modelFileExists = (name: string): boolean => {
-    const dir = resolveDir(relocatedModelToService.get(name));
-    const path = `src/${ctx.namespace}/${dir}/models/${fileName(name)}.py`;
-    return fileExistsAfterRun(path, isModelInScope(name, ctx), ctx);
-  };
 
   const models = spec.models.filter(
     (m) =>
       !(isListWrapperModel(m) && !nonPaginatedRefs.has(m.name)) &&
       !(isListMetadataModel(m) && !listMetadataNeeded.has(m.name)) &&
-      !requestOnlyModelNames.has(m.name) &&
-      modelFileExists(m.name),
+      !requestOnlyModelNames.has(m.name),
   );
   if (models.length === 0) return null;
 

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -21,6 +21,7 @@ import {
   collectBodyFieldTypes,
   isModelInScope,
   fileExistsAfterRun,
+  isScopedRun,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { classifyUnassignedModel } from './models.js';
@@ -208,7 +209,15 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     });
   }
 
-  files.push(generateModelRoundTripTest(spec, ctx));
+  // Minimal scope: the model round-trip test is one wholesale file covering
+  // every model, so regenerating it in a scoped run would either drag in every
+  // on-disk model (surface) or drop their coverage. Skip it entirely in a scoped
+  // run — leave the on-disk file untouched. The selected service's models still
+  // regenerate; their brand-new fields just aren't round-trip-tested until the
+  // next full generation (accepted trade-off for X-only diffs).
+  if (!isScopedRun(ctx)) {
+    files.push(generateModelRoundTripTest(spec, ctx));
+  }
 
   return files;
 }

--- a/src/rust/fixtures.ts
+++ b/src/rust/fixtures.ts
@@ -1,17 +1,22 @@
 import type { ApiSpec, GeneratedFile, Model, Enum, TypeRef, EmitterContext } from '@workos/oagen';
 import { walkTypeRef } from '@workos/oagen';
 import { moduleName } from './naming.js';
-import { isModelInScope, fileExistsAfterRun } from '../shared/resolved-ops.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate JSON test fixture files under `tests/fixtures/`. The Rust tests
  * pull these in via `include_str!` so no I/O is required at test time.
  *
- * Scoped runs only emit a fixture for a model whose file will exist on disk
- * after the run (in-scope, or already present from a prior run). Emitting a
- * fixture for a brand-new out-of-scope model would add a stray file for a model
- * the SDK can't even reference yet; in-scope tests only `include_str!` fixtures
- * for in-scope models, so gating here is safe.
+ * A fixture is a per-model FILE, so under a scoped (`--services`) run it is
+ * gated to the SELECTED set alone ({@link isModelInScope}) — exactly like the
+ * per-model `.rs` file writer in models.ts. Out-of-scope models' fixtures are
+ * left byte-for-byte untouched on disk (a scoped run must regenerate ONLY the
+ * selected services' files). We deliberately do NOT retain prior-on-disk
+ * fixtures via `fileExistsAfterRun`: unlike a barrel/`mod.rs` there is no
+ * aggregate that must reference every fixture, and scoped test files only
+ * `include_str!` fixtures for in-scope models, so re-emitting an out-of-scope
+ * fixture would only rewrite another service's file. A full run (scoping
+ * inert) still emits every fixture.
  */
 export function generateFixtures(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
@@ -25,7 +30,7 @@ export function generateFixtures(spec: ApiSpec, ctx: EmitterContext): GeneratedF
     seen.add(model.name);
 
     const path = `tests/fixtures/${moduleName(model.name)}.json`;
-    if (!fileExistsAfterRun(path, isModelInScope(model.name, ctx), ctx)) continue;
+    if (!isModelInScope(model.name, ctx)) continue;
 
     const fixture = generateModelFixture(model, modelMap, enumMap, new Set());
     files.push({

--- a/test/dotnet/scoped-aggregates.test.ts
+++ b/test/dotnet/scoped-aggregates.test.ts
@@ -160,7 +160,14 @@ describe('dotnet/scoped aggregates', () => {
     expect(converter.content).toContain('ToObject<SessionReauthenticated>');
   });
 
-  it('gates per-model fixtures to models whose file exists after a scoped run', () => {
+  it('gates per-model fixtures to SELECTED (in-scope) models only under a scoped run', () => {
+    // Minimal scoped generation: a scoped `--services X` run must regenerate
+    // ONLY the selected service's fixtures and leave every other service's
+    // fixtures byte-for-byte untouched on disk. The fixture gate is therefore
+    // SELECTED-only (`isModelInScope`), NOT the SURFACE `fileExistsAfterRun`
+    // gate — even an out-of-scope fixture that already sits on disk from a
+    // prior full run must be left alone (never re-emitted), so the run cannot
+    // rewrite/drift files outside the requested scope.
     const models: Model[] = [
       {
         name: 'OrganizationMembership',
@@ -202,7 +209,9 @@ describe('dotnet/scoped aggregates', () => {
       spec,
       scopedServices: new Set(['OrganizationMemberships']),
       scopedModelNames: new Set(['OrganizationMembership']),
-      // The renamed/removed model is on disk; the brand-new one is not.
+      // OrganizationDomainStandAlone already sits on disk from a prior full
+      // run, but it is OUT OF SCOPE this run — a minimal scoped run must NOT
+      // re-emit it.
       priorTargetManifestPaths: new Set([
         'test/WorkOSTests/testdata/organization_membership.json',
         'test/WorkOSTests/testdata/organization_domain_stand_alone.json',
@@ -212,13 +221,79 @@ describe('dotnet/scoped aggregates', () => {
     const files = generateTests(spec, ctx);
     const paths = files.map((f) => f.path);
 
-    // In-scope model fixture is emitted.
+    // In-scope (SELECTED) model fixture is emitted.
     expect(paths).toContain('testdata/organization_membership.json');
-    // Renamed/removed-but-on-disk fixture is retained.
-    expect(paths).toContain('testdata/organization_domain_stand_alone.json');
-    // Brand-new out-of-scope fixture is EXCLUDED (stray file for an
-    // unreferenceable model).
+    // Out-of-scope fixture already on disk is LEFT UNTOUCHED (not re-emitted).
+    expect(paths.some((p) => p.includes('organization_domain_stand_alone'))).toBe(false);
+    // Brand-new out-of-scope fixture is EXCLUDED (never in scope).
     expect(paths.some((p) => p.includes('session_reauthenticated'))).toBe(false);
+  });
+
+  it('does not emit a monolithic model round-trip test under a scoped run', () => {
+    // Unlike some emitters (e.g. Ruby's GeneratedModelRoundTrip aggregate),
+    // the .NET emitter has no wholesale model-round-trip test file: round-trip
+    // coverage is inlined into each per-service `Tests/*Test.cs` file, which is
+    // already scoped via `scopedMountGroups`. So a scoped run must emit ONLY
+    // the selected service's test file and no cross-service aggregate.
+    const models: Model[] = [
+      {
+        name: 'OrganizationMembership',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'SessionReauthenticated',
+        fields: [{ name: 'session_id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    const services: Service[] = [
+      {
+        name: 'OrganizationMemberships',
+        operations: [
+          {
+            name: 'getOrganizationMembership',
+            httpMethod: 'get',
+            path: '/organization_memberships/{id}',
+            pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'OrganizationMembership' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+
+    const spec: ApiSpec = { ...emptySpec, services, models };
+    const ctx: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec,
+      scopedServices: new Set(['OrganizationMemberships']),
+      scopedModelNames: new Set(['OrganizationMembership']),
+      // Minimal resolvedOperations table so scopedMountGroups can group the
+      // selected service by mount target.
+      resolvedOperations: services.flatMap((service) =>
+        service.operations.map((operation) => ({
+          service,
+          operation,
+          methodName: operation.name,
+          mountOn: service.name,
+          defaults: {},
+          inferFromClient: [],
+          urlBuilder: false,
+        })),
+      ),
+    };
+
+    const files = generateTests(spec, ctx);
+    const csTestFiles = files.filter((f) => f.path.startsWith('Tests/') && f.path.endsWith('.cs'));
+
+    // Only the selected service's test file is emitted...
+    expect(csTestFiles.map((f) => f.path)).toEqual(['Tests/OrganizationMembershipsServiceTest.cs']);
+    // ...and there is no aggregate/wholesale round-trip test file.
+    expect(files.some((f) => /RoundTrip/i.test(f.path))).toBe(false);
   });
 
   it('emits all per-model fixtures on a full (unscoped) run', () => {

--- a/test/go/scoping.test.ts
+++ b/test/go/scoping.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { generateModels } from '../../src/go/models.js';
 import { generateEnums } from '../../src/go/enums.js';
+import { generateFixtures } from '../../src/go/fixtures.js';
 
 const emptySpec: ApiSpec = {
   name: 'Test',
@@ -320,5 +321,51 @@ describe('go scoped flat-file reconciliation (events.go)', () => {
     const events = generateEnums(enums, ctx).find((f) => f.path === 'pkg/events/events.go')!.content;
     expect(events).toContain('organization.created');
     expect(events).toContain('session.reauthenticated');
+  });
+});
+
+describe('go scoped fixtures (testdata/*.json)', () => {
+  // Fixtures are standalone per-model files. Under minimal scoped generation a
+  // scoped run must emit fixtures ONLY for SELECTED models — NOT the surface —
+  // so every out-of-scope service's fixtures stay byte-for-byte untouched.
+  const fixtureModels: Model[] = [
+    { name: 'InScopeThing', fields: [strField('id'), strField('label')] },
+    { name: 'OutOfScopeNew', fields: [strField('id'), strField('extra')] },
+  ];
+  const fixtureSpec = { models: fixtureModels, enums: [] as Enum[], services: [] as any[] };
+
+  it('emits a fixture only for the SELECTED model, dropping brand-new out-of-scope', () => {
+    const ctx = scopedCtx({
+      scopedServices: ['InScope'],
+      scopedModelNames: ['InScopeThing'], // OutOfScopeNew NOT selected
+      priorManifestPaths: ['models.go'],
+    });
+    const { files } = generateFixtures(fixtureSpec, ctx);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('testdata/in_scope_thing.json');
+    expect(paths).not.toContain('testdata/out_of_scope_new.json');
+  });
+
+  it('does NOT re-emit an out-of-scope fixture already present on disk (selected-only, not surface)', () => {
+    // The out-of-scope fixture's path is recorded in the prior manifest. A
+    // SURFACE gate (fileExistsAfterRun) would re-emit it (rewriting a file
+    // outside the requested scope); the SELECTED-only gate must skip it so the
+    // on-disk fixture stays byte-for-byte untouched.
+    const ctx = scopedCtx({
+      scopedServices: ['InScope'],
+      scopedModelNames: ['InScopeThing'],
+      priorManifestPaths: ['models.go', 'testdata/out_of_scope_new.json'],
+    });
+    const { files } = generateFixtures(fixtureSpec, ctx);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('testdata/in_scope_thing.json');
+    expect(paths).not.toContain('testdata/out_of_scope_new.json');
+  });
+
+  it('full run (no scoping) emits every fixture', () => {
+    const { files } = generateFixtures(fixtureSpec); // no ctx -> full run
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('testdata/in_scope_thing.json');
+    expect(paths).toContain('testdata/out_of_scope_new.json');
   });
 });

--- a/test/kotlin/tests.test.ts
+++ b/test/kotlin/tests.test.ts
@@ -173,8 +173,11 @@ describe('kotlin/tests', () => {
     generateEnums([], scopedCtx);
     const files = generateTests(scopedSpec, scopedCtx);
 
-    // The monolithic round-trip aggregate is absent in a scoped run.
+    // BOTH whole-suite aggregates under com/workos/models are absent in a scoped
+    // run (they cover every model; regenerating either would rewrite a shared
+    // file outside the selected service).
     expect(files.some((f) => f.path.endsWith('GeneratedModelRoundTripTest.kt'))).toBe(false);
+    expect(files.some((f) => f.path.endsWith('GeneratedForwardCompatTest.kt'))).toBe(false);
 
     // The scoped per-service test class is still emitted.
     expect(files.some((f) => f.path.includes('OrganizationsTest.kt'))).toBe(true);

--- a/test/kotlin/tests.test.ts
+++ b/test/kotlin/tests.test.ts
@@ -142,7 +142,13 @@ describe('kotlin/tests', () => {
     expect(content).toContain('assertEquals(parsed.toInstant(), reparsed.toInstant())');
   });
 
-  it('scoped run: round-trip test omits brand-new out-of-scope models, retains on-disk ones', () => {
+  it('scoped run: skips the monolithic model round-trip test entirely', () => {
+    // MINIMAL SCOPED GENERATION: a scoped (`--services`) run regenerates only
+    // the selected service's files and must leave every other on-disk service
+    // byte-for-byte untouched. The model round-trip suite is a single
+    // whole-suite AGGREGATE file covering every model, so a scoped run must
+    // NOT emit it (the on-disk copy is left in place). Per-service test
+    // classes remain scoped via `scopedMountGroups` and are still emitted.
     const roundTripModel = (name: string): Model => ({
       name,
       fields: [
@@ -152,7 +158,6 @@ describe('kotlin/tests', () => {
     });
     const scopedModels: Model[] = [
       roundTripModel('Organization'), // in scope
-      roundTripModel('PipesPipe'), // brand-new, out of scope, NOT on disk
       roundTripModel('Directory'), // out of scope but ON disk
     ];
     const scopedSpec: ApiSpec = { ...spec, models: scopedModels };
@@ -167,12 +172,12 @@ describe('kotlin/tests', () => {
 
     generateEnums([], scopedCtx);
     const files = generateTests(scopedSpec, scopedCtx);
-    const roundTrip = files.find((f) => f.path.includes('GeneratedModelRoundTripTest.kt'))!;
-    const content = roundTrip.content;
 
-    expect(content).toContain('Organization round-trips through Jackson');
-    expect(content).toContain('Directory round-trips through Jackson'); // retained (on disk)
-    expect(content).not.toContain('PipesPipe round-trips through Jackson'); // omitted (brand-new)
+    // The monolithic round-trip aggregate is absent in a scoped run.
+    expect(files.some((f) => f.path.endsWith('GeneratedModelRoundTripTest.kt'))).toBe(false);
+
+    // The scoped per-service test class is still emitted.
+    expect(files.some((f) => f.path.includes('OrganizationsTest.kt'))).toBe(true);
   });
 
   it('emits valid ISO-8601 for date-time fields in round-trip fixtures', () => {

--- a/test/php/tests.test.ts
+++ b/test/php/tests.test.ts
@@ -182,4 +182,131 @@ describe('generateTests', () => {
     expect(parsed).toHaveProperty('id');
     expect(parsed).toHaveProperty('name');
   });
+
+  describe('scoped (--services) generation', () => {
+    // Two-service / two-model spec: a scoped run selecting only `Organizations`
+    // must regenerate ONLY Organizations' artifacts and leave Connections'
+    // fixtures/tests untouched on disk (never emitted this run).
+    const scopedModels: Model[] = [
+      {
+        name: 'Organization',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+      {
+        name: 'Connection',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+    ];
+
+    const scopedServices: Service[] = [
+      ...services,
+      {
+        name: 'Connections',
+        operations: [
+          {
+            name: 'getConnection',
+            httpMethod: 'get',
+            path: '/connections/{id}',
+            pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'Connection' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+          {
+            name: 'listConnections',
+            httpMethod: 'get',
+            path: '/connections',
+            pathParams: [],
+            queryParams: [{ name: 'after', type: { kind: 'primitive', type: 'string' }, required: false }],
+            headerParams: [],
+            response: { kind: 'model', name: 'Connection' },
+            errors: [],
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'Connection' },
+            },
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+
+    const scopedSpec: ApiSpec = { ...spec, services: scopedServices, models: scopedModels };
+
+    // Resolved operations drive mount grouping (scopedMountGroups). Provide them
+    // for both services so a scoped run can select `Organizations` and drop
+    // `Connections`.
+    const resolvedOperations = [
+      ...scopedServices[0].operations.map((operation) => ({
+        operation,
+        service: scopedServices[0],
+        methodName: operation.name,
+        mountOn: 'Organizations',
+      })),
+      ...scopedServices[1].operations.map((operation) => ({
+        operation,
+        service: scopedServices[1],
+        methodName: operation.name,
+        mountOn: 'Connections',
+      })),
+    ] as any;
+
+    // Scope to `Organizations` only. `scopedModelNames` (selected-only) is what
+    // gates fixtures — Connection is reachable only from the out-of-scope service.
+    const scopedCtx: EmitterContext = {
+      ...ctx,
+      spec: scopedSpec,
+      resolvedOperations,
+      scopedServices: new Set(['Organizations']),
+      scopedModelNames: new Set(['Organization']),
+    };
+
+    it('emits fixtures only for in-scope (selected) models', () => {
+      const result = generateTests(scopedSpec, scopedCtx);
+
+      // In-scope model fixture (+ list fixture) present.
+      expect(result.find((f) => f.path === 'tests/Fixtures/organization.json')).toBeDefined();
+      expect(result.find((f) => f.path === 'tests/Fixtures/list_organization.json')).toBeDefined();
+
+      // Out-of-scope model fixtures NOT emitted (left untouched on disk).
+      expect(result.find((f) => f.path === 'tests/Fixtures/connection.json')).toBeUndefined();
+      expect(result.find((f) => f.path === 'tests/Fixtures/list_connection.json')).toBeUndefined();
+    });
+
+    it('emits per-service test files only for the selected service', () => {
+      const result = generateTests(scopedSpec, scopedCtx);
+
+      expect(result.find((f) => f.path === 'tests/Service/OrganizationsTest.php')).toBeDefined();
+      expect(result.find((f) => f.path === 'tests/Service/ConnectionsTest.php')).toBeUndefined();
+    });
+
+    it('does not emit a monolithic model round-trip test (PHP has none)', () => {
+      const result = generateTests(scopedSpec, scopedCtx);
+
+      // PHP round-trips models inline in the per-service tests; there is no
+      // whole-suite aggregate file that would reference out-of-scope models.
+      const roundTrip = result.find((f) => /round.?trip|model_round|ModelRoundTrip/i.test(f.path));
+      expect(roundTrip).toBeUndefined();
+    });
+
+    it('a full (unscoped) run still emits every model fixture', () => {
+      const fullCtx: EmitterContext = { ...ctx, spec: scopedSpec, resolvedOperations };
+      const result = generateTests(scopedSpec, fullCtx);
+
+      expect(result.find((f) => f.path === 'tests/Fixtures/organization.json')).toBeDefined();
+      expect(result.find((f) => f.path === 'tests/Fixtures/connection.json')).toBeDefined();
+      expect(result.find((f) => f.path === 'tests/Service/OrganizationsTest.php')).toBeDefined();
+      expect(result.find((f) => f.path === 'tests/Service/ConnectionsTest.php')).toBeDefined();
+    });
+  });
 });

--- a/test/python/scoped-aggregates.test.ts
+++ b/test/python/scoped-aggregates.test.ts
@@ -161,24 +161,25 @@ describe('python scoped aggregates', () => {
   });
 
   describe('round-trip test + fixtures', () => {
-    it('does not reference or fixture a brand-new out-of-scope model', () => {
+    // Minimal scoped generation: the monolithic round-trip test covers ALL
+    // models, so a scoped run must not touch it — it is not emitted at all,
+    // leaving the on-disk file byte-for-byte untouched.
+    it('does not emit the wholesale model round-trip test on a scoped run', () => {
       const files = generateTests(spec, scopedCtx());
       const roundTrip = files.find((f) => f.path === 'tests/test_models_round_trip.py');
-      expect(roundTrip).toBeDefined();
-      expect(roundTrip!.content).not.toContain('GadgetBrandNew');
-      // No fixture for the brand-new out-of-scope model.
-      expect(files.find((f) => f.path === 'tests/fixtures/gadget_brand_new.json')).toBeUndefined();
+      expect(roundTrip).toBeUndefined();
     });
 
-    it('keeps the in-scope model and retains the on-disk out-of-scope model', () => {
+    it('emits a fixture ONLY for the selected in-scope model', () => {
       const files = generateTests(spec, scopedCtx());
-      const roundTrip = files.find((f) => f.path === 'tests/test_models_round_trip.py');
-      expect(roundTrip!.content).toContain('WidgetA');
-      // GadgetOnDisk's per-model file exists on disk (prior manifest), so the
-      // round-trip test may still import it and its fixture is emitted.
-      expect(roundTrip!.content).toContain('GadgetOnDisk');
-      expect(files.find((f) => f.path === 'tests/fixtures/gadget_on_disk.json')).toBeDefined();
+      // The selected service's model gets its fixture.
       expect(files.find((f) => f.path === 'tests/fixtures/widget_a.json')).toBeDefined();
+      // No fixture for the brand-new out-of-scope model.
+      expect(files.find((f) => f.path === 'tests/fixtures/gadget_brand_new.json')).toBeUndefined();
+      // The on-disk out-of-scope model is NOT re-fixtured: minimal scoped
+      // generation leaves every other service's fixtures untouched on disk,
+      // even ones recorded in the prior manifest.
+      expect(files.find((f) => f.path === 'tests/fixtures/gadget_on_disk.json')).toBeUndefined();
     });
   });
 

--- a/test/ruby/tests.test.ts
+++ b/test/ruby/tests.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { EmitterContext, ApiSpec, Service, Model, ResolvedOperation } from '@workos/oagen';
-import { defaultSdkBehavior, toSnakeCase, toPascalCase, assignModelsToServices } from '@workos/oagen';
+import { defaultSdkBehavior, toSnakeCase, toPascalCase } from '@workos/oagen';
 import { generateTests } from '../../src/ruby/tests.js';
-import { fileName, buildMountDirMap } from '../../src/ruby/naming.js';
-import { classifyUnassignedModel } from '../../src/ruby/models.js';
 
 function makeSpec(services: Service[], models: Model[]): ApiSpec {
   return {
@@ -34,17 +32,6 @@ function buildResolvedOps(services: Service[]): ResolvedOperation[] {
     }
   }
   return ops;
-}
-
-/** Compute the per-model `.rb` path exactly as ruby/models.ts (and tests.ts) does. */
-function modelFilePath(modelName: string, spec: ApiSpec, ctx: EmitterContext): string {
-  const modelToService = assignModelsToServices(spec.models as Model[], spec.services, ctx.modelHints);
-  const mountDirMap = buildMountDirMap(ctx);
-  const service = modelToService.get(modelName);
-  const dir = service
-    ? (mountDirMap.get(service) ?? classifyUnassignedModel(modelName))
-    : classifyUnassignedModel(modelName);
-  return `lib/workos/${dir}/${fileName(modelName)}.rb`;
 }
 
 const models: Model[] = [
@@ -97,34 +84,21 @@ describe('ruby/tests model round-trip aggregate scoping', () => {
     expect(content).toContain('WorkOS::Directory.new');
   });
 
-  it('scoped run: keeps in-scope + on-disk models, drops brand-new out-of-scope models', () => {
-    const onDiskPath = modelFilePath('Connection', spec, {
-      namespace: 'workos',
-      namespacePascal: 'WorkOS',
-      spec,
-      resolvedOperations: buildResolvedOps(services),
-    });
-
+  it('scoped run: does NOT emit the wholesale round-trip test (leaves the on-disk one untouched)', () => {
     const ctx: EmitterContext = {
       namespace: 'workos',
       namespacePascal: 'WorkOS',
       spec,
       resolvedOperations: buildResolvedOps(services),
-      // Scoped to the Organizations service / Organization model only.
       scopedServices: new Set(['Organizations']),
       scopedModelNames: new Set(['Organization']),
-      // Connection's per-model file already exists on disk from a prior run.
-      priorTargetManifestPaths: new Set([onDiskPath]),
     };
 
-    const content = findRoundTripFile(generateTests(spec, ctx)).content;
-
-    // In-scope model: kept.
-    expect(content).toContain('WorkOS::Organization.new');
-    // On-disk (prior manifest) model: retained even though out-of-scope.
-    expect(content).toContain('WorkOS::Connection.new');
-    // Brand-new out-of-scope model: NO round-trip test (would NameError).
-    expect(content).not.toContain('WorkOS::Directory.new');
-    expect(content).not.toContain('def test_directory_round_trip');
+    const files = generateTests(spec, ctx);
+    // Minimal scope: the monolithic round-trip test is skipped in a scoped run so
+    // it never drags in (surface) — nor drops — other services' models. The
+    // on-disk file is left untouched; the selected service's own test still emits.
+    expect(files.some((f) => f.path === 'test/workos/test_model_round_trip.rb')).toBe(false);
+    expect(files.length).toBeGreaterThan(0);
   });
 });

--- a/test/rust/fixtures.test.ts
+++ b/test/rust/fixtures.test.ts
@@ -206,6 +206,48 @@ describe('rust/fixtures', () => {
     expect(exampleFromSpec([], { kind: 'array', items: { kind: 'primitive', type: 'string' } }, enums)).toBeUndefined();
   });
 
+  it('scoped run: emits fixtures ONLY for selected models, leaving on-disk siblings untouched', () => {
+    const models: Model[] = [
+      {
+        name: 'Pipe',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'Radar',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+    const s = spec(models);
+    // Scope selects Pipe only. `scopedModelNames` is the selected set (models
+    // reachable from the selected services), set by oagen-core. Radar's fixture
+    // is already on disk (prior manifest) but is out of scope, so a scoped run
+    // must NOT rewrite it — the SELECTED-only gate (`isModelInScope`) drops it
+    // even though `fileExistsAfterRun` would have retained it.
+    const scopedCtx: EmitterContext = {
+      ...ctx(s),
+      scopedServices: new Set(['Pipes']),
+      scopedModelNames: new Set(['Pipe']),
+      priorTargetManifestPaths: new Set(['tests/fixtures/radar.json']),
+    };
+    const files = generateFixtures(s, scopedCtx);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('tests/fixtures/pipe.json');
+    // Out-of-scope on-disk sibling is left byte-for-byte untouched: not re-emitted.
+    expect(paths).not.toContain('tests/fixtures/radar.json');
+  });
+
+  it('full run (scoping inert): emits a fixture for every model', () => {
+    const models: Model[] = [
+      { name: 'Pipe', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      { name: 'Radar', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const s = spec(models);
+    const files = generateFixtures(s, ctx(s));
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('tests/fixtures/pipe.json');
+    expect(paths).toContain('tests/fixtures/radar.json');
+  });
+
   it('threads required-only field selection through generateModelFixture', () => {
     const models: Model[] = [
       {

--- a/test/rust/tests.test.ts
+++ b/test/rust/tests.test.ts
@@ -501,4 +501,65 @@ describe('rust/tests', () => {
     const content = getMountTestFile(files, 'things');
     expect(content).not.toContain('encodes_query_params');
   });
+
+  describe('minimal scoped generation', () => {
+    const svc = (name: string): Service => ({
+      name,
+      operations: [
+        {
+          name: `list${name}`,
+          httpMethod: 'get',
+          path: `/${name.toLowerCase()}`,
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: `${name}Item` },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    });
+
+    it('emits per-service test files ONLY for the selected mount, leaving siblings untouched', () => {
+      const pipes = svc('Pipes');
+      const radar = svc('Radar');
+      const models: ApiSpec['models'] = [
+        { name: 'PipesItem', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+        { name: 'RadarItem', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      ];
+      const scopedCtx: EmitterContext = {
+        ...ctxWithResolved([pipes, radar], models),
+        scopedServices: new Set(['Pipes']),
+        scopedModelNames: new Set(['PipesItem']),
+      };
+      const files = generateTests({ ...baseSpec, services: [pipes, radar], models }, scopedCtx);
+      const paths = files.map((f) => f.path);
+      // Selected service's mount test file is emitted; the sibling's is not.
+      expect(paths).toContain('tests/pipes_test.rs');
+      expect(paths).not.toContain('tests/radar_test.rs');
+    });
+
+    it('has NO monolithic all-models round-trip file — round-trips are per-op inside per-service files', () => {
+      const pipes = svc('Pipes');
+      const radar = svc('Radar');
+      const models: ApiSpec['models'] = [
+        { name: 'PipesItem', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+        { name: 'RadarItem', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      ];
+      const scopedCtx: EmitterContext = {
+        ...ctxWithResolved([pipes, radar], models),
+        scopedServices: new Set(['Pipes']),
+        scopedModelNames: new Set(['PipesItem']),
+      };
+      const files = generateTests({ ...baseSpec, services: [pipes, radar], models }, scopedCtx);
+      // The only *_test.rs files are the per-service mount tests (here: pipes).
+      // No aggregate model_round_trip / all-models test file exists to gate.
+      const testFiles = files.filter((f) => f.path.endsWith('_test.rs')).map((f) => f.path);
+      expect(testFiles).toEqual(['tests/pipes_test.rs']);
+      // The out-of-scope sibling's round-trip must not leak into the emitted file.
+      const pipesContent = getMountTestFile(files, 'pipes');
+      expect(pipesContent).toContain('async fn pipes_list_pipes_round_trip()');
+      expect(pipesContent).not.toContain('radar');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The emitter half of minimal scoped generation. Pairs with **workos/oagen#121** (which scopes model/enum *files* to the selected service). Together they make a scoped `--services X` run touch only X's own files, leaving other on-disk services byte-for-byte untouched.

Two per-language moves, applied where each language needs them (the structure varies):

- **Skip the wholesale round-trip test in scoped runs** — languages that emit one monolithic all-models test file gate it on `!isScopedRun(ctx)`, leaving the on-disk file untouched: **ruby**, **kotlin**, **python**. (dotnet/go/php/rust have no such aggregate — their round-trips are per-service, already scoped via `scopedMountGroups`.)
- **Gate fixtures to the SELECTED set** — languages that emitted standalone fixture files on the *surface* (`fileExistsAfterRun`, which re-emits on-disk out-of-scope fixtures) now gate on `isModelInScope` (selected-only): **php, dotnet, go, rust, python**. (ruby/kotlin have inline fixtures — nothing separate to scope.)

One commit per language, each file-scoped, each with regression tests asserting a scoped run does NOT emit out-of-scope fixtures / the monolithic test, while a full run still emits everything.

### ⚠️ Must ship WITH the core change
Release together with **workos/oagen#121**. Emitters alone (models still surface-scoped) or core alone (fixtures still surface / test still wholesale) each leave the tree inconsistent.

Full emitter suite: **601 tests green**; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)