### PR TITLE
fix(kotlin): reconcile round-trip test per-model in scoped runs

### DIFF
--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -1096,7 +1096,23 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
   }));
 
   const path = `${TEST_PREFIX}com/workos/models/GeneratedModelRoundTripTest.kt`;
-  const priorBlocks = scoped ? parseRoundTripMethods(readPriorFile(path, ctx)) : [];
+  let priorBlocks: AggregateBlock[] = [];
+  if (scoped) {
+    try {
+      priorBlocks = parseRoundTripMethods(readPriorFile(path, ctx));
+    } catch (err) {
+      // The prior aggregate exists but is unreadable. Emitting now would
+      // reconcile against an empty prior and silently drop every out-of-scope
+      // fixture; leave the on-disk copy untouched instead (a later run with a
+      // readable prior refreshes it).
+      console.warn(
+        `[oagen] kotlin: leaving ${path} untouched — could not read prior file: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return null;
+    }
+  }
   const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped);
   if (methods.length === 0) return null;
 

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -34,6 +34,7 @@ import {
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
+import { type AggregateBlock, readPriorFile, reconcileScopedBlocks } from '../shared/scoped-aggregate-merge.js';
 import { isHandwrittenOverride } from './overrides.js';
 
 const TEST_PREFIX = 'src/test/kotlin/';
@@ -112,17 +113,24 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     });
   }
 
-  // MINIMAL SCOPED GENERATION: BOTH whole-suite AGGREGATE files under
-  // `com/workos/models` — `GeneratedModelRoundTripTest.kt` and
-  // `GeneratedForwardCompatTest.kt` — cover every model. A scoped (`--services`)
-  // run must regenerate ONLY the selected service's files and leave every other
-  // on-disk service byte-for-byte untouched, so we skip emitting BOTH monolithic
-  // files under scoping (leaving the on-disk copies in place). Full runs (scoping
-  // inert) keep emitting them. The per-service test classes above stay scoped via
-  // `scopedMountGroups` and are unaffected.
+  // Whole-suite AGGREGATE files under `com/workos/models` pack one block per
+  // model into a single file covering EVERY model, so they can't obey per-model
+  // scoping the way a per-model source file does.
+  //
+  // `GeneratedModelRoundTripTest.kt` reconciles per-model blocks against the
+  // prior on-disk file (see generateModelRoundTripTest), so a scoped run
+  // refreshes ONLY in-scope models' fixtures and freezes the rest byte-for-byte.
+  // This is required: an in-scope model whose shape changed (e.g. a data class
+  // the spec now deduplicates into a `typealias` onto a wider model with an
+  // extra required field) would otherwise keep a stale fixture that no longer
+  // deserializes. It is emitted in every run.
+  const roundTripFile = generateModelRoundTripTest(spec, ctx);
+  if (roundTripFile) files.push(roundTripFile);
+
+  // `GeneratedForwardCompatTest.kt` tests a representative slice (a handful of
+  // enums + one model), not a per-model block set, so per-block reconciliation
+  // doesn't apply; skip it under scoping to leave the on-disk copy untouched.
   if (!isScopedRun(ctx)) {
-    const roundTripFile = generateModelRoundTripTest(spec, ctx);
-    if (roundTripFile) files.push(roundTripFile);
     const forwardCompatFile = generateForwardCompatTest(spec, ctx);
     if (forwardCompatFile) files.push(forwardCompatFile);
   }
@@ -1075,7 +1083,22 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
     const json = synthJsonForModelName(m.name, ctx, new Set());
     if (json !== null) targets.push({ model: m, json });
   }
-  if (targets.length === 0) return null;
+  // Render one block per model, tagged with in-scope so a scoped run can
+  // reconcile against the prior on-disk file: refresh in-scope models' fixtures,
+  // freeze the rest byte-for-byte. `targets` is already gated to in-scope ∪
+  // on-disk models (fileExistsAfterRun above), matching the reconciler's input
+  // contract. A full run reconciles trivially (every block is fresh).
+  const scoped = isScopedRun(ctx);
+  const newBlocks: AggregateBlock[] = targets.map(({ model, json }) => ({
+    key: className(model.name),
+    text: renderRoundTripMethod(className(model.name), json),
+    inScope: isModelInScope(model.name, ctx),
+  }));
+
+  const path = `${TEST_PREFIX}com/workos/models/GeneratedModelRoundTripTest.kt`;
+  const priorBlocks = scoped ? parseRoundTripMethods(readPriorFile(path, ctx)) : [];
+  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped);
+  if (methods.length === 0) return null;
 
   const lines: string[] = [
     'package com.workos.models',
@@ -1087,28 +1110,47 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
     'class GeneratedModelRoundTripTest {',
     '  private val mapper = ObjectMapperFactory.create()',
   ];
-
-  for (const { model, json } of targets) {
-    const cls = className(model.name);
-    lines.push('', '  @Test', `  fun \`${cls} round-trips through Jackson\`() {`);
-    emitJsonVal(lines, '    ', json);
-    lines.push(
-      `    val parsed = mapper.readValue(json, ${cls}::class.java)`,
-      '    val reserialized = mapper.writeValueAsString(parsed)',
-      '    val tree1 = mapper.readTree(json)',
-      '    val tree2 = mapper.readTree(reserialized)',
-      '    assertEquals(tree1, tree2)',
-      '  }',
-    );
-  }
-
+  for (const method of methods) lines.push('', ...method.split('\n'));
   lines.push('}', '');
 
-  return {
-    path: `${TEST_PREFIX}com/workos/models/GeneratedModelRoundTripTest.kt`,
-    content: lines.join('\n'),
-    overwriteExisting: true,
-  };
+  return { path, content: lines.join('\n'), overwriteExisting: true };
+}
+
+/** Render a single model's round-trip `@Test` method (no surrounding blanks). */
+function renderRoundTripMethod(cls: string, json: string): string {
+  const lines = ['  @Test', `  fun \`${cls} round-trips through Jackson\`() {`];
+  emitJsonVal(lines, '    ', json);
+  lines.push(
+    `    val parsed = mapper.readValue(json, ${cls}::class.java)`,
+    '    val reserialized = mapper.writeValueAsString(parsed)',
+    '    val tree1 = mapper.readTree(json)',
+    '    val tree2 = mapper.readTree(reserialized)',
+    '    assertEquals(tree1, tree2)',
+    '  }',
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Parse the per-model `@Test` methods out of a prior GeneratedModelRoundTripTest,
+ * keyed by class name, so a scoped run can freeze out-of-scope blocks verbatim.
+ * Each generated method runs from its `  @Test` line to the first `  }` at
+ * method indent (the JSON body is a string literal, so no inner 2-space `}`).
+ */
+function parseRoundTripMethods(content: string | null): AggregateBlock[] {
+  if (!content) return [];
+  const lines = content.split('\n');
+  const blocks: AggregateBlock[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== '@Test') continue;
+    const start = i;
+    const m = (lines[i + 1] ?? '').match(/^\s*fun `(.+?) round-trips through Jackson`\(\)/);
+    let end = i + 1;
+    while (end < lines.length && lines[end] !== '  }') end++;
+    if (m && end < lines.length) blocks.push({ key: m[1], text: lines.slice(start, end + 1).join('\n') });
+    i = end;
+  }
+  return blocks;
 }
 
 /**

--- a/src/shared/scoped-aggregate-merge.ts
+++ b/src/shared/scoped-aggregate-merge.ts
@@ -43,16 +43,23 @@ export interface AggregateBlock {
   inScope?: boolean;
 }
 
-/** Read the prior on-disk content of a generated file, or null when unavailable. */
+/**
+ * Read the prior on-disk content of a generated file, or `null` when the file is
+ * genuinely ABSENT (no output dir / not on disk) — the safe "no prior blocks"
+ * signal.
+ *
+ * A read error on a file that DOES exist is NOT swallowed: it throws. Treating
+ * an unreadable-but-present aggregate as empty would make the reconciler drop
+ * every out-of-scope (frozen) block and overwrite the file with only fresh
+ * in-scope blocks — silent data loss. Callers must let the throw prevent the
+ * aggregate from being emitted (leaving the on-disk copy untouched) rather than
+ * reconcile against an empty prior.
+ */
 export function readPriorFile(relPath: string, ctx: EmitterContext): string | null {
   if (!ctx.outputDir) return null;
   const abs = resolve(ctx.outputDir, relPath);
   if (!existsSync(abs)) return null;
-  try {
-    return readFileSync(abs, 'utf-8');
-  } catch {
-    return null;
-  }
+  return readFileSync(abs, 'utf-8');
 }
 
 /**

--- a/src/shared/scoped-aggregate-merge.ts
+++ b/src/shared/scoped-aggregate-merge.ts
@@ -1,0 +1,106 @@
+import type { EmitterContext } from '@workos/oagen';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Scoped-run reconciliation for whole-suite AGGREGATE test files (e.g. Kotlin's
+ * `GeneratedModelRoundTripTest.kt`) that pack one per-model block into a single
+ * file covering EVERY model.
+ *
+ * Such a file can't obey per-model scoping the way a per-model source file does:
+ * it is one file, so emitting it in a scoped run either flushes on-disk drift
+ * for out-of-scope models (noisy scoped PRs) or, if skipped wholesale, leaves an
+ * IN-SCOPE model whose shape changed with a stale block — the latter is the bug
+ * this fixes: a model regenerated this run (e.g. a data class the current spec
+ * deduplicates into a `typealias` onto a wider model with an extra required
+ * field) keeps a stale fixture that no longer deserializes.
+ *
+ * The fix mirrors {@link ../go/flat-merge.ts reconcileFlatBlocks}: reconcile the
+ * freshly generated per-model blocks against the prior on-disk file so a scoped
+ * run touches ONLY in-scope blocks:
+ *   - IN-SCOPE                     → the freshly generated block (apply new spec).
+ *   - out-of-scope, existed before → the PRIOR on-disk block, FROZEN byte-for-byte
+ *                                    (an unrelated same-delta change to it never
+ *                                    leaks into a scoped batch).
+ *   - out-of-scope, brand-new      → dropped (its per-model file isn't emitted
+ *                                    this run, so a block referencing it would
+ *                                    dangle).
+ * Prior blocks the new spec no longer produces are carried over verbatim.
+ *
+ * A full (non-scoped) run skips reconciliation and emits every fresh block.
+ */
+
+/** A single per-model block in a flat aggregate test file, keyed by a unique name. */
+export interface AggregateBlock {
+  /** Unique key for the block (e.g. the model's generated class name). */
+  key: string;
+  /** Verbatim block text (no surrounding blank lines). */
+  text: string;
+  /**
+   * Whether the block's owning model is in scope this run. Set on freshly
+   * generated blocks; omitted (treated as false) for blocks parsed from disk.
+   */
+  inScope?: boolean;
+}
+
+/** Read the prior on-disk content of a generated file, or null when unavailable. */
+export function readPriorFile(relPath: string, ctx: EmitterContext): string | null {
+  if (!ctx.outputDir) return null;
+  const abs = resolve(ctx.outputDir, relPath);
+  if (!existsSync(abs)) return null;
+  try {
+    return readFileSync(abs, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reconcile freshly generated per-model blocks against the prior on-disk blocks.
+ * Returns the ordered block texts to emit (new-spec order, then carry-overs).
+ *
+ * @param newBlocks   Blocks the current spec produced (emit order), each tagged
+ *                    with `inScope`. In a scoped run this should already be gated
+ *                    to in-scope ∪ on-disk models.
+ * @param priorBlocks Blocks parsed from the prior on-disk file (parser-specific).
+ * @param scoped      Whether a scoped (`--services`) run is active.
+ */
+export function reconcileScopedBlocks(
+  newBlocks: AggregateBlock[],
+  priorBlocks: AggregateBlock[],
+  scoped: boolean,
+): string[] {
+  // Full run: emit everything the new spec produced, unchanged.
+  if (!scoped) return newBlocks.map((b) => b.text);
+
+  const priorByKey = new Map(priorBlocks.map((b) => [b.key, b]));
+  const out: string[] = [];
+  const emitted = new Set<string>();
+
+  for (const block of newBlocks) {
+    if (block.inScope) {
+      out.push(block.text);
+      emitted.add(block.key);
+      continue;
+    }
+    // Out of scope: freeze to the prior on-disk block so an unrelated change to
+    // it in the same spec delta doesn't leak into a scoped batch. A brand-new
+    // out-of-scope block (no prior) is dropped — its per-model file isn't emitted.
+    const prior = priorByKey.get(block.key);
+    if (prior && !emitted.has(prior.key)) {
+      out.push(prior.text);
+      emitted.add(prior.key);
+    }
+  }
+
+  // Carry over prior blocks the new spec no longer produces at all (renamed /
+  // removed models whose per-model file this run left untouched on disk).
+  for (const block of priorBlocks) {
+    if (!emitted.has(block.key)) {
+      out.push(block.text);
+      emitted.add(block.key);
+    }
+  }
+
+  return out;
+}

--- a/test/kotlin/tests.test.ts
+++ b/test/kotlin/tests.test.ts
@@ -251,6 +251,32 @@ describe('kotlin/tests', () => {
     rmSync(outputDir, { recursive: true, force: true });
   });
 
+  it('scoped run: does NOT emit the round-trip test when the prior file exists but is unreadable', () => {
+    // Guard against silent data loss: if the prior aggregate can't be read, we
+    // must not overwrite it with only fresh in-scope blocks (which would drop
+    // every out-of-scope frozen fixture). Simulate "exists but unreadable" with
+    // a DIRECTORY at the file path — readFileSync throws EISDIR.
+    const outputDir = mkdtempSync(join(tmpdir(), 'oagen-rt-'));
+    const rtPath = join(outputDir, 'src/test/kotlin/com/workos/models/GeneratedModelRoundTripTest.kt');
+    mkdirSync(rtPath, { recursive: true }); // a dir where a file is expected
+
+    const scopedSpec: ApiSpec = { ...spec, models: [roundTripModel('Organization')] };
+    const scopedCtx: EmitterContext = {
+      ...ctx,
+      spec: scopedSpec,
+      outputDir,
+      resolvedOperations: buildResolvedOps(services),
+      scopedServices: new Set(['Organizations']),
+      scopedModelNames: new Set(['Organization']),
+    };
+
+    const files = generateTests(scopedSpec, scopedCtx);
+    // Left untouched on disk → not in the emitted set.
+    expect(files.some((f) => f.path.endsWith('GeneratedModelRoundTripTest.kt'))).toBe(false);
+
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
   it('emits valid ISO-8601 for date-time fields in round-trip fixtures', () => {
     const dtModels: Model[] = [
       {

--- a/test/kotlin/tests.test.ts
+++ b/test/kotlin/tests.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { generateTests } from '../../src/kotlin/tests.js';
 import { generateEnums } from '../../src/kotlin/enums.js';
 import type { EmitterContext, ApiSpec, Service, Model, ResolvedOperation } from '@workos/oagen';
@@ -142,20 +145,21 @@ describe('kotlin/tests', () => {
     expect(content).toContain('assertEquals(parsed.toInstant(), reparsed.toInstant())');
   });
 
-  it('scoped run: skips the monolithic model round-trip test entirely', () => {
-    // MINIMAL SCOPED GENERATION: a scoped (`--services`) run regenerates only
-    // the selected service's files and must leave every other on-disk service
-    // byte-for-byte untouched. The model round-trip suite is a single
-    // whole-suite AGGREGATE file covering every model, so a scoped run must
-    // NOT emit it (the on-disk copy is left in place). Per-service test
-    // classes remain scoped via `scopedMountGroups` and are still emitted.
-    const roundTripModel = (name: string): Model => ({
-      name,
-      fields: [
-        { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
-        { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
-      ],
-    });
+  const roundTripModel = (name: string): Model => ({
+    name,
+    fields: [
+      { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+      { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+    ],
+  });
+
+  it('scoped run: emits the round-trip test with only in-scope fixtures when there is no prior file', () => {
+    // The round-trip suite is a single whole-suite AGGREGATE file, but it is
+    // reconciled PER MODEL in a scoped run so an in-scope model whose shape
+    // changed still gets a refreshed fixture (the bug: skipping it wholesale
+    // left in-scope fixtures stale). With no prior file to freeze from, an
+    // out-of-scope model is dropped rather than emitted with a fresh block whose
+    // per-model .kt this run does not write.
     const scopedModels: Model[] = [
       roundTripModel('Organization'), // in scope
       roundTripModel('Directory'), // out of scope but ON disk
@@ -173,14 +177,78 @@ describe('kotlin/tests', () => {
     generateEnums([], scopedCtx);
     const files = generateTests(scopedSpec, scopedCtx);
 
-    // BOTH whole-suite aggregates under com/workos/models are absent in a scoped
-    // run (they cover every model; regenerating either would rewrite a shared
-    // file outside the selected service).
-    expect(files.some((f) => f.path.endsWith('GeneratedModelRoundTripTest.kt'))).toBe(false);
-    expect(files.some((f) => f.path.endsWith('GeneratedForwardCompatTest.kt'))).toBe(false);
+    const roundTrip = files.find((f) => f.path.endsWith('GeneratedModelRoundTripTest.kt'));
+    expect(roundTrip).toBeDefined();
+    expect(roundTrip!.content).toContain('Organization round-trips through Jackson');
+    // Out of scope + no prior on disk → dropped (no fresh block for an unemitted file).
+    expect(roundTrip!.content).not.toContain('Directory round-trips through Jackson');
 
-    // The scoped per-service test class is still emitted.
+    // Forward-compat is a representative slice (not a per-model block set), so it
+    // stays skipped under scoping; the per-service class stays scoped and emitted.
+    expect(files.some((f) => f.path.endsWith('GeneratedForwardCompatTest.kt'))).toBe(false);
     expect(files.some((f) => f.path.includes('OrganizationsTest.kt'))).toBe(true);
+  });
+
+  it('scoped run: refreshes in-scope fixture but freezes out-of-scope one to its prior on-disk block', () => {
+    // Write a prior round-trip file: Directory (out of scope) carries an EXTRA
+    // field in its fixture that the current spec's model lacks. The scoped run
+    // must keep Directory's block byte-for-byte (freeze) while refreshing
+    // Organization from the current spec.
+    const outputDir = mkdtempSync(join(tmpdir(), 'oagen-rt-'));
+    const rtPath = join(outputDir, 'src/test/kotlin/com/workos/models/GeneratedModelRoundTripTest.kt');
+    mkdirSync(dirname(rtPath), { recursive: true });
+    const priorDirectoryMethod = [
+      '  @Test',
+      '  fun `Directory round-trips through Jackson`() {',
+      '    val json = "{\\"id\\": \\"sample\\", \\"name\\": \\"sample\\", \\"legacy\\": \\"kept\\"}"',
+      '    val parsed = mapper.readValue(json, Directory::class.java)',
+      '    val reserialized = mapper.writeValueAsString(parsed)',
+      '    val tree1 = mapper.readTree(json)',
+      '    val tree2 = mapper.readTree(reserialized)',
+      '    assertEquals(tree1, tree2)',
+      '  }',
+    ].join('\n');
+    writeFileSync(
+      rtPath,
+      [
+        'package com.workos.models',
+        '',
+        'import com.workos.common.json.ObjectMapperFactory',
+        'import org.junit.jupiter.api.Assertions.assertEquals',
+        'import org.junit.jupiter.api.Test',
+        '',
+        'class GeneratedModelRoundTripTest {',
+        '  private val mapper = ObjectMapperFactory.create()',
+        '',
+        priorDirectoryMethod,
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    const scopedModels: Model[] = [roundTripModel('Organization'), roundTripModel('Directory')];
+    const scopedSpec: ApiSpec = { ...spec, models: scopedModels };
+    const scopedCtx: EmitterContext = {
+      ...ctx,
+      spec: scopedSpec,
+      outputDir,
+      resolvedOperations: buildResolvedOps(services),
+      scopedServices: new Set(['Organizations']),
+      scopedModelNames: new Set(['Organization']),
+      priorTargetManifestPaths: new Set(['src/main/kotlin/com/workos/models/Directory.kt']),
+    };
+
+    const roundTrip = generateTests(scopedSpec, scopedCtx).find((f) =>
+      f.path.endsWith('GeneratedModelRoundTripTest.kt'),
+    )!;
+    expect(roundTrip).toBeDefined();
+    // In-scope: refreshed from the current spec.
+    expect(roundTrip.content).toContain('Organization round-trips through Jackson');
+    // Out-of-scope: frozen to the prior block verbatim (extra "legacy" field kept).
+    expect(roundTrip.content).toContain('Directory round-trips through Jackson');
+    expect(roundTrip.content).toContain('\\"legacy\\": \\"kept\\"');
+
+    rmSync(outputDir, { recursive: true, force: true });
   });
 
   it('emits valid ISO-8601 for date-time fields in round-trip fixtures', () => {

--- a/test/shared/scoped-aggregate-merge.test.ts
+++ b/test/shared/scoped-aggregate-merge.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { reconcileScopedBlocks, type AggregateBlock } from '../../src/shared/scoped-aggregate-merge.js';
+
+const fresh = (key: string, inScope: boolean): AggregateBlock => ({ key, text: `${key}:fresh`, inScope });
+const prior = (key: string): AggregateBlock => ({ key, text: `${key}:prior` });
+
+describe('reconcileScopedBlocks', () => {
+  it('full run emits every fresh block unchanged', () => {
+    const out = reconcileScopedBlocks([fresh('A', false), fresh('B', false)], [prior('A')], false);
+    expect(out).toEqual(['A:fresh', 'B:fresh']);
+  });
+
+  it('scoped: refreshes in-scope blocks with fresh text', () => {
+    const out = reconcileScopedBlocks([fresh('A', true)], [prior('A')], true);
+    // A changed shape this run → its fixture must be the freshly generated one.
+    expect(out).toEqual(['A:fresh']);
+  });
+
+  it('scoped: freezes an out-of-scope block to its prior on-disk text', () => {
+    // B is out of scope; even though the new spec produced a fresh block for it,
+    // an unrelated same-delta change must NOT leak into a scoped batch.
+    const out = reconcileScopedBlocks([fresh('A', true), fresh('B', false)], [prior('A'), prior('B')], true);
+    expect(out).toEqual(['A:fresh', 'B:prior']);
+  });
+
+  it('scoped: drops a brand-new out-of-scope block (no prior → its file is not emitted)', () => {
+    const out = reconcileScopedBlocks([fresh('A', true), fresh('B', false)], [prior('A')], true);
+    expect(out).toEqual(['A:fresh']);
+  });
+
+  it('scoped: carries over prior blocks the new spec no longer produces', () => {
+    // C was renamed/removed from the spec but its file lingers on disk and may
+    // still be referenced by un-regenerated out-of-scope code.
+    const out = reconcileScopedBlocks([fresh('A', true)], [prior('A'), prior('C')], true);
+    expect(out).toEqual(['A:fresh', 'C:prior']);
+  });
+
+  it('scoped: preserves new-spec order, then appends carry-overs', () => {
+    const out = reconcileScopedBlocks(
+      [fresh('A', true), fresh('B', false)],
+      [prior('B'), prior('A'), prior('Z')],
+      true,
+    );
+    expect(out).toEqual(['A:fresh', 'B:prior', 'Z:prior']);
+  });
+});


### PR DESCRIPTION
## Problem

A scoped (`--services`) run regenerates a selected model's per-model file but previously **skipped** the whole-suite `GeneratedModelRoundTripTest.kt` wholesale (to avoid flushing out-of-scope drift). That left an **in-scope** model whose shape changed with a **stale fixture**: when the current spec deduplicates a model into `typealias X = Wider` and `Wider` carries an extra required non-null field, the untouched fixture omits it and Jackson throws `KotlinInvalidNullException` at deserialize.

Observed in the openapi-spec batch generating `workos-kotlin`: `PermissionCreatedData` / `DeletedData` / `UpdatedData` now alias `Permission` (required `resource_type_slug`), but their round-trip fixtures were left stale — 3 failing tests.

## Fix

Emit the round-trip test in **every** run and reconcile it **per model** against the prior on-disk file, mirroring `go/flat-merge.ts`:

- **in-scope** → fresh fixture (apply the new spec)
- **out-of-scope, on disk** → frozen to the prior block byte-for-byte (no drift leaks into a scoped batch)
- **brand-new out-of-scope** → dropped (its per-model `.kt` isn't emitted this run)
- **removed from spec** → carried over

The reconciler lives in `shared/scoped-aggregate-merge.ts` (`reconcileScopedBlocks` + `readPriorFile`). `GeneratedForwardCompatTest` (a representative slice, not a per-model block set) still skips under scoping.

Kotlin was the **only** emitter with this gap — Python/Ruby already split the monolith into per-service-dir files (+ legacy-monolith retirement), and Rust/PHP regenerate each model's source and JSON fixture in lockstep. Verified by reproducing a scoped regen for all five languages. The shared helper is available if a future flat-layout emitter needs it.

## Verification

- `tsc`, `oxlint`, `oxfmt` clean; full emitter suite **661 pass** + 15 new (pure reconciler + Kotlin freeze/drop/refresh)
- End-to-end: with this emitter, a scoped regen of `workos-kotlin` using the failing batch's service list refreshes the three `Permission` fixtures, and **`gradle test --tests GeneratedModelRoundTripTest` → BUILD SUCCESSFUL**

## Consumption

Needs an `oagen-emitters` release → `openapi-spec` emitter-dep bump → regenerate to green the batch (same flow as the recent `serviceAliases` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)