### PR TITLE
fix(php,dotnet): serialize date-time request-body params correctly

### DIFF
--- a/src/dotnet/tests.ts
+++ b/src/dotnet/tests.ts
@@ -647,6 +647,9 @@ function isSeedableStringRef(ref: import('@workos/oagen').TypeRef): boolean {
   if (ref.type !== 'string') return false;
   // `binary` maps to byte[], not a string literal
   if (ref.format === 'binary') return false;
+  // `date-time` maps to DateTimeOffset (a value type); a string-literal seed
+  // would not compile against the generated property.
+  if (ref.format === 'date-time') return false;
   return true;
 }
 

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -466,7 +466,11 @@ function generateMethod(
       for (const field of visibleFields) {
         const phpName = bodyParamMap.get(field.name) ?? fieldName(field.name);
         const nullsafe = field.required ? '' : '?';
-        const valueExpr = isEnumType(field.type) ? `$${phpName}${nullsafe}->value` : `$${phpName}`;
+        const valueExpr = isEnumType(field.type)
+          ? `$${phpName}${nullsafe}->value`
+          : isDateTimeType(field.type)
+            ? `$${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED)`
+            : `$${phpName}`;
         lines.push(`            '${field.name}' => ${valueExpr},`);
       }
       // Inject constant defaults
@@ -523,7 +527,11 @@ function generateMethod(
     for (const field of visibleFields) {
       const phpName = bodyParamMap.get(field.name) ?? fieldName(field.name);
       const nullsafe = field.required ? '' : '?';
-      const valueExpr = isEnumType(field.type) ? `$${phpName}${nullsafe}->value` : `$${phpName}`;
+      const valueExpr = isEnumType(field.type)
+        ? `$${phpName}${nullsafe}->value`
+        : isDateTimeType(field.type)
+          ? `$${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED)`
+          : `$${phpName}`;
       lines.push(`            '${field.name}' => ${valueExpr},`);
     }
     // Inject constant defaults

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -29,6 +29,12 @@ import {
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { isRedirectEndpoint, deriveVariantFieldName } from './resources.js';
 
+// Deterministic date-time seed shared by generated call args and request-body
+// assertions so the two stay in sync. TEST_DATE_TIME_WIRE is the
+// RFC3339_EXTENDED form the generated client emits for `\DateTimeImmutable`.
+const TEST_DATE_TIME_ARG = "new \\DateTimeImmutable('2023-01-01T00:00:00Z')";
+const TEST_DATE_TIME_WIRE = '2023-01-01T00:00:00.000+00:00';
+
 /**
  * Generate PHPUnit test files and fixture JSON files.
  */
@@ -398,7 +404,7 @@ function generateTestValue(
   switch (ref.kind) {
     case 'primitive':
       if (ref.format === 'date-time') {
-        return "new \\DateTimeImmutable('2023-01-01T00:00:00Z')";
+        return TEST_DATE_TIME_ARG;
       }
       switch (ref.type) {
         case 'string':
@@ -648,7 +654,10 @@ function emitBodyAssertions(lines: string[], op: Operation, ctx: EmitterContext,
 
   lines.push('        $body = json_decode((string) $request->getBody(), true);');
   for (const f of primitiveRequired) {
-    if (f.type.kind === 'primitive' && f.type.type === 'string') {
+    if (f.type.kind === 'primitive' && f.type.format === 'date-time') {
+      // Serialized by the client via RFC3339_EXTENDED, not the raw string seed.
+      lines.push(`        $this->assertSame('${TEST_DATE_TIME_WIRE}', $body['${f.name}']);`);
+    } else if (f.type.kind === 'primitive' && f.type.type === 'string') {
       lines.push(`        $this->assertSame('test_value', $body['${f.name}']);`);
     } else if (f.type.kind === 'primitive' && f.type.type === 'integer') {
       lines.push(`        $this->assertSame(1, $body['${f.name}']);`);

--- a/test/dotnet/tests.test.ts
+++ b/test/dotnet/tests.test.ts
@@ -199,4 +199,45 @@ describe('dotnet/tests', () => {
     expect(content).toContain('MockSequentialResponses');
     expect(content).toContain('await foreach');
   });
+
+  it('does not seed a string literal into a date-time (DateTimeOffset) property', () => {
+    const dtModels: Model[] = [
+      {
+        name: 'ExportCreation',
+        fields: [
+          { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'range_start', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+        ],
+      },
+      { name: 'Export', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const dtServices: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'createExport',
+            httpMethod: 'post',
+            path: '/audit_logs/exports',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'ExportCreation' },
+            response: { kind: 'model', name: 'Export' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const dtSpec: ApiSpec = { ...spec, models: dtModels, services: dtServices };
+    const content = generateTests(dtSpec, { ...ctx, spec: dtSpec }).find(
+      (f) => f.path === 'Tests/AuditLogsServiceTest.cs',
+    )!.content;
+
+    // A DateTimeOffset property must never be assigned a string literal seed.
+    expect(content).not.toContain('RangeStart = "');
+    // The plain string field is still seeded.
+    expect(content).toContain('OrganizationId = "test_organization_id"');
+  });
 });

--- a/test/php/resources.test.ts
+++ b/test/php/resources.test.ts
@@ -889,4 +889,45 @@ describe('generateResources', () => {
     expect(content).toContain('public function getProfileAndToken(');
     expect(content).toMatch(/function getProfileAndToken\(\s*string \$code/);
   });
+
+  it('serializes required date-time body fields via RFC3339_EXTENDED', () => {
+    const dtModels: Model[] = [
+      {
+        name: 'ExportCreation',
+        fields: [
+          { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'range_start', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+          { name: 'range_end', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+        ],
+      },
+      { name: 'Export', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const dtServices: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'createExport',
+            httpMethod: 'post',
+            path: '/audit_logs/exports',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'ExportCreation' },
+            response: { kind: 'model', name: 'Export' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const dtSpec: ApiSpec = { ...emptySpec, models: dtModels, services: dtServices };
+    const content = generateResources(dtServices, { ...ctx, spec: dtSpec })[0].content;
+
+    // date-time body fields must be formatted, not passed as raw \DateTimeImmutable
+    expect(content).toContain("'range_start' => $rangeStart->format(\\DateTimeInterface::RFC3339_EXTENDED)");
+    expect(content).toContain("'range_end' => $rangeEnd->format(\\DateTimeInterface::RFC3339_EXTENDED)");
+    // plain string fields are unaffected
+    expect(content).toContain("'organization_id' => $organizationId");
+  });
 });

--- a/test/php/tests.test.ts
+++ b/test/php/tests.test.ts
@@ -309,4 +309,46 @@ describe('generateTests', () => {
       expect(result.find((f) => f.path === 'tests/Service/ConnectionsTest.php')).toBeDefined();
     });
   });
+
+  it('asserts date-time request-body fields against the RFC3339 wire value', () => {
+    const dtModels: Model[] = [
+      {
+        name: 'ExportCreation',
+        fields: [
+          { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'range_start', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+        ],
+      },
+      { name: 'Export', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const dtServices: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'createExport',
+            httpMethod: 'post',
+            path: '/audit_logs/exports',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'ExportCreation' },
+            response: { kind: 'model', name: 'Export' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const dtSpec: ApiSpec = { ...spec, models: dtModels, services: dtServices };
+    const content = generateTests(dtSpec, { ...ctx, spec: dtSpec }).find(
+      (f) => f.path === 'tests/Service/AuditLogsTest.php',
+    )!.content;
+
+    // Call passes a DateTimeImmutable; the body assertion expects its RFC3339 form.
+    expect(content).toContain("new \\DateTimeImmutable('2023-01-01T00:00:00Z')");
+    expect(content).toContain("assertSame('2023-01-01T00:00:00.000+00:00', $body['range_start'])");
+    // The plain-string placeholder must NOT be used for a date-time field.
+    expect(content).not.toContain("assertSame('test_value', $body['range_start'])");
+  });
 });


### PR DESCRIPTION
## Summary

When a request-body field carries `format: date-time`, the **model** emitter maps it to a native date type (PHP `\DateTimeImmutable`, C# `DateTimeOffset`) — but three parts of the PHP/dotnet emitters still treated it as a plain string, producing internally-inconsistent generated code. This surfaced in [workos/openapi-spec#46](https://github.com/workos/openapi-spec/pull/46), which added `format: date-time` to `AuditLogExportCreation.range_start`/`range_end` and broke the generated **workos-php** and **workos-dotnet** Audit Logs tests (145-breaking compat aside, these were hard build/test failures).

## Root cause & fixes

| Emitter | Bug | Fix |
|---|---|---|
| **php `resources.ts`** (client, functional bug) | date-time body params were json-encoded as the raw `\DateTimeImmutable`, emitting `{"date":…,"timezone_type":2,"timezone":"Z"}` on the wire instead of an RFC3339 string | format via `RFC3339_EXTENDED`, mirroring the existing query-param handling (`buildQueryArray`) |
| **php `tests.ts`** | generated request-body assertion hardcoded `assertSame('test_value', …)` for every string field, including date-time | assert the RFC3339 wire value; call arg + assertion kept in sync via shared `TEST_DATE_TIME_ARG`/`TEST_DATE_TIME_WIRE` constants |
| **dotnet `tests.ts`** | `isSeedableStringRef` seeded a C# string literal into a now-`DateTimeOffset` property → `CS0029` compile error | exclude `date-time` from string seeding (mirrors the value-type mapping) |

The PHP one is a genuine client serialization bug affecting real users, not just tests — a `DateTimeImmutable` passed to any date-time body param was serialized wrong on the wire.

## Validation

- `npm test` — 612 passed (+3 new regression tests: php resources, php tests, dotnet tests)
- `typecheck`, `lint`, `format` — clean
- End-to-end: built this branch, regenerated **workos-php** and **workos-dotnet** from openapi-spec#46's spec and confirmed the generated Audit Logs code is now self-consistent:
  - php client: `'range_start' => $rangeStart->format(\DateTimeInterface::RFC3339_EXTENDED)`
  - php test: `assertSame('2023-01-01T00:00:00.000+00:00', $body['range_start'])`
  - dotnet test: no longer assigns a string to `options.RangeStart` (typed `DateTimeOffset`) → compiles

## Follow-up

After release, bump `@workos/oagen-emitters` in workos/openapi-spec and regenerate; the dotnet/php `sdk_build` (and the dependent `sdk-validation`) checks on #46 will go green. The `sdk-compat` breaking count is separate (mostly accumulated drift) and remains a review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)