### PR TITLE
fix(fixtures): overwrite generated fixtures instead of deep-merging

### DIFF
--- a/src/dotnet/tests.ts
+++ b/src/dotnet/tests.ts
@@ -29,13 +29,18 @@ import {
 export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const files: GeneratedFile[] = [];
 
-  // Generate fixture JSON files
+  // Generate fixture JSON files. Fixtures are fully generated artifacts, so
+  // overwrite rather than let the writer deep-merge into the on-disk JSON — a
+  // merge preserves stale entries (e.g. an old `metadata: { "key": {} }` map
+  // placeholder survives after the example became `{ "timezone": ... }`, leaving
+  // an object value a `Dictionary<string,string>` model can't deserialize).
   const fixtures = generateFixtures(spec, ctx);
   for (const fixture of fixtures) {
     files.push({
       path: fixture.path,
       content: fixture.content,
       headerPlacement: 'skip',
+      overwriteExisting: true,
     });
   }
 

--- a/src/go/tests.ts
+++ b/src/go/tests.ts
@@ -76,10 +76,14 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   // fixtures byte-for-byte untouched on disk (see generateFixtures).
   const { files: fixtures, pathRewrites: fixtureRewrites } = generateFixtures(spec, ctx);
   for (const fixture of fixtures) {
+    // Fixtures are fully generated artifacts: overwrite instead of deep-merging
+    // into the on-disk JSON, which would preserve stale entries (e.g. a leftover
+    // object-valued `metadata: { "key": {} }` map placeholder).
     files.push({
       path: fixture.path,
       content: fixture.content,
       headerPlacement: 'skip',
+      overwriteExisting: true,
     });
   }
 

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -93,12 +93,16 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
   // models.ts. PHP has no monolithic model round-trip test — model round-trips
   // are exercised inline in the per-service `*Test.php` files (already scoped via
   // `scopedMountGroups`) — so there is no whole-suite aggregate to skip here.
+  // Fixtures are fully generated artifacts: overwrite instead of deep-merging
+  // into the on-disk JSON, which would preserve stale entries (e.g. a leftover
+  // object-valued `metadata: { "key": {} }` map placeholder).
   const fixtures = generateFixtures(spec, ctx);
   for (const fixture of fixtures) {
     files.push({
       path: fixture.path,
       content: fixture.content,
       headerPlacement: 'skip',
+      overwriteExisting: true,
     });
   }
 

--- a/src/rust/fixtures.ts
+++ b/src/rust/fixtures.ts
@@ -33,10 +33,14 @@ export function generateFixtures(spec: ApiSpec, ctx: EmitterContext): GeneratedF
     if (!isModelInScope(model.name, ctx)) continue;
 
     const fixture = generateModelFixture(model, modelMap, enumMap, new Set());
+    // Fixtures are fully generated artifacts: overwrite instead of deep-merging
+    // into the on-disk JSON, which would preserve stale entries (e.g. a leftover
+    // object-valued `metadata: { "key": {} }` map placeholder).
     files.push({
       path,
       content: JSON.stringify(fixture, null, 2) + '\n',
       headerPlacement: 'skip',
+      overwriteExisting: true,
     });
   }
 

--- a/test/dotnet/tests.test.ts
+++ b/test/dotnet/tests.test.ts
@@ -122,6 +122,9 @@ describe('dotnet/tests', () => {
     const fixture = files.find((f) => f.path === 'testdata/organization.json');
     expect(fixture).toBeDefined();
     expect(fixture!.headerPlacement).toBe('skip');
+    // Fixtures overwrite rather than deep-merge into the on-disk JSON, so a
+    // regen can't preserve stale entries (e.g. an old `metadata: { "key": {} }`).
+    expect(fixture!.overwriteExisting).toBe(true);
 
     const data = JSON.parse(fixture!.content);
     expect(data).toHaveProperty('id');

--- a/test/go/tests.test.ts
+++ b/test/go/tests.test.ts
@@ -65,6 +65,9 @@ describe('go/tests', () => {
 
     expect(testFiles.length).toBeGreaterThanOrEqual(1);
     expect(fixtureFiles.length).toBeGreaterThanOrEqual(1);
+    // Fixtures overwrite rather than deep-merge, so a regen can't preserve
+    // stale entries (e.g. an old `metadata: { "key": {} }` map placeholder).
+    expect(fixtureFiles.every((f) => f.overwriteExisting === true)).toBe(true);
   });
 
   it('generates httptest-based tests', () => {

--- a/test/php/tests.test.ts
+++ b/test/php/tests.test.ts
@@ -178,6 +178,9 @@ describe('generateTests', () => {
 
     const fixture = result.find((f) => f.path.includes('Fixtures/organization.json'));
     expect(fixture).toBeDefined();
+    // Fixtures overwrite rather than deep-merge, so a regen can't preserve
+    // stale entries (e.g. an old `metadata: { "key": {} }` map placeholder).
+    expect(fixture!.overwriteExisting).toBe(true);
     const parsed = JSON.parse(fixture!.content);
     expect(parsed).toHaveProperty('id');
     expect(parsed).toHaveProperty('name');

--- a/test/rust/fixtures.test.ts
+++ b/test/rust/fixtures.test.ts
@@ -45,6 +45,9 @@ describe('rust/fixtures', () => {
     const files = generateFixtures(spec(models), ctx(spec(models)));
     const file = files.find((f) => f.path === 'tests/fixtures/event.json')!;
     expect(file).toBeDefined();
+    // Fixtures overwrite rather than deep-merge, so a regen can't preserve
+    // stale entries (e.g. an old `metadata: { "key": {} }` map placeholder).
+    expect(file.overwriteExisting).toBe(true);
     const parsed = JSON.parse(file.content);
     expect(parsed.id).toBe('event_01XXXX');
     expect(parsed.created_at).toBe('2026-02-02T16:35:39.317Z');


### PR DESCRIPTION
## Summary
Generated test fixtures were being **deep-merged** into their on-disk counterparts by the engine writer, the same as `package.json`-style config. For fixtures that's wrong — they're fully generated artifacts, so the current output must be authoritative. Merging *preserves stale entries*.

Concretely, an open-ended map field (a user's `metadata`) was once emitted as the placeholder `{ "key": {} }`. After the spec gained a real example the generator emits `{ "timezone": "..." }`, but the merge keeps **both** — leaving an object-valued `"key": {}` that a `Dictionary<string,string>` model can't deserialize.

This broke `WorkOSTests.UserManagementServiceTest.TestCreateAsync` in a preview CI run:
```
Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: {. Path 'metadata.key', line 13, position 12.
```

## Fix
Mark generated fixtures `overwriteExisting: true` — matching the precedent python already had — for **dotnet**, **go**, **php**, and **rust** (rust in `fixtures.ts` since its `tests.ts` spreads `generateFixtures()`).

- **python** already set it — no change.
- **node** intentionally uses `skipIfExists` (write-once) — left as-is.
- Scoping is unaffected: out-of-scope fixtures are never emitted, so the byte-for-byte-untouched-siblings guarantee holds. `overwriteExisting` still honors `@oagen-ignore` regions.

## Validation
- Reproduced with unfixed emitters: generate → inject stale `key:{}` → regen → `key:{}` **preserved** (merge).
- With the fix: same steps → `metadata` regenerates to `{ "timezone": ... }`, stale `key:{}` **gone** (overwrite).
- Confirmed the committed `workos-dotnet` fixture is currently `metadata: {"key": {}}`, so the next regen overwrites it and the test passes.
- Added regression assertions to the dotnet/go/php/rust fixture tests.
- Full emitter suite: **621/621 pass**; lint + format clean.

## Downstream
`openapi-spec` pins a published `@workos/oagen-emitters` version, so this needs a release + bump there to take effect in the SDK-generation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)