### PR TITLE
fix: two more scoped-generation orphan classes (rust unions + ruby inflections)

### DIFF
--- a/src/ruby/client.ts
+++ b/src/ruby/client.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { ApiSpec, EmitterContext, GeneratedFile, Service, Model, Enum } from '@workos/oagen';
 import { assignModelsToServices } from '@workos/oagen';
 import {
@@ -10,7 +12,7 @@ import {
   resolveServiceTarget,
 } from './naming.js';
 import { classifyUnassignedModel } from './models.js';
-import { getMountTarget } from '../shared/resolved-ops.js';
+import { getMountTarget, isScopedRun } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { NON_SPEC_SERVICES } from '../shared/non-spec-services.js';
 
@@ -128,7 +130,56 @@ function buildInflectionMap(spec: ApiSpec, ctx: EmitterContext): Map<string, str
 
   for (const [file, cls] of NON_SPEC_INFLECTIONS) inflections.set(file, cls);
 
+  preserveOnDiskInflections(inflections, ctx);
+
   return inflections;
+}
+
+/**
+ * Keep Zeitwerk acronym overrides for model files that survive on disk but are
+ * no longer in the spec the emitter was handed.
+ *
+ * A scoped (`--services`) run rebuilds `inflections.rb` from the narrowed spec,
+ * so an override for a model the spec has since REMOVED gets dropped — yet a
+ * scoped run never prunes another service's `.rb` files, so e.g.
+ * `admin_portal/sso_intent_options.rb` remains. Without its
+ * `"sso_intent_options" => "SSOIntentOptions"` override Zeitwerk infers
+ * `SsoIntentOptions` and every reference to `WorkOS::SSOIntentOptions` raises
+ * `uninitialized constant` at load time. Re-derive the override from the prior
+ * on-disk file (its real class name) rather than guessing casing from the path.
+ *
+ * Scoped-only: a full run prunes stale files, so there is nothing on disk to
+ * keep an override alive for.
+ */
+function preserveOnDiskInflections(inflections: Map<string, string>, ctx: EmitterContext): void {
+  if (!isScopedRun(ctx)) return;
+  const rootDir = ctx.targetDir ?? ctx.outputDir;
+  const onDisk = ctx.priorTargetManifestPaths;
+  if (!rootDir || !onDisk || onDisk.size === 0) return;
+
+  let prior: string;
+  try {
+    prior = fs.readFileSync(path.join(rootDir, 'lib/workos/inflections.rb'), 'utf8');
+  } catch {
+    return; // first run into this dir — no prior overrides to preserve
+  }
+
+  // Basenames (sans .rb) of every file still on disk after this run. Zeitwerk
+  // inflects by basename, so the inflection map is basename-keyed too.
+  const onDiskBasenames = new Set<string>();
+  for (const p of onDisk) {
+    if (p.endsWith('.rb')) onDiskBasenames.add(path.basename(p, '.rb'));
+  }
+
+  // Parse `  "key" => "Value"` rows from the prior WORKOS_INFLECTIONS hash and
+  // restore any whose file survives on disk and the current spec no longer covers.
+  const entryRe = /"([^"]+)"\s*=>\s*"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(prior)) !== null) {
+    const [, key, cls] = m;
+    if (inflections.has(key)) continue; // current spec already emits this override
+    if (onDiskBasenames.has(key)) inflections.set(key, cls);
+  }
 }
 
 /** Generate lib/workos/inflections.rb — Zeitwerk inflection overrides (T40/C5). */

--- a/src/rust/models.ts
+++ b/src/rust/models.ts
@@ -35,14 +35,22 @@ export function generateModels(models: Model[], ctx: EmitterContext, registry: U
     seen.add(mod);
 
     // renderModel registers inline unions into `registry` as a side effect, and
-    // `_unions.rs` is rendered later (in generateClient) from that registry — so
-    // it MUST run for every model, even out-of-scope ones, or scoped runs drop
-    // unions. Compute content unconditionally; only the per-model `.rs` FILE write
-    // is scoped (FR-1.4) — an out-of-scope model's existing `.rs` file stays
-    // untouched on disk.
+    // `_unions.rs` is rendered later (in generateClient) from that registry.
+    // Register a model's unions ONLY when its own `.rs` file will exist on disk
+    // after this run — in-scope (emitted just below) or already present from a
+    // prior run (fileExistsAfterRun). A model that is NEITHER selected NOR on
+    // disk (e.g. a service the spec recently gained but this SDK has never
+    // generated, such as Agent) must NOT contribute: its variant model files
+    // are never written, so the synthesised enum in `_unions.rs` would
+    // reference dangling types and break the build (orphan class). On-disk
+    // out-of-scope models DO register — their existing `.rs` files reference
+    // those unions, so `_unions.rs` must keep them. A full run registers every
+    // model (fileExistsAfterRun ⇒ true when scoping is inert).
     const inScope = isModelInScope(model.name, ctx);
     const hintPath = ctx.overlayLookup?.fileBySymbol?.get(model.name);
     const path = hintPath ?? `src/models/${mod}.rs`;
+    if (!fileExistsAfterRun(path, inScope, ctx)) continue;
+
     const content = renderModel(model, registry, taggedVariantFields.get(model.name));
     if (inScope) {
       files.push({
@@ -51,15 +59,7 @@ export function generateModels(models: Model[], ctx: EmitterContext, registry: U
         overwriteExisting: true,
       });
     }
-
-    // Declare the module only if its `.rs` file will exist on disk after this
-    // run: in-scope (emitted just now) or already present from a prior run. A
-    // scoped run must NOT declare a brand-new out-of-scope model whose file it
-    // never emits — that dangling `mod` is what broke the build. A full run
-    // declares every module (fileExistsAfterRun ⇒ true when scoping is inert).
-    if (fileExistsAfterRun(path, inScope, ctx)) {
-      moduleNames.push(mod);
-    }
+    moduleNames.push(mod);
   }
 
   // Scoped runs: retain barrel entries for model files still on disk (prior


### PR DESCRIPTION
Follow-up to #176. Two additional scoped-generation orphan-class bugs surfaced in a dry-run preview (Pipes) on 0.19.6 — rust and ruby both failed CI while every other language passed. Both are the same root shape #176 addressed elsewhere: **an aggregate file whose contents no longer match the source files that actually exist on disk.**

### rust — `_unions.rs` over-collects
`_unions.rs` is rendered from the `UnionRegistry`, which `renderModel` populates as a side effect for *every* model handed to `generateModels` — including a service the spec recently gained that this SDK has **never generated** (Agent). That leaked an orphan `AgentRegistrationCredentialIssuedDataDetailOneOf` enum whose variant model files are never emitted:

```
error[E0412]: cannot find type `AgentRegistrationCredentialIssuedDataDetail` in this scope
```

Fix: gate union registration on `fileExistsAfterRun` — register a model's unions only when its own `.rs` file will exist after the run (in-scope, or already on disk). On-disk out-of-scope models still register; full runs are unaffected.

### ruby — `inflections.rb` under-preserves
A scoped run rebuilds `inflections.rb` from the narrowed spec, dropping the Zeitwerk override for a model the spec has since **removed** (`SSOIntentOptions`) — but a scoped run never prunes another service's `.rb` files, so `admin_portal/sso_intent_options.rb` survives. Without `"sso_intent_options" => "SSOIntentOptions"`, Zeitwerk infers `SsoIntentOptions`:

```
NameError: uninitialized constant WorkOS::SSOIntentOptions
```

Fix: re-read the prior `inflections.rb` and restore any override whose file survives on disk (prior manifest) and the current spec no longer covers — using the real class name, not a casing guess. Scoped-only.

### Verification (generated Pipes-scoped into fresh clones)
- **rust**: `cargo test` → 27 + 7 + 2 passed, 0 failed (was `E0412`, wouldn't compile)
- **ruby**: full suite → 983 runs, 0 failures, **0 errors** (was 2 errors)
- **emitter unit tests**: 85 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)