### PR TITLE
fix(python,ruby): per-service model round-trip tests so scoped runs stay in sync

### DIFF
--- a/src/dotnet/tests.ts
+++ b/src/dotnet/tests.ts
@@ -647,6 +647,9 @@ function isSeedableStringRef(ref: import('@workos/oagen').TypeRef): boolean {
   if (ref.type !== 'string') return false;
   // `binary` maps to byte[], not a string literal
   if (ref.format === 'binary') return false;
+  // `date-time` maps to DateTimeOffset (a value type); a string-literal seed
+  // would not compile against the generated property.
+  if (ref.format === 'date-time') return false;
   return true;
 }
 

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -466,7 +466,11 @@ function generateMethod(
       for (const field of visibleFields) {
         const phpName = bodyParamMap.get(field.name) ?? fieldName(field.name);
         const nullsafe = field.required ? '' : '?';
-        const valueExpr = isEnumType(field.type) ? `$${phpName}${nullsafe}->value` : `$${phpName}`;
+        const valueExpr = isEnumType(field.type)
+          ? `$${phpName}${nullsafe}->value`
+          : isDateTimeType(field.type)
+            ? `$${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED)`
+            : `$${phpName}`;
         lines.push(`            '${field.name}' => ${valueExpr},`);
       }
       // Inject constant defaults
@@ -523,7 +527,11 @@ function generateMethod(
     for (const field of visibleFields) {
       const phpName = bodyParamMap.get(field.name) ?? fieldName(field.name);
       const nullsafe = field.required ? '' : '?';
-      const valueExpr = isEnumType(field.type) ? `$${phpName}${nullsafe}->value` : `$${phpName}`;
+      const valueExpr = isEnumType(field.type)
+        ? `$${phpName}${nullsafe}->value`
+        : isDateTimeType(field.type)
+          ? `$${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED)`
+          : `$${phpName}`;
       lines.push(`            '${field.name}' => ${valueExpr},`);
     }
     // Inject constant defaults

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -29,6 +29,12 @@ import {
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { isRedirectEndpoint, deriveVariantFieldName } from './resources.js';
 
+// Deterministic date-time seed shared by generated call args and request-body
+// assertions so the two stay in sync. TEST_DATE_TIME_WIRE is the
+// RFC3339_EXTENDED form the generated client emits for `\DateTimeImmutable`.
+const TEST_DATE_TIME_ARG = "new \\DateTimeImmutable('2023-01-01T00:00:00Z')";
+const TEST_DATE_TIME_WIRE = '2023-01-01T00:00:00.000+00:00';
+
 /**
  * Generate PHPUnit test files and fixture JSON files.
  */
@@ -398,7 +404,7 @@ function generateTestValue(
   switch (ref.kind) {
     case 'primitive':
       if (ref.format === 'date-time') {
-        return "new \\DateTimeImmutable('2023-01-01T00:00:00Z')";
+        return TEST_DATE_TIME_ARG;
       }
       switch (ref.type) {
         case 'string':
@@ -648,7 +654,10 @@ function emitBodyAssertions(lines: string[], op: Operation, ctx: EmitterContext,
 
   lines.push('        $body = json_decode((string) $request->getBody(), true);');
   for (const f of primitiveRequired) {
-    if (f.type.kind === 'primitive' && f.type.type === 'string') {
+    if (f.type.kind === 'primitive' && f.type.format === 'date-time') {
+      // Serialized by the client via RFC3339_EXTENDED, not the raw string seed.
+      lines.push(`        $this->assertSame('${TEST_DATE_TIME_WIRE}', $body['${f.name}']);`);
+    } else if (f.type.kind === 'primitive' && f.type.type === 'string') {
       lines.push(`        $this->assertSame('test_value', $body['${f.name}']);`);
     } else if (f.type.kind === 'primitive' && f.type.type === 'integer') {
       lines.push(`        $this->assertSame(1, $body['${f.name}']);`);

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -31,6 +31,7 @@ import {
   buildHiddenParams,
   collectGroupedParamNames,
   isScopedRun,
+  isModelInScope,
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { pythonLiteral } from './wrappers.js';
@@ -136,16 +137,16 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     if (testFile) files.push(testFile);
   }
 
-  // Generate model round-trip tests (P3-7).
-  // This is ONE monolithic file (tests/test_models_round_trip.py) covering ALL
-  // models. Under minimal scoped generation a scoped `--services X` run must not
-  // touch it: it would otherwise be rewritten to reference only the selected
-  // service's models, mutating a file that belongs to the whole SDK. Skip
-  // emitting it entirely on a scoped run so the on-disk file is left untouched.
-  if (!isScopedRun(ctx)) {
-    const modelTests = generateModelRoundTripTests(spec, ctx);
-    if (modelTests) files.push(modelTests);
-  }
+  // Model round-trip tests (P3-7): one file per service dir
+  // (tests/test_<dir>_models_round_trip.py), each covering only that dir's
+  // models regenerated this run. Unlike the former wholesale file — which a
+  // scoped run skipped, leaving it stale until a full regen — a scoped run now
+  // regenerates the selected services' round-trip tests in lockstep with their
+  // models (fixing "selected model changed shape but its round-trip test still
+  // asserts the old shape") and leaves untouched services' files alone.
+  files.push(...generateModelRoundTripTests(spec, ctx));
+  const legacyRoundTrip = retireLegacyRoundTripMonolith(ctx);
+  if (legacyRoundTrip) files.push(legacyRoundTrip);
 
   return files;
 }
@@ -1444,10 +1445,22 @@ function toPythonLiteral(value: unknown): string {
   return 'None';
 }
 
+const LEGACY_ROUNDTRIP_PATH = 'tests/test_models_round_trip.py';
+
 /**
- * Generate model round-trip tests: Model.from_dict(instance.to_dict()) == instance
+ * Per-service model round-trip tests (from_dict(to_dict()) == instance): one
+ * file per service dir (`tests/test_<dir>_models_round_trip.py`), each covering
+ * only the models emitted for that dir this run.
+ *
+ * `isModelInScope` is true for every model on a full run and selected-only under
+ * `--services`, so a scoped run regenerates a dir's round-trip file in lockstep
+ * with that dir's regenerated models — replacing the former single wholesale
+ * file, which a scoped run skipped entirely and thus left asserting the OLD
+ * shape of a model the same run had just regenerated (the failure this fixes).
+ * Dirs with no in-scope models are skipped, so untouched services' files are
+ * left byte-for-byte alone (scoped runs never prune).
  */
-function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile | null {
+function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   // Collect models used as request bodies only (not returned in responses)
   const responseModelNames = new Set<string>();
   const requestOnlyModelNames = new Set<string>();
@@ -1470,149 +1483,151 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(spec.services);
   const listMetadataNeeded = collectReferencedListMetadataModels(spec.models, nonPaginatedRefs);
 
-  // The round-trip test imports models from their *natural* (pre-relocation)
-  // service so existing callers keep working — those imports resolve via the
-  // BC re-exports that the model emitter writes into each service barrel.
-  // This wholesale test only runs on a FULL (non-scoped) generation — a scoped
-  // run skips emitting it entirely (see generateTests → isScopedRun) — so no
-  // per-model on-disk gate is needed here: every non-request-only model file is
-  // freshly emitted by the same full run.
   const placement = computeSchemaPlacement(spec, ctx);
   const modelToService = placement.originalModelToService;
   const roundTripDirMap = buildMountDirMap(ctx);
   const resolveDir = (irService: string | undefined) =>
     irService ? (roundTripDirMap.get(irService) ?? 'common') : 'common';
 
-  const models = spec.models.filter(
+  const eligible = spec.models.filter(
     (m) =>
       !(isListWrapperModel(m) && !nonPaginatedRefs.has(m.name)) &&
       !(isListMetadataModel(m) && !listMetadataNeeded.has(m.name)) &&
-      !requestOnlyModelNames.has(m.name),
+      !requestOnlyModelNames.has(m.name) &&
+      // A scoped run emits only the selected services' per-model files, so a
+      // dir's round-trip test may only cover models regenerated THIS run —
+      // otherwise it would assert against an untouched (possibly drifted)
+      // on-disk model. Full run ⇒ isModelInScope is true for everything.
+      isModelInScope(m.name, ctx),
   );
-  if (models.length === 0) return null;
 
-  const lines: string[] = [];
-  lines.push('"""Model round-trip tests: from_dict(to_dict()) preserves data."""');
-  lines.push('');
-  lines.push('import pytest');
-  lines.push('');
-  lines.push('from tests.generated_helpers import load_fixture');
-  lines.push('');
-
-  // Collect imports by directory
-  const importsByDir = new Map<string, string[]>();
-  for (const model of models) {
-    const service = modelToService.get(model.name);
-    const dirName = resolveDir(service);
-    if (!importsByDir.has(dirName)) importsByDir.set(dirName, []);
-    importsByDir.get(dirName)!.push(className(model.name));
-  }
-  // Add discriminator Unknown variant classes to imports for dispatch tests
-  for (const model of models) {
-    if (!(model as any).discriminator) continue;
-    const service = modelToService.get(model.name);
-    const dirName = resolveDir(service);
-    if (!importsByDir.has(dirName)) importsByDir.set(dirName, []);
-    importsByDir.get(dirName)!.push(`${className(model.name)}Unknown`);
+  const modelsByDir = new Map<string, Model[]>();
+  for (const model of eligible) {
+    const dir = resolveDir(modelToService.get(model.name));
+    if (!modelsByDir.has(dir)) modelsByDir.set(dir, []);
+    modelsByDir.get(dir)!.push(model);
   }
 
-  for (const [dirName, names] of [...importsByDir].sort()) {
-    lines.push(`from ${ctx.namespace}.${dirToModule(dirName)}.models import ${names.sort().join(', ')}`);
+  const files: GeneratedFile[] = [];
+  for (const [dirName, dirModels] of [...modelsByDir].sort(([a], [b]) => a.localeCompare(b))) {
+    const file = buildDirRoundTripFile(dirName, dirModels, spec, ctx, modelToService, resolveDir);
+    if (file) files.push(file);
   }
+  return files;
+}
 
-  lines.push('');
-  lines.push('');
-  lines.push('class TestModelRoundTrip:');
+/** Build one service dir's round-trip test file, or null when it has no testable models. */
+function buildDirRoundTripFile(
+  dirName: string,
+  dirModels: Model[],
+  spec: ApiSpec,
+  ctx: EmitterContext,
+  modelToService: Map<string, string>,
+  resolveDir: (irService: string | undefined) => string,
+): GeneratedFile | null {
+  const roundTripModels = dirModels.filter((m) => m.fields.length > 0 && !(m as any).discriminator);
+  const discriminatorModels = dirModels.filter((m) => (m as any).discriminator);
+  if (roundTripModels.length === 0 && discriminatorModels.length === 0) return null;
 
-  for (const model of models) {
-    // Skip models with no fields or discriminated union dispatchers — these
-    // don't have a to_dict() and their round-trip semantics differ.
-    if (model.fields.length === 0) continue;
-    if ((model as any).discriminator) continue;
-    // Deduplicate fields by DOMAIN identifier (mirrors models.ts, which honors
-    // `domainName`); the wire key stays `field.name`.
-    const seenFieldNames = new Set<string>();
-    const dedupFields = model.fields.filter((f) => {
-      const pyName = domainFieldName(f);
-      if (seenFieldNames.has(pyName)) return false;
-      seenFieldNames.add(pyName);
-      return true;
-    });
-    const dedupModel = { ...model, fields: dedupFields };
+  // Imported classes grouped by their OWN dir: a discriminator's first variant
+  // may live in another service's dir, so a single file can import across dirs.
+  const importsByDir = new Map<string, Set<string>>();
+  const addImport = (modelName: string, cls: string) => {
+    const dir = resolveDir(modelToService.get(modelName));
+    if (!importsByDir.has(dir)) importsByDir.set(dir, new Set());
+    importsByDir.get(dir)!.add(cls);
+  };
 
-    const modelClass = className(model.name);
-    const fixtureName = `${fileName(model.name)}.json`;
-    const fullFixture = generateModelFixture(
-      dedupModel,
-      new Map(spec.models.map((m) => [m.name, m])),
-      new Map(spec.enums.map((e) => [e.name, e])),
-    );
-    const minimalPayload = buildMinimalModelPayload(dedupModel, fullFixture);
-    const absentOptionalPayload = buildPayloadWithoutOptionalNonNullableFields(dedupModel, fullFixture);
-    const nullablePayload = buildPayloadWithNullableFieldsSetToNull(dedupModel, fullFixture);
-    const unknownEnumPayload = buildPayloadWithUnknownEnumValue(dedupModel, fullFixture);
+  const modelMap = new Map(spec.models.map((m) => [m.name, m]));
+  const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
+  const body: string[] = [];
 
-    lines.push('');
-    lines.push(`    def test_${fileName(model.name)}_round_trip(self):`);
-    lines.push(`        data = load_fixture("${fixtureName}")`);
-    lines.push(`        instance = ${modelClass}.from_dict(data)`);
-    lines.push('        serialized = instance.to_dict()');
-    lines.push('        assert serialized == data');
-    lines.push(`        restored = ${modelClass}.from_dict(serialized)`);
-    lines.push('        assert restored.to_dict() == serialized');
+  if (roundTripModels.length > 0) {
+    body.push('');
+    body.push('');
+    body.push('class TestModelRoundTrip:');
+    for (const model of roundTripModels) {
+      // Deduplicate fields by DOMAIN identifier (mirrors models.ts, which honors
+      // `domainName`); the wire key stays `field.name`.
+      const seenFieldNames = new Set<string>();
+      const dedupFields = model.fields.filter((f) => {
+        const pyName = domainFieldName(f);
+        if (seenFieldNames.has(pyName)) return false;
+        seenFieldNames.add(pyName);
+        return true;
+      });
+      const dedupModel = { ...model, fields: dedupFields };
 
-    const requiredFields = dedupFields.filter((field) => field.required);
-    lines.push('');
-    lines.push(`    def test_${fileName(model.name)}_minimal_payload(self):`);
-    lines.push(`        data = ${toPythonLiteral(minimalPayload)}`);
-    lines.push(`        instance = ${modelClass}.from_dict(data)`);
-    if (requiredFields.length > 0) {
-      lines.push('        serialized = instance.to_dict()');
-      for (const field of requiredFields) {
-        lines.push(`        assert serialized[${toPythonLiteral(field.name)}] == data[${toPythonLiteral(field.name)}]`);
+      const modelClass = className(model.name);
+      addImport(model.name, modelClass);
+      const fixtureName = `${fileName(model.name)}.json`;
+      const fullFixture = generateModelFixture(dedupModel, modelMap, enumMap);
+      const minimalPayload = buildMinimalModelPayload(dedupModel, fullFixture);
+      const absentOptionalPayload = buildPayloadWithoutOptionalNonNullableFields(dedupModel, fullFixture);
+      const nullablePayload = buildPayloadWithNullableFieldsSetToNull(dedupModel, fullFixture);
+      const unknownEnumPayload = buildPayloadWithUnknownEnumValue(dedupModel, fullFixture);
+
+      body.push('');
+      body.push(`    def test_${fileName(model.name)}_round_trip(self):`);
+      body.push(`        data = load_fixture("${fixtureName}")`);
+      body.push(`        instance = ${modelClass}.from_dict(data)`);
+      body.push('        serialized = instance.to_dict()');
+      body.push('        assert serialized == data');
+      body.push(`        restored = ${modelClass}.from_dict(serialized)`);
+      body.push('        assert restored.to_dict() == serialized');
+
+      const requiredFields = dedupFields.filter((field) => field.required);
+      body.push('');
+      body.push(`    def test_${fileName(model.name)}_minimal_payload(self):`);
+      body.push(`        data = ${toPythonLiteral(minimalPayload)}`);
+      body.push(`        instance = ${modelClass}.from_dict(data)`);
+      if (requiredFields.length > 0) {
+        body.push('        serialized = instance.to_dict()');
+        for (const field of requiredFields) {
+          body.push(
+            `        assert serialized[${toPythonLiteral(field.name)}] == data[${toPythonLiteral(field.name)}]`,
+          );
+        }
+      } else {
+        body.push('        assert instance.to_dict() is not None');
       }
-    } else {
-      lines.push('        assert instance.to_dict() is not None');
-    }
 
-    if (Object.keys(absentOptionalPayload).length !== Object.keys(fullFixture).length) {
-      lines.push('');
-      lines.push(`    def test_${fileName(model.name)}_omits_absent_optional_non_nullable_fields(self):`);
-      lines.push(`        data = ${toPythonLiteral(absentOptionalPayload)}`);
-      lines.push(`        instance = ${modelClass}.from_dict(data)`);
-      lines.push('        serialized = instance.to_dict()');
-      for (const field of dedupFields.filter((field) => !field.required && field.type.kind !== 'nullable')) {
-        lines.push(`        assert ${toPythonLiteral(field.name)} not in serialized`);
+      if (Object.keys(absentOptionalPayload).length !== Object.keys(fullFixture).length) {
+        body.push('');
+        body.push(`    def test_${fileName(model.name)}_omits_absent_optional_non_nullable_fields(self):`);
+        body.push(`        data = ${toPythonLiteral(absentOptionalPayload)}`);
+        body.push(`        instance = ${modelClass}.from_dict(data)`);
+        body.push('        serialized = instance.to_dict()');
+        for (const field of dedupFields.filter((field) => !field.required && field.type.kind !== 'nullable')) {
+          body.push(`        assert ${toPythonLiteral(field.name)} not in serialized`);
+        }
       }
-    }
 
-    if (nullablePayload) {
-      lines.push('');
-      lines.push(`    def test_${fileName(model.name)}_preserves_nullable_fields(self):`);
-      lines.push(`        data = ${toPythonLiteral(nullablePayload)}`);
-      lines.push(`        instance = ${modelClass}.from_dict(data)`);
-      lines.push('        serialized = instance.to_dict()');
-      for (const field of dedupFields.filter((field) => field.type.kind === 'nullable')) {
-        lines.push(`        assert serialized[${toPythonLiteral(field.name)}] is None`);
+      if (nullablePayload) {
+        body.push('');
+        body.push(`    def test_${fileName(model.name)}_preserves_nullable_fields(self):`);
+        body.push(`        data = ${toPythonLiteral(nullablePayload)}`);
+        body.push(`        instance = ${modelClass}.from_dict(data)`);
+        body.push('        serialized = instance.to_dict()');
+        for (const field of dedupFields.filter((field) => field.type.kind === 'nullable')) {
+          body.push(`        assert serialized[${toPythonLiteral(field.name)}] is None`);
+        }
       }
-    }
 
-    if (unknownEnumPayload) {
-      lines.push('');
-      lines.push(`    def test_${fileName(model.name)}_round_trips_unknown_enum_values(self):`);
-      lines.push(`        data = ${toPythonLiteral(unknownEnumPayload)}`);
-      lines.push(`        instance = ${modelClass}.from_dict(data)`);
-      lines.push('        assert instance.to_dict() == data');
+      if (unknownEnumPayload) {
+        body.push('');
+        body.push(`    def test_${fileName(model.name)}_round_trips_unknown_enum_values(self):`);
+        body.push(`        data = ${toPythonLiteral(unknownEnumPayload)}`);
+        body.push(`        instance = ${modelClass}.from_dict(data)`);
+        body.push('        assert instance.to_dict() == data');
+      }
     }
   }
 
-  // Discriminator dispatch tests — targeted coverage for from_dict routing
-  const discriminatorModels = models.filter((m) => (m as any).discriminator);
   if (discriminatorModels.length > 0) {
-    lines.push('');
-    lines.push('');
-    lines.push('class TestDiscriminatorDispatch:');
-
+    body.push('');
+    body.push('');
+    body.push('class TestDiscriminatorDispatch:');
     for (const model of discriminatorModels) {
       const disc = (model as any).discriminator as { property: string; mapping: Record<string, string> };
       const modelClass = className(model.name);
@@ -1624,40 +1639,75 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
       const [, firstVariantName] = sortedEntries[0];
       const firstVariantClass = className(firstVariantName);
       const firstVariantFixture = `${fileName(firstVariantName)}.json`;
+      addImport(model.name, modelClass);
+      addImport(model.name, unknownClass);
+      addImport(firstVariantName, firstVariantClass);
 
-      lines.push('');
-      lines.push(`    def test_${fileName(model.name)}_dispatches_known_variant(self):`);
-      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
-      lines.push(`        result = ${modelClass}.from_dict(data)`);
-      lines.push(`        assert isinstance(result, ${firstVariantClass})`);
+      body.push('');
+      body.push(`    def test_${fileName(model.name)}_dispatches_known_variant(self):`);
+      body.push(`        data = load_fixture("${firstVariantFixture}")`);
+      body.push(`        result = ${modelClass}.from_dict(data)`);
+      body.push(`        assert isinstance(result, ${firstVariantClass})`);
 
-      lines.push('');
-      lines.push(`    def test_${fileName(model.name)}_returns_unknown_for_unrecognized_type(self):`);
-      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
-      lines.push(`        data = {**data, "${disc.property}": "future.unrecognized.type"}`);
-      lines.push(`        result = ${modelClass}.from_dict(data)`);
-      lines.push(`        assert isinstance(result, ${unknownClass})`);
-      lines.push('        assert result.raw_data == data');
+      body.push('');
+      body.push(`    def test_${fileName(model.name)}_returns_unknown_for_unrecognized_type(self):`);
+      body.push(`        data = load_fixture("${firstVariantFixture}")`);
+      body.push(`        data = {**data, "${disc.property}": "future.unrecognized.type"}`);
+      body.push(`        result = ${modelClass}.from_dict(data)`);
+      body.push(`        assert isinstance(result, ${unknownClass})`);
+      body.push('        assert result.raw_data == data');
 
-      lines.push('');
-      lines.push(`    def test_${fileName(model.name)}_raises_on_missing_discriminator(self):`);
-      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
-      lines.push(`        data = {k: v for k, v in data.items() if k != "${disc.property}"}`);
-      lines.push('        with pytest.raises(Exception):');
-      lines.push(`            ${modelClass}.from_dict(data)`);
+      body.push('');
+      body.push(`    def test_${fileName(model.name)}_raises_on_missing_discriminator(self):`);
+      body.push(`        data = load_fixture("${firstVariantFixture}")`);
+      body.push(`        data = {k: v for k, v in data.items() if k != "${disc.property}"}`);
+      body.push('        with pytest.raises(Exception):');
+      body.push(`            ${modelClass}.from_dict(data)`);
 
-      lines.push('');
-      lines.push(`    def test_${fileName(model.name)}_raises_on_none_discriminator(self):`);
-      lines.push(`        data = load_fixture("${firstVariantFixture}")`);
-      lines.push(`        data = {**data, "${disc.property}": None}`);
-      lines.push('        with pytest.raises(Exception):');
-      lines.push(`            ${modelClass}.from_dict(data)`);
+      body.push('');
+      body.push(`    def test_${fileName(model.name)}_raises_on_none_discriminator(self):`);
+      body.push(`        data = load_fixture("${firstVariantFixture}")`);
+      body.push(`        data = {**data, "${disc.property}": None}`);
+      body.push('        with pytest.raises(Exception):');
+      body.push(`            ${modelClass}.from_dict(data)`);
     }
   }
 
+  const lines: string[] = [];
+  lines.push('"""Model round-trip tests: from_dict(to_dict()) preserves data."""');
+  lines.push('');
+  lines.push('import pytest');
+  lines.push('');
+  lines.push('from tests.generated_helpers import load_fixture');
+  lines.push('');
+  for (const [dir, names] of [...importsByDir].sort(([a], [b]) => a.localeCompare(b))) {
+    lines.push(`from ${ctx.namespace}.${dirToModule(dir)}.models import ${[...names].sort().join(', ')}`);
+  }
+
   return {
-    path: 'tests/test_models_round_trip.py',
-    content: lines.join('\n'),
+    path: `tests/test_${dirName.replace(/\//g, '_')}_models_round_trip.py`,
+    content: [...lines, ...body].join('\n'),
+    integrateTarget: true,
+    overwriteExisting: true,
+  };
+}
+
+/**
+ * Retire the pre-split monolith (`tests/test_models_round_trip.py`). A full run
+ * simply stops emitting it, so the engine prunes it; a scoped run never prunes,
+ * so overwrite the stale (now-failing) monolith with an inert placeholder while
+ * it's still on disk (recorded in the prior manifest). Gating on the prior
+ * manifest means it is NOT recreated once a full run has pruned it.
+ */
+function retireLegacyRoundTripMonolith(ctx: EmitterContext): GeneratedFile | null {
+  if (!isScopedRun(ctx)) return null;
+  if (!ctx.priorTargetManifestPaths?.has(LEGACY_ROUNDTRIP_PATH)) return null;
+  return {
+    path: LEGACY_ROUNDTRIP_PATH,
+    content:
+      '"""Model round-trip tests moved to per-service ' +
+      'tests/test_<service>_models_round_trip.py files.\n\n' +
+      'This placeholder remains only until the next full generation prunes it."""\n',
     integrateTarget: true,
     overwriteExisting: true,
   };

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -20,7 +20,6 @@ import {
   buildHiddenParams,
   collectBodyFieldTypes,
   isModelInScope,
-  fileExistsAfterRun,
   isScopedRun,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
@@ -209,47 +208,41 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     });
   }
 
-  // Minimal scope: the model round-trip test is one wholesale file covering
-  // every model, so regenerating it in a scoped run would either drag in every
-  // on-disk model (surface) or drop their coverage. Skip it entirely in a scoped
-  // run — leave the on-disk file untouched. The selected service's models still
-  // regenerate; their brand-new fields just aren't round-trip-tested until the
-  // next full generation (accepted trade-off for X-only diffs).
-  if (!isScopedRun(ctx)) {
-    files.push(generateModelRoundTripTest(spec, ctx));
-  }
+  // Model round-trip tests: one file per service dir
+  // (test/workos/test_<dir>_model_round_trip.rb), each covering only that dir's
+  // models regenerated this run. A scoped run regenerates the selected
+  // services' round-trip tests in lockstep with their models — fixing the
+  // former wholesale file, which a scoped run skipped and thus left asserting a
+  // selected model's OLD shape — and leaves untouched services' files alone.
+  files.push(...generateModelRoundTripTests(spec, ctx));
+  const legacyRoundTrip = retireLegacyRoundTripMonolith(ctx);
+  if (legacyRoundTrip) files.push(legacyRoundTrip);
 
   return files;
 }
 
-/**
- * Emit test/workos/model_round_trip_test.rb that round-trips every non-wrapper
- * model through `.new(json)` and `.to_json`, asserting the result is a Hash and
- * that required fields appear with the seeded values.
- *
- * This is a whole-suite AGGREGATE: it references `WorkOS::<Class>` for every
- * model. Under a scoped (`--services`) run only the selected services' per-model
- * `.rb` files are (re)written, so a test referencing a brand-new out-of-scope
- * model whose file was never emitted would raise `NameError: uninitialized
- * constant`. Each per-model test is therefore gated by {@link fileExistsAfterRun}
- * on the SAME path `models.ts` writes (`lib/workos/<dir>/<file>.rb`): emit only
- * when that file will exist on disk after the run — in-scope (emitted this run)
- * OR already present from a prior run (`priorTargetManifestPaths`). Brand-new
- * out-of-scope models are excluded; renamed/removed-but-on-disk models are
- * retained. A full run (scoping inert) keeps every model.
- */
-function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): GeneratedFile {
-  const lines: string[] = [];
-  lines.push(`require 'test_helper'`);
-  lines.push('');
-  lines.push('class ModelRoundTripTest < Minitest::Test');
+const LEGACY_ROUNDTRIP_PATH = 'test/workos/test_model_round_trip.rb';
 
+/**
+ * Per-service model round-trip tests: one file per service dir
+ * (`test/workos/test_<dir>_model_round_trip.rb`) that round-trips every
+ * non-wrapper model in that dir through `.new(json)`/`.to_h`, asserting a Hash
+ * result and that seeded keys survive.
+ *
+ * Only IN-SCOPE models are emitted (`isModelInScope`: everything on a full run,
+ * selected-only under `--services`), so a scoped run regenerates a dir's
+ * round-trip file in lockstep with that dir's regenerated per-model `.rb`
+ * files. This replaces the former single wholesale file, which a scoped run
+ * skipped entirely — leaving it asserting the OLD shape of a model the same run
+ * had just regenerated (the failure this fixes). Dirs with no in-scope models
+ * are skipped, so untouched services' files are left byte-for-byte alone
+ * (scoped runs never prune). Because every emitted model is in-scope, its
+ * `WorkOS::<Class>` constant is written by this same run — the reference can't
+ * dangle into an `uninitialized constant`.
+ */
+function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const models = (spec.models as Model[]).filter((m) => !isListWrapperModel(m) && !isListMetadataModel(m));
   const enumNames = new Set(spec.enums.map((e) => e.name));
-  const emitted = new Set<string>();
-
-  // Resolve each model's per-model file path EXACTLY as models.ts does, so the
-  // scope gate keys on the same path the per-model FILE writer uses.
   const modelToService = assignModelsToServices(models, ctx.spec.services, ctx.modelHints);
   const mountDirMap = buildMountDirMap(ctx);
   const dirFor = (modelName: string): string => {
@@ -258,19 +251,48 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
     return mountDirMap.get(service) ?? classifyUnassignedModel(modelName);
   };
 
+  // Group in-scope models by their dir; skip out-of-scope so untouched dirs'
+  // files stay put and each emitted file matches its regenerated models.
+  const modelsByDir = new Map<string, Model[]>();
   for (const model of models) {
-    // Skip models whose per-model `.rb` file will NOT exist on disk after this
-    // run (brand-new + out-of-scope under `--services`). Without this gate the
-    // aggregate would reference an undefined constant. The path mirrors
-    // models.ts's `lib/workos/${dirFor}/${fileName}.rb`.
-    const modelFilePath = `lib/workos/${dirFor(model.name)}/${fileName(model.name)}.rb`;
-    if (!fileExistsAfterRun(modelFilePath, isModelInScope(model.name, ctx), ctx)) continue;
+    if (!isModelInScope(model.name, ctx)) continue;
+    const dir = dirFor(model.name);
+    if (!modelsByDir.has(dir)) modelsByDir.set(dir, []);
+    modelsByDir.get(dir)!.push(model);
+  }
 
+  const files: GeneratedFile[] = [];
+  for (const [dirName, dirModels] of [...modelsByDir].sort(([a], [b]) => a.localeCompare(b))) {
+    const file = buildDirRoundTripFile(dirName, dirModels, enumNames);
+    if (file) files.push(file);
+  }
+  return files;
+}
+
+/** Build one service dir's round-trip test file, or null when it has no models. */
+function buildDirRoundTripFile(dirName: string, dirModels: Model[], enumNames: Set<string>): GeneratedFile | null {
+  // Each dir gets a distinct test-class name so two files never reopen the same
+  // Minitest class (which would merge — and clash — their methods).
+  const dirClass = dirName
+    .split(/[_/]/)
+    .filter(Boolean)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+
+  const lines: string[] = [];
+  lines.push(`require 'test_helper'`);
+  lines.push('');
+  lines.push(`class ${dirClass}ModelRoundTripTest < Minitest::Test`);
+
+  const emitted = new Set<string>();
+  let count = 0;
+  for (const model of dirModels) {
     // Avoid duplicate test names when two IR model names collapse to the same
     // snake_case file name (we use the file name as the test suffix).
     const fileBase = fileName(model.name);
     if (emitted.has(fileBase)) continue;
     emitted.add(fileBase);
+    count += 1;
 
     // Build a fixture hash with string keys and stub values for every field.
     const fixtureEntries: string[] = [];
@@ -327,10 +349,32 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
   }
 
   lines.push('end');
+  if (count === 0) return null;
 
   return {
-    path: 'test/workos/test_model_round_trip.rb',
+    path: `test/workos/test_${dirName.replace(/\//g, '_')}_model_round_trip.rb`,
     content: lines.join('\n'),
+    integrateTarget: true,
+    overwriteExisting: true,
+  };
+}
+
+/**
+ * Retire the pre-split monolith (`test/workos/test_model_round_trip.rb`). A full
+ * run stops emitting it (engine prunes it); a scoped run never prunes, so
+ * overwrite the stale (now-failing) monolith with an inert placeholder while
+ * it's still on disk (recorded in the prior manifest). Gating on the prior
+ * manifest means it is NOT recreated once a full run has pruned it.
+ */
+function retireLegacyRoundTripMonolith(ctx: EmitterContext): GeneratedFile | null {
+  if (!isScopedRun(ctx)) return null;
+  if (!ctx.priorTargetManifestPaths?.has(LEGACY_ROUNDTRIP_PATH)) return null;
+  return {
+    path: LEGACY_ROUNDTRIP_PATH,
+    content:
+      '# Model round-trip tests moved to per-service ' +
+      'test/workos/test_<service>_model_round_trip.rb files.\n' +
+      '# This placeholder remains only until the next full generation prunes it.\n',
     integrateTarget: true,
     overwriteExisting: true,
   };

--- a/test/dotnet/tests.test.ts
+++ b/test/dotnet/tests.test.ts
@@ -199,4 +199,45 @@ describe('dotnet/tests', () => {
     expect(content).toContain('MockSequentialResponses');
     expect(content).toContain('await foreach');
   });
+
+  it('does not seed a string literal into a date-time (DateTimeOffset) property', () => {
+    const dtModels: Model[] = [
+      {
+        name: 'ExportCreation',
+        fields: [
+          { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'range_start', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+        ],
+      },
+      { name: 'Export', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const dtServices: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'createExport',
+            httpMethod: 'post',
+            path: '/audit_logs/exports',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'ExportCreation' },
+            response: { kind: 'model', name: 'Export' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const dtSpec: ApiSpec = { ...spec, models: dtModels, services: dtServices };
+    const content = generateTests(dtSpec, { ...ctx, spec: dtSpec }).find(
+      (f) => f.path === 'Tests/AuditLogsServiceTest.cs',
+    )!.content;
+
+    // A DateTimeOffset property must never be assigned a string literal seed.
+    expect(content).not.toContain('RangeStart = "');
+    // The plain string field is still seeded.
+    expect(content).toContain('OrganizationId = "test_organization_id"');
+  });
 });

--- a/test/php/resources.test.ts
+++ b/test/php/resources.test.ts
@@ -889,4 +889,45 @@ describe('generateResources', () => {
     expect(content).toContain('public function getProfileAndToken(');
     expect(content).toMatch(/function getProfileAndToken\(\s*string \$code/);
   });
+
+  it('serializes required date-time body fields via RFC3339_EXTENDED', () => {
+    const dtModels: Model[] = [
+      {
+        name: 'ExportCreation',
+        fields: [
+          { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'range_start', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+          { name: 'range_end', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+        ],
+      },
+      { name: 'Export', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const dtServices: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'createExport',
+            httpMethod: 'post',
+            path: '/audit_logs/exports',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'ExportCreation' },
+            response: { kind: 'model', name: 'Export' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const dtSpec: ApiSpec = { ...emptySpec, models: dtModels, services: dtServices };
+    const content = generateResources(dtServices, { ...ctx, spec: dtSpec })[0].content;
+
+    // date-time body fields must be formatted, not passed as raw \DateTimeImmutable
+    expect(content).toContain("'range_start' => $rangeStart->format(\\DateTimeInterface::RFC3339_EXTENDED)");
+    expect(content).toContain("'range_end' => $rangeEnd->format(\\DateTimeInterface::RFC3339_EXTENDED)");
+    // plain string fields are unaffected
+    expect(content).toContain("'organization_id' => $organizationId");
+  });
 });

--- a/test/php/tests.test.ts
+++ b/test/php/tests.test.ts
@@ -309,4 +309,46 @@ describe('generateTests', () => {
       expect(result.find((f) => f.path === 'tests/Service/ConnectionsTest.php')).toBeDefined();
     });
   });
+
+  it('asserts date-time request-body fields against the RFC3339 wire value', () => {
+    const dtModels: Model[] = [
+      {
+        name: 'ExportCreation',
+        fields: [
+          { name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'range_start', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+        ],
+      },
+      { name: 'Export', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ];
+    const dtServices: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'createExport',
+            httpMethod: 'post',
+            path: '/audit_logs/exports',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'ExportCreation' },
+            response: { kind: 'model', name: 'Export' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    const dtSpec: ApiSpec = { ...spec, models: dtModels, services: dtServices };
+    const content = generateTests(dtSpec, { ...ctx, spec: dtSpec }).find(
+      (f) => f.path === 'tests/Service/AuditLogsTest.php',
+    )!.content;
+
+    // Call passes a DateTimeImmutable; the body assertion expects its RFC3339 form.
+    expect(content).toContain("new \\DateTimeImmutable('2023-01-01T00:00:00Z')");
+    expect(content).toContain("assertSame('2023-01-01T00:00:00.000+00:00', $body['range_start'])");
+    // The plain-string placeholder must NOT be used for a date-time field.
+    expect(content).not.toContain("assertSame('test_value', $body['range_start'])");
+  });
 });

--- a/test/python/scoped-aggregates.test.ts
+++ b/test/python/scoped-aggregates.test.ts
@@ -161,13 +161,43 @@ describe('python scoped aggregates', () => {
   });
 
   describe('round-trip test + fixtures', () => {
-    // Minimal scoped generation: the monolithic round-trip test covers ALL
-    // models, so a scoped run must not touch it — it is not emitted at all,
-    // leaving the on-disk file byte-for-byte untouched.
-    it('does not emit the wholesale model round-trip test on a scoped run', () => {
+    // A scoped run regenerates the SELECTED service's per-dir round-trip file in
+    // lockstep with its models, covering ONLY in-scope models, and leaves
+    // out-of-scope services' files untouched (not emitted → scoped no-prune
+    // keeps them). This replaces the old wholesale skip that left one shared
+    // file asserting the old shape of a just-regenerated model.
+    it('emits the selected service dir round-trip file covering only in-scope models', () => {
       const files = generateTests(spec, scopedCtx());
-      const roundTrip = files.find((f) => f.path === 'tests/test_models_round_trip.py');
-      expect(roundTrip).toBeUndefined();
+      const widgetRoundTrip = files.find((f) => f.path === 'tests/test_widgets_models_round_trip.py');
+      expect(widgetRoundTrip).toBeDefined();
+      expect(widgetRoundTrip!.content).toContain('def test_widget_a_round_trip(self):');
+      expect(widgetRoundTrip!.content).toContain('from workos.widgets.models import WidgetA');
+      // The out-of-scope gadget models get no test — their untouched on-disk
+      // models are never asserted against with a fresh (possibly drifted) fixture.
+      expect(widgetRoundTrip!.content).not.toContain('GadgetBrandNew');
+      expect(widgetRoundTrip!.content).not.toContain('GadgetOnDisk');
+    });
+
+    it('does NOT emit a round-trip file for an out-of-scope service dir', () => {
+      const files = generateTests(spec, scopedCtx());
+      expect(files.find((f) => f.path === 'tests/test_gadgets_models_round_trip.py')).toBeUndefined();
+    });
+
+    it('does not resurrect the pre-split monolith when it is absent from disk', () => {
+      const files = generateTests(spec, scopedCtx());
+      expect(files.find((f) => f.path === 'tests/test_models_round_trip.py')).toBeUndefined();
+    });
+
+    it('overwrites the pre-split monolith with an inert placeholder while it is still on disk', () => {
+      const ctx = scopedCtx();
+      ctx.priorTargetManifestPaths!.add('tests/test_models_round_trip.py');
+      const files = generateTests(spec, ctx);
+      const legacy = files.find((f) => f.path === 'tests/test_models_round_trip.py');
+      expect(legacy).toBeDefined();
+      expect(legacy!.content).toContain('moved to per-service');
+      // Inert: no test classes or functions, so it passes as it awaits pruning.
+      expect(legacy!.content).not.toContain('class Test');
+      expect(legacy!.content).not.toContain('def test_');
     });
 
     it('emits a fixture ONLY for the selected in-scope model', () => {
@@ -198,7 +228,8 @@ describe('python scoped aggregates', () => {
       expect(gadgetBarrel!.content).not.toContain('import *');
 
       const testFiles = generateTests(spec, fullCtx);
-      const roundTrip = testFiles.find((f) => f.path === 'tests/test_models_round_trip.py');
+      // Full run emits a per-dir round-trip file for every service dir.
+      const roundTrip = testFiles.find((f) => f.path === 'tests/test_gadgets_models_round_trip.py');
       expect(roundTrip!.content).toContain('GadgetBrandNew');
       expect(testFiles.find((f) => f.path === 'tests/fixtures/gadget_brand_new.json')).toBeDefined();
     });

--- a/test/python/tests.test.ts
+++ b/test/python/tests.test.ts
@@ -175,7 +175,7 @@ describe('generateTests', () => {
     };
 
     const files = generateTests(discSpec, { ...ctx, spec: discSpec });
-    const roundTripTest = files.find((f) => f.path === 'tests/test_models_round_trip.py');
+    const roundTripTest = files.find((f) => f.path === 'tests/test_events_models_round_trip.py');
     expect(roundTripTest).toBeDefined();
 
     const content = roundTripTest!.content;
@@ -274,7 +274,7 @@ describe('generateTests', () => {
 
     const files = generateTests(edgeSpec, { ...ctx, spec: edgeSpec });
     const serviceTest = files.find((f) => f.path === 'tests/test_organizations.py');
-    const roundTripTest = files.find((f) => f.path === 'tests/test_models_round_trip.py');
+    const roundTripTest = files.find((f) => f.path === 'tests/test_organizations_models_round_trip.py');
 
     expect(serviceTest).toBeDefined();
     expect(serviceTest!.content).toContain('assert len(page.data) == 1');

--- a/test/ruby/tests.test.ts
+++ b/test/ruby/tests.test.ts
@@ -64,27 +64,32 @@ const services: Service[] = [
 
 const spec = makeSpec(services, models);
 
-function findRoundTripFile(files: { path: string; content: string }[]): { path: string; content: string } {
-  const file = files.find((f) => f.path === 'test/workos/test_model_round_trip.rb');
-  if (!file) throw new Error('round-trip test file not emitted');
-  return file;
+const LEGACY_ROUNDTRIP_PATH = 'test/workos/test_model_round_trip.rb';
+
+// The per-dir round-trip files (test/workos/test_<dir>_model_round_trip.rb),
+// excluding the pre-split monolith which also ends with _model_round_trip.rb.
+function roundTripContent(files: { path: string; content: string }[]): string {
+  return files
+    .filter((f) => f.path !== LEGACY_ROUNDTRIP_PATH && f.path.endsWith('_model_round_trip.rb'))
+    .map((f) => f.content)
+    .join('\n');
 }
 
-describe('ruby/tests model round-trip aggregate scoping', () => {
-  it('full run: round-trips every model', () => {
+describe('ruby/tests model round-trip per-service scoping', () => {
+  it('full run: round-trips every model across per-dir files', () => {
     const ctx: EmitterContext = {
       namespace: 'workos',
       namespacePascal: 'WorkOS',
       spec,
       resolvedOperations: buildResolvedOps(services),
     };
-    const content = findRoundTripFile(generateTests(spec, ctx)).content;
-    expect(content).toContain('WorkOS::Organization.new');
-    expect(content).toContain('WorkOS::Connection.new');
-    expect(content).toContain('WorkOS::Directory.new');
+    const combined = roundTripContent(generateTests(spec, ctx));
+    expect(combined).toContain('WorkOS::Organization.new');
+    expect(combined).toContain('WorkOS::Connection.new');
+    expect(combined).toContain('WorkOS::Directory.new');
   });
 
-  it('scoped run: does NOT emit the wholesale round-trip test (leaves the on-disk one untouched)', () => {
+  it('scoped run: regenerates ONLY the selected service dir round-trip file', () => {
     const ctx: EmitterContext = {
       namespace: 'workos',
       namespacePascal: 'WorkOS',
@@ -95,10 +100,33 @@ describe('ruby/tests model round-trip aggregate scoping', () => {
     };
 
     const files = generateTests(spec, ctx);
-    // Minimal scope: the monolithic round-trip test is skipped in a scoped run so
-    // it never drags in (surface) — nor drops — other services' models. The
-    // on-disk file is left untouched; the selected service's own test still emits.
-    expect(files.some((f) => f.path === 'test/workos/test_model_round_trip.rb')).toBe(false);
-    expect(files.length).toBeGreaterThan(0);
+    const combined = roundTripContent(files);
+    // The selected service's model IS round-trip tested, in lockstep with its
+    // regenerated per-model file.
+    expect(combined).toContain('WorkOS::Organization.new');
+    // Out-of-scope models get no round-trip test — their untouched on-disk
+    // models are never asserted against with a fresh (possibly drifted) fixture.
+    expect(combined).not.toContain('WorkOS::Connection.new');
+    expect(combined).not.toContain('WorkOS::Directory.new');
+    // The pre-split monolith is not resurrected when it isn't on disk.
+    expect(files.some((f) => f.path === LEGACY_ROUNDTRIP_PATH)).toBe(false);
+  });
+
+  it('scoped run: overwrites the pre-split monolith with an inert placeholder while it is on disk', () => {
+    const ctx: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec,
+      resolvedOperations: buildResolvedOps(services),
+      scopedServices: new Set(['Organizations']),
+      scopedModelNames: new Set(['Organization']),
+      priorTargetManifestPaths: new Set([LEGACY_ROUNDTRIP_PATH]),
+    };
+    const legacy = generateTests(spec, ctx).find((f) => f.path === LEGACY_ROUNDTRIP_PATH);
+    expect(legacy).toBeDefined();
+    expect(legacy!.content).toContain('moved to per-service');
+    // Inert: no test class or methods, so it passes while awaiting pruning.
+    expect(legacy!.content).not.toContain('def test_');
+    expect(legacy!.content).not.toContain('Minitest::Test');
   });
 });


### PR DESCRIPTION
## Problem

The Python and Ruby emitters produced **one wholesale** model round-trip test (`tests/test_models_round_trip.py`, `test/workos/test_model_round_trip.rb`) and **skipped regenerating it on a scoped `--services` run** — to avoid rewriting a whole-SDK file down to a selected-only subset.

But a scoped run still regenerates the selected services' **models**. So the skipped (committed) round-trip test kept asserting the **old shape** of a model the same run had just changed:

- a field that became **required** → `from_dict` `KeyError` (e.g. `UserRoleAssignment.source`)
- a field that was **removed** → `to_h` missing key (e.g. `GenerateLinkDto.intent_options`)

…failing the generated SDK's own tests on every sync/preview. A full regen would have passed — this was purely scoped-run staleness, not a spec or model-generator defect.

## Fix

Split the wholesale file into **one file per service dir** (`tests/test_<dir>_models_round_trip.py`, `test/workos/test_<dir>_model_round_trip.rb`), each covering only that dir's **in-scope** models (`isModelInScope`: everything on a full run, selected-only under `--services`) — mirroring the Node emitter's per-dir serializer tests.

- A scoped run regenerates the selected services' round-trip tests **in lockstep** with their models.
- Untouched services' files aren't emitted → left alone (scoped runs never prune).
- Dirs with no in-scope models emit nothing.
- Removed the `isScopedRun` wholesale skip.

### Migration (self-cleaning)

The pre-split monolith is retired automatically:
- **Full run**: no longer emitted → engine prunes it.
- **Scoped run** (never prunes): overwrite it with an inert placeholder *while it's still in the prior manifest*, so the stale failing file passes; gated on the manifest so it isn't resurrected once a full run removes it.

After this ships + **one full generation per SDK**, scoped previews are clean. The shim keeps them green in the interim.

## Tests

Rewrote the scoped round-trip expectations for both emitters to assert:
- the selected service dir's file **is** regenerated (in sync with its model),
- out-of-scope service dirs get **no** file,
- the monolith placeholder fires **only** while it's still on disk.

Full suite **616 pass**, typecheck + lint + format clean.

> [!NOTE]
> Validated at the emitter/unit level here. The true end-to-end proof — the regenerated Python/Ruby SDKs passing their own pytest/minitest — happens in the `openapi-spec` generate pipeline.

## Follow-up (not in this PR)

Coverage parity: only Python/Ruby/Node have thorough model round-trip tests; Kotlin's covers only all-required simple models; **.NET and Go have none** — so a real serialization regression can currently ship undetected there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)