### PR TITLE
fix(node): don't coalesce optional nullable body fields to null

### DIFF
--- a/src/node/field-plan.ts
+++ b/src/node/field-plan.ts
@@ -8,6 +8,7 @@ import {
   createServiceDirResolver,
   modelHasNewFields,
   assignModelsToServices,
+  baselineFieldCompatible,
 } from './utils.js';
 import {
   liveSurfaceHasFunction,
@@ -592,6 +593,25 @@ export function planSerializeField(
   return { line: emitAssignment(wire, expr, domainAccess, guard), skip: false };
 }
 
+/**
+ * Whether the wire field must carry a value on serialize. Mirrors the interface
+ * emitter's optionality decision: a captured baseline's `optional` flag is only
+ * authoritative when the baseline is compatible with the IR field
+ * (`baselineFieldCompatible`). When it isn't — e.g. the IR marks the field
+ * optional+nullable but a stale baseline snapshot recorded the wire field as
+ * required — the interface layer re-derives optionality from the IR and emits
+ * the field as optional (`models.ts` `baselineFieldCompatible` gate). The
+ * serializer must follow suit; otherwise it coalesces omitted values to
+ * `?? null` for a field its own response interface declares optional, turning
+ * every partial update into an unintended field clear.
+ */
+function baselineWireRequired(baselineWireField: BaselineFieldInfo | undefined, field: Field): boolean {
+  if (baselineWireField && baselineFieldCompatible(baselineWireField, field)) {
+    return !baselineWireField.optional;
+  }
+  return field.required;
+}
+
 function planSerializeGuard(
   field: Field,
   expr: string,
@@ -627,7 +647,7 @@ function planSerializeGuard(
   const isNewFieldOnExistingDomain = baselineDomain && !baselineDomainField;
   const domainFieldIsOptional =
     !field.required || (baselineDomainField?.optional ?? false) || !!isNewFieldOnExistingDomain;
-  const wireFieldIsRequired = baselineWireField ? !baselineWireField.optional : field.required;
+  const wireFieldIsRequired = baselineWireRequired(baselineWireField, field);
   const needsUndefinedCoalesce = domainFieldIsOptional && wireFieldIsRequired && expr === domainAccess;
 
   if (needsUndefinedCoalesce) {
@@ -648,7 +668,15 @@ function planSerializeGuard(
       responseBaselineField2 &&
       responseBaselineField2.optional;
     const fieldEffectivelyOptional = !field.required || !!isNewSerField || !!domainResponseMismatch;
-    if (fieldEffectivelyOptional) {
+    // Only coalesce when the wire field is REQUIRED — it must carry a value, so
+    // a nullish domain value has to become `null` (or `undefined` if the wire
+    // rejects null). When the wire field is itself optional, a passthrough is
+    // correct and compat-faithful: `undefined` omits the field (matching the
+    // hand-written serializers) and an explicit `null` is preserved. Inventing
+    // `?? null` here would send `description: null` for an omitted optional
+    // field, turning a partial update into an unintended clear.
+    const wireFieldIsRequired2 = baselineWireRequired(responseBaselineField2, field);
+    if (fieldEffectivelyOptional && wireFieldIsRequired2) {
       // The wire side may not accept `null` (e.g. `metadata?: Record<...>`).
       // Fall back to `undefined` in that case so the assignment matches the
       // baseline wire field's actual type.

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { Model, Field, TypeRef, EmitterContext, GeneratedFile, Operation, Service } from '@workos/oagen';
+import type { Model, TypeRef, EmitterContext, GeneratedFile, Operation, Service } from '@workos/oagen';
 import { planOperation } from '@workos/oagen';
 import { mapTypeRef, mapWireTypeRef, isInlineEnum } from './type-map.js';
 import {
@@ -32,6 +32,7 @@ import {
   computeNonEventReachable,
   isServiceCoveredByExisting,
   hasMethodsAbsentFromBaseline,
+  baselineFieldCompatible,
 } from './utils.js';
 import { assignEnumsToServices } from './enums.js';
 import {
@@ -1262,75 +1263,6 @@ function baselineTypeResolvable(typeStr: string, importableNames: Set<string>): 
     return false;
   }
   return true;
-}
-
-function baselineFieldCompatible(baselineField: { type: string; optional: boolean }, irField: Field): boolean {
-  // A baseline `any` is the footprint of a previously-broken generation:
-  // api-surface extraction types a field as `any` when its import failed to
-  // resolve (e.g. the enum file hadn't been emitted yet in that run). Copying
-  // it forward would freeze the degradation — once `state: any` lands in the
-  // SDK, every later regen sees it as the baseline and re-emits it. When the
-  // IR knows the real model/enum name, always re-derive from the IR instead.
-  if (baselineTypeIsDegradedAny(baselineField.type) && hasNamedTypeReference(irField.type)) {
-    return false;
-  }
-
-  const irNullable = irField.type.kind === 'nullable';
-  const baselineHasNull = baselineField.type.includes('null');
-
-  if (irNullable && !baselineHasNull && irField.required) {
-    return false;
-  }
-
-  if (!irField.required && !baselineField.optional && !baselineField.type.includes('undefined')) {
-    return false;
-  }
-
-  if (baselineField.type === 'Record<string, unknown>' && hasSpecificIRType(irField.type)) {
-    return false;
-  }
-
-  return true;
-}
-
-/** `any`, `any[]`, `any | null`, … — shapes api-surface extraction degrades to. */
-function baselineTypeIsDegradedAny(typeStr: string): boolean {
-  const stripped = typeStr
-    .replace(/\s*\|\s*(?:null|undefined)\b/g, '')
-    .replace(/\[\]$/, '')
-    .trim();
-  return stripped === 'any';
-}
-
-/** Does the IR type reference a named model/enum anywhere (incl. arrays)? */
-function hasNamedTypeReference(ref: TypeRef): boolean {
-  switch (ref.kind) {
-    case 'model':
-    case 'enum':
-      return true;
-    case 'array':
-      return hasNamedTypeReference(ref.items);
-    case 'nullable':
-      return hasNamedTypeReference(ref.inner);
-    case 'union':
-      return ref.variants.some((v) => hasNamedTypeReference(v));
-    default:
-      return false;
-  }
-}
-
-function hasSpecificIRType(ref: TypeRef): boolean {
-  switch (ref.kind) {
-    case 'model':
-    case 'enum':
-      return true;
-    case 'union':
-      return ref.variants.some((v) => v.kind === 'model' || v.kind === 'enum');
-    case 'nullable':
-      return hasSpecificIRType(ref.inner);
-    default:
-      return false;
-  }
 }
 
 /** True when a baseline field type references one of the model's generic

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -1,4 +1,4 @@
-import type { Model, EmitterContext, Service, Operation, TypeRef } from '@workos/oagen';
+import type { Model, EmitterContext, Service, Operation, TypeRef, Field } from '@workos/oagen';
 import { toPascalCase } from '@workos/oagen';
 export {
   collectModelRefs,
@@ -616,4 +616,81 @@ export function computeNonEventReachable(services: Service[], models: Model[]): 
     }
   }
   return reachable;
+}
+
+/**
+ * Decide whether a captured baseline field can be reused verbatim, or whether
+ * the emitter must re-derive the field from the IR instead. Shared by the
+ * interface emitter (which picks `?` optionality) and the serializer guard
+ * (which decides whether to coalesce omitted values to `null`) so the two stay
+ * consistent — a serializer must never emit `?? null` for a field its own
+ * response interface declares optional.
+ */
+export function baselineFieldCompatible(baselineField: { type: string; optional: boolean }, irField: Field): boolean {
+  // A baseline `any` is the footprint of a previously-broken generation:
+  // api-surface extraction types a field as `any` when its import failed to
+  // resolve (e.g. the enum file hadn't been emitted yet in that run). Copying
+  // it forward would freeze the degradation — once `state: any` lands in the
+  // SDK, every later regen sees it as the baseline and re-emits it. When the
+  // IR knows the real model/enum name, always re-derive from the IR instead.
+  if (baselineTypeIsDegradedAny(baselineField.type) && hasNamedTypeReference(irField.type)) {
+    return false;
+  }
+
+  const irNullable = irField.type.kind === 'nullable';
+  const baselineHasNull = baselineField.type.includes('null');
+
+  if (irNullable && !baselineHasNull && irField.required) {
+    return false;
+  }
+
+  if (!irField.required && !baselineField.optional && !baselineField.type.includes('undefined')) {
+    return false;
+  }
+
+  if (baselineField.type === 'Record<string, unknown>' && hasSpecificIRType(irField.type)) {
+    return false;
+  }
+
+  return true;
+}
+
+/** `any`, `any[]`, `any | null`, … — shapes api-surface extraction degrades to. */
+function baselineTypeIsDegradedAny(typeStr: string): boolean {
+  const stripped = typeStr
+    .replace(/\s*\|\s*(?:null|undefined)\b/g, '')
+    .replace(/\[\]$/, '')
+    .trim();
+  return stripped === 'any';
+}
+
+/** Does the IR type reference a named model/enum anywhere (incl. arrays)? */
+function hasNamedTypeReference(ref: TypeRef): boolean {
+  switch (ref.kind) {
+    case 'model':
+    case 'enum':
+      return true;
+    case 'array':
+      return hasNamedTypeReference(ref.items);
+    case 'nullable':
+      return hasNamedTypeReference(ref.inner);
+    case 'union':
+      return ref.variants.some((v) => hasNamedTypeReference(v));
+    default:
+      return false;
+  }
+}
+
+function hasSpecificIRType(ref: TypeRef): boolean {
+  switch (ref.kind) {
+    case 'model':
+    case 'enum':
+      return true;
+    case 'union':
+      return ref.variants.some((v) => v.kind === 'model' || v.kind === 'enum');
+    case 'nullable':
+      return hasSpecificIRType(ref.inner);
+    default:
+      return false;
+  }
 }

--- a/test/node/models.test.ts
+++ b/test/node/models.test.ts
@@ -681,6 +681,107 @@ describe('generateSerializers', () => {
     expect(file.content).toContain('createdAt: new Date(response.created_at)');
   });
 
+  // Regression: optional+nullable request-body fields must serialize as a
+  // passthrough, never `?? null`. Coercing an omitted field to explicit null
+  // turns a partial update like `updateDataIntegration({ enabled: true })` into
+  // an unintended clear of `description`/`scopes` (null = reset, per the API's
+  // PUT semantics; undefined = no-op). Covers both a brand-new model (no
+  // baseline) and a stale baseline that recorded the wire field as required.
+  const optionalNullableBodyModels: Model[] = [
+    {
+      name: 'UpdateDataIntegration',
+      fields: [
+        {
+          name: 'description',
+          type: { kind: 'nullable', inner: { kind: 'primitive', type: 'string' } },
+          required: false,
+        },
+        { name: 'enabled', type: { kind: 'primitive', type: 'boolean' }, required: false },
+        {
+          name: 'scopes',
+          type: { kind: 'nullable', inner: { kind: 'array', items: { kind: 'primitive', type: 'string' } } },
+          required: false,
+        },
+      ],
+    },
+    {
+      name: 'DataIntegration',
+      fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+    },
+  ];
+
+  const optionalNullableBodySpec: ApiSpec = {
+    ...emptySpec,
+    models: optionalNullableBodyModels,
+    services: [
+      {
+        name: 'Pipes',
+        operations: [
+          {
+            name: 'updateDataIntegration',
+            httpMethod: 'put',
+            path: '/data-integrations/{slug}',
+            pathParams: [{ name: 'slug', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'UpdateDataIntegration' },
+            response: { kind: 'model', name: 'DataIntegration' },
+            errors: [],
+            injectIdempotencyKey: false,
+          } as any,
+        ],
+      },
+    ],
+  };
+
+  function expectPassthrough(content: string): void {
+    expect(content).toContain('description: model.description,');
+    expect(content).toContain('scopes: model.scopes,');
+    expect(content).not.toContain('description: model.description ?? null');
+    expect(content).not.toContain('scopes: model.scopes ?? null');
+  }
+
+  it('does not coalesce optional nullable body fields to null (new model, no baseline)', () => {
+    const ctxWithModels: EmitterContext = { ...ctx, spec: optionalNullableBodySpec };
+    const result = generateSerializers(optionalNullableBodyModels, ctxWithModels);
+    const ser = result.find((f) => f.path.includes('update-data-integration.serializer'));
+    expect(ser).toBeTruthy();
+    expectPassthrough(ser!.content);
+  });
+
+  it('does not coalesce optional nullable body fields against a stale required-wire baseline', () => {
+    const ctxWithBaseline: EmitterContext = {
+      ...ctx,
+      spec: optionalNullableBodySpec,
+      apiSurface: {
+        language: 'node',
+        extractedFrom: '',
+        extractedAt: '2026-05-12T00:00:00Z',
+        classes: {},
+        interfaces: {
+          // Stale snapshot: wire fields captured as REQUIRED (optional: false),
+          // the footprint of an older generation.
+          UpdateDataIntegrationResponse: {
+            name: 'UpdateDataIntegrationResponse',
+            fields: {
+              description: { type: 'string | null', optional: false },
+              scopes: { type: 'string[] | null', optional: false },
+            },
+            extends: [],
+            sourceFile: 'src/pipes/interfaces/update-data-integration.interface.ts',
+          },
+        },
+        typeAliases: {},
+        enums: {},
+        exports: {},
+      } as any,
+    };
+    const result = generateSerializers(optionalNullableBodyModels, ctxWithBaseline);
+    const ser = result.find((f) => f.path.includes('update-data-integration.serializer'));
+    expect(ser).toBeTruthy();
+    expectPassthrough(ser!.content);
+  });
+
   it('generates nested model deserialization', () => {
     const models: Model[] = [
       {


### PR DESCRIPTION
## Summary

- The Node serializer was coercing omitted optional+nullable request-body fields to `?? null`. Because the API treats an explicit `null` as "clear this field" and `undefined` as "leave unchanged", a partial update like `updateDataIntegration({ enabled: true })` silently cleared unrelated fields such as `description` and `scopes`.
- Optional wire fields now pass through unchanged, so omitting a field omits it from the request (matching the hand-written serializers) while an explicit `null` is still preserved. `?? null` is now only emitted when the wire field is genuinely required.
- Extracted `baselineFieldCompatible` (plus its `hasNamedTypeReference` / `hasSpecificIRType` helpers) from `models.ts` into `utils.ts` so the serializer guard and the interface emitter share one optionality decision and can't disagree.
- Added regression tests covering both a brand-new model (no baseline) and a stale baseline that recorded the wire field as required.
