### PR TITLE
feat(python,ruby): per-call client_id override on generated URL builders

### DIFF
--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -33,6 +33,7 @@ import {
   scopedMountGroups,
   getOpDefaults,
   getOpInferFromClient,
+  getUrlBuilderClientOverrides,
   buildHiddenParams as buildHiddenParamsShared,
   collectGroupedParamNames,
   collectBodyFieldTypes,
@@ -200,6 +201,8 @@ function emitMethodSignature(
   resolvedOp?: ResolvedOperation,
 ): SignatureMetadata {
   const hiddenParams = buildHiddenParams(resolvedOp);
+  const clientOverrides = getUrlBuilderClientOverrides(op, resolvedOp);
+  for (const field of clientOverrides) hiddenParams.delete(field);
   const isPaginated = plan.isPaginated;
   const isDelete = plan.isDelete;
   // Redirect endpoints never await, so emit as plain def even in async class
@@ -288,7 +291,9 @@ function emitMethodSignature(
         if (bodyModel?.fields.some((f) => bodyParamName(f, pathParamNames) === paramName)) continue;
       }
       const paramType = mapTypeRefUnquoted(param.type, specEnumNames, true);
-      if (usesClientCredentialDefaults && (param.name === 'client_id' || param.name === 'client_secret')) {
+      if (clientOverrides.has(param.name)) {
+        lines.push(`        ${paramName}: Optional[${paramType}] = None,`);
+      } else if (usesClientCredentialDefaults && (param.name === 'client_id' || param.name === 'client_secret')) {
         lines.push(`        ${paramName}: Optional[${paramType}] = None,`);
       } else if (param.required) {
         lines.push(`        ${paramName}: ${paramType},`);
@@ -413,6 +418,8 @@ function emitMethodDocstring(
   const { returnType, pathParamNames, hasBearerOverride } = meta;
   const isPaginated = plan.isPaginated;
   const hiddenParams = buildHiddenParams(resolvedOp);
+  const clientOverrides = getUrlBuilderClientOverrides(op, resolvedOp);
+  for (const field of clientOverrides) hiddenParams.delete(field);
 
   // Description — indent continuation lines to align with the opening `"""`
   if (op.description) {
@@ -478,6 +485,10 @@ function emitMethodDocstring(
       if (param.default != null) {
         const defaultStr = `Defaults to \`${param.default}\`.`;
         desc = desc ? `${desc} ${defaultStr}` : defaultStr;
+      }
+      if (clientOverrides.has(param.name)) {
+        const fallbackStr = `Defaults to the client's configured ${param.name}.`;
+        desc = desc ? `${desc} ${fallbackStr}` : fallbackStr;
       }
       allParams.push({ name: pn, desc });
     }
@@ -583,6 +594,8 @@ function emitMethodBody(
   const awaitPrefix = isAsync ? 'await ' : '';
   const usesClientCredentialDefaults = false;
   const hiddenParams = buildHiddenParams(resolvedOp);
+  const clientOverrides = getUrlBuilderClientOverrides(op, resolvedOp);
+  for (const field of clientOverrides) hiddenParams.delete(field);
   const opDefaults = getOpDefaults(resolvedOp);
   const opInferFromClient = getOpInferFromClient(resolvedOp);
 
@@ -642,11 +655,17 @@ function emitMethodBody(
           lines.push(`        params["${key}"] = ${pythonLiteral(value)}`);
         }
       }
-      // Inject fields from client config
+      // Inject fields from client config. Fields surfaced as optional
+      // override parameters (url-builder ops) are already in params when the
+      // caller passed them explicitly — only fill from config when absent.
       if (opInferFromClient.length > 0) {
         for (const field of opInferFromClient) {
           const expr = clientFieldExpression(field);
-          lines.push(`        if ${expr} is not None:`);
+          if (clientOverrides.has(field)) {
+            lines.push(`        if "${field}" not in params and ${expr} is not None:`);
+          } else {
+            lines.push(`        if ${expr} is not None:`);
+          }
           lines.push(`            params["${field}"] = ${expr}`);
         }
       }
@@ -916,11 +935,17 @@ function emitMethodBody(
           lines.push(`        params["${key}"] = ${pythonLiteral(value)}`);
         }
       }
-      // Inject fields from client config
+      // Inject fields from client config. Fields surfaced as optional
+      // override parameters (url-builder ops) are already in params when the
+      // caller passed them explicitly — only fill from config when absent.
       if (opInferFromClient.length > 0) {
         for (const field of opInferFromClient) {
           const expr = clientFieldExpression(field);
-          lines.push(`        if ${expr} is not None:`);
+          if (clientOverrides.has(field)) {
+            lines.push(`        if "${field}" not in params and ${expr} is not None:`);
+          } else {
+            lines.push(`        if ${expr} is not None:`);
+          }
           lines.push(`            params["${field}"] = ${expr}`);
         }
       }

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -20,6 +20,7 @@ import {
   isModelInScope,
   lookupResolved,
   buildHiddenParams,
+  getUrlBuilderClientOverrides,
   collectGroupedParamNames,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
@@ -185,7 +186,52 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
 
       const resolved = lookupResolved(op, lookup);
       if (resolved?.urlBuilder) {
+        // Url-builder methods construct the URL client-side (no HTTP) and
+        // return it as a String. inferFromClient query params surface as
+        // nilable overrides of the client's configured value. Mirrors
+        // emitUrlBuilderMethod in ruby/resources.ts.
         emittedMethods.add(method);
+        const hidden = buildHiddenParams(resolved);
+        const overrides = getUrlBuilderClientOverrides(op, resolved);
+        for (const field of overrides) hidden.delete(field);
+        const visibleQuery = (op.queryParams ?? []).filter((q) => !hidden.has(q.name));
+        const sigParams: string[] = [];
+        const seen = new Set<string>();
+        for (const p of op.pathParams ?? []) {
+          const n = safeParamName(p.name);
+          if (seen.has(n)) continue;
+          seen.add(n);
+          sigParams.push(`${n}: ${mapSorbetType(p.type)}`);
+        }
+        for (const q of visibleQuery) {
+          if (!q.required || overrides.has(q.name)) continue;
+          const n = safeParamName(q.name);
+          if (seen.has(n)) continue;
+          seen.add(n);
+          sigParams.push(`${n}: ${mapSorbetType(q.type)}`);
+        }
+        for (const q of visibleQuery) {
+          if (q.required && !overrides.has(q.name)) continue;
+          const n = safeParamName(q.name);
+          if (seen.has(n)) continue;
+          seen.add(n);
+          sigParams.push(`${n}: ${wrapNilable(mapSorbetType(q.type))}`);
+        }
+        if (sigParams.length === 0) {
+          lines.push('    sig { returns(String) }');
+          lines.push(`    def ${method}; end`);
+        } else {
+          lines.push('    sig do');
+          lines.push('      params(');
+          for (let i = 0; i < sigParams.length; i++) {
+            const sep = i === sigParams.length - 1 ? '' : ',';
+            lines.push(`        ${sigParams[i]}${sep}`);
+          }
+          lines.push('      ).returns(String)');
+          lines.push('    end');
+          lines.push(`    def ${method}(${sigParams.map((p) => p.split(':')[0].trim() + ':').join(', ')}); end`);
+        }
+        lines.push('');
         continue;
       }
       emittedMethods.add(method);

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -18,6 +18,7 @@ import {
   scopedMountGroups,
   getOpDefaults,
   getOpInferFromClient,
+  getUrlBuilderClientOverrides,
   buildHiddenParams,
   collectGroupedParamNames,
 } from '../shared/resolved-ops.js';
@@ -79,13 +80,22 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
       if (emittedMethodNames.has(method)) continue;
 
       const resolved = lookupResolved(op, lookup);
-      // Skip url-builder operations: these are spec-marked client-side URL
-      // constructors (no HTTP), and the Ruby SDK provides them via
-      // hand-maintained inline @oagen-ignore extensions on the relevant
-      // service class instead of generating an HTTP wrapper that would
-      // incorrectly hit the API.
+      // Url-builder operations are spec-marked client-side URL constructors
+      // (no HTTP): emit a method that assembles the URL locally instead of an
+      // HTTP wrapper that would incorrectly hit the API.
       if (resolved?.urlBuilder) {
         emittedMethodNames.add(method);
+        requires.add('uri');
+        methodBodies.push(
+          emitUrlBuilderMethod({
+            op,
+            method,
+            defaults: getOpDefaults(resolved),
+            inferFromClient: getOpInferFromClient(resolved),
+            clientOverrides: getUrlBuilderClientOverrides(op, resolved),
+            hiddenParams: buildHiddenParams(resolved),
+          }),
+        );
         continue;
       }
 
@@ -137,6 +147,7 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
     // Zeitwerk autoloads every WorkOS::* constant; only stdlib requires.
     if (requires.has('json')) {
       lines.push(`require 'json'`);
+      if (requires.has('uri')) lines.push(`require 'uri'`);
       lines.push('');
     }
     lines.push('module WorkOS');
@@ -172,6 +183,152 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
   }
 
   return files;
+}
+
+/**
+ * Build a Ruby method for a url-builder operation: assembles the URL
+ * client-side from the configured base URL, makes no HTTP request.
+ *
+ * inferFromClient query params (e.g. `client_id` on an OAuth authorize URL)
+ * surface as optional keyword args that override the client's configured
+ * value — a multi-tenant caller builds URLs for several applications from
+ * one configured client. See getUrlBuilderClientOverrides.
+ */
+function emitUrlBuilderMethod(args: {
+  op: Operation;
+  method: string;
+  defaults: Record<string, string | number | boolean>;
+  inferFromClient: string[];
+  clientOverrides: Set<string>;
+  hiddenParams: Set<string>;
+}): string {
+  const { op, method, defaults, inferFromClient, clientOverrides, hiddenParams } = args;
+  for (const field of clientOverrides) hiddenParams.delete(field);
+
+  const pathParams = op.pathParams ?? [];
+  const queryParams = (op.queryParams ?? []).filter((q) => !hiddenParams.has(q.name));
+  const isOverride = (q: Parameter): boolean => clientOverrides.has(q.name);
+  const isRequiredKwarg = (q: Parameter): boolean => Boolean(q.required) && !isOverride(q);
+
+  const lines: string[] = [];
+
+  // YARD docs.
+  const summary = op.description ?? `${op.httpMethod.toUpperCase()} ${op.path}`;
+  lines.push(`    # ${summary.split('\n')[0] ?? ''}`);
+  lines.push('    # Builds the URL client-side; no HTTP request is made.');
+  if (op.deprecated) lines.push('    # @deprecated');
+  for (const p of pathParams) {
+    const n = safeParamName(p.name);
+    lines.push(`    # @param ${n} [${mapTypeRefForYard(p.type)}] ${oneLine(p.description)}`.trimEnd());
+  }
+  for (const q of queryParams) {
+    const n = safeParamName(q.name);
+    const type = mapTypeRefForYard(q.type);
+    const alreadyNilable = type.split(', ').includes('nil');
+    const suffix = isRequiredKwarg(q) || alreadyNilable ? '' : ', nil';
+    const overrideNote = isOverride(q) ? ` Defaults to the client's configured ${fieldName(q.name)}.` : '';
+    lines.push(`    # @param ${n} [${type}${suffix}] ${oneLine(q.description)}${overrideNote}`.trimEnd());
+  }
+  lines.push('    # @return [String]');
+
+  // Signature: required kwargs first, then optional (overrides default to nil).
+  const sigParts: string[] = [];
+  const seenParamNames = new Set<string>();
+  for (const p of pathParams) {
+    const n = safeParamName(p.name);
+    if (seenParamNames.has(n)) continue;
+    seenParamNames.add(n);
+    sigParts.push(`${n}:`);
+  }
+  for (const q of queryParams) {
+    if (!isRequiredKwarg(q)) continue;
+    const n = safeParamName(q.name);
+    if (seenParamNames.has(n)) continue;
+    seenParamNames.add(n);
+    sigParts.push(`${n}:`);
+  }
+  for (const q of queryParams) {
+    if (isRequiredKwarg(q)) continue;
+    const n = safeParamName(q.name);
+    if (seenParamNames.has(n)) continue;
+    seenParamNames.add(n);
+    // Unlike HTTP methods, spec defaults are not surfaced here: a URL builder
+    // must only emit query params the caller actually chose (e.g. screen_hint
+    // is only valid for the authkit provider), letting the server apply its
+    // own defaults. Matches the Python emitter's url-builder behavior.
+    sigParts.push(`${n}: nil`);
+  }
+
+  if (sigParts.length === 0) {
+    lines.push(`    def ${method}`);
+  } else if (sigParts.length === 1 && sigParts[0].length < 60) {
+    lines.push(`    def ${method}(${sigParts[0]})`);
+  } else {
+    lines.push(`    def ${method}(`);
+    for (let i = 0; i < sigParts.length; i++) {
+      const sep = i === sigParts.length - 1 ? '' : ',';
+      lines.push(`      ${sigParts[i]}${sep}`);
+    }
+    lines.push('    )');
+  }
+
+  if (op.deprecated) {
+    lines.push(`      warn "[DEPRECATION] \\\`${method}\\\` is deprecated.", uplevel: 1`);
+  }
+
+  // Query hash from visible params; `.compact` drops omitted optionals.
+  const queryHasNilable = queryParams.some((q) => !isRequiredKwarg(q));
+  if (queryParams.length > 0) {
+    lines.push('      params = {');
+    for (let i = 0; i < queryParams.length; i++) {
+      const q = queryParams[i];
+      const sep = i === queryParams.length - 1 ? '' : ',';
+      lines.push(`        ${rubyStringLit(q.name)} => ${safeParamName(q.name)}${sep}`);
+    }
+    lines.push(`      }${queryHasNilable ? '.compact' : ''}`);
+    // URI.encode_www_form can't serialize structured values the way the API
+    // expects: explode=false arrays are comma-joined (matching the Python
+    // emitter's serializeParameterValue) and map params are JSON-encoded
+    // (URI.encode_www_form would emit the Ruby Hash#to_s repr otherwise).
+    for (const q of queryParams) {
+      const t = q.type.kind === 'nullable' ? q.type.inner : q.type;
+      const n = safeParamName(q.name);
+      const explode = (q as Parameter & { explode?: boolean }).explode;
+      if (t.kind === 'array' && explode === false) {
+        lines.push(`      params[${rubyStringLit(q.name)}] = ${n}.join(",") unless ${n}.nil?`);
+      } else if (t.kind === 'map') {
+        lines.push(`      params[${rubyStringLit(q.name)}] = JSON.generate(${n}) unless ${n}.nil?`);
+      }
+    }
+  } else {
+    lines.push('      params = {}');
+  }
+
+  // Constant defaults (e.g. response_type=code).
+  for (const [k, v] of Object.entries(defaults)) {
+    lines.push(`      params[${rubyStringLit(k)}] = ${rubyDefaultLiteral(v)}`);
+  }
+
+  // Fields inferred from client config. Override params are already in the
+  // hash when the caller passed them explicitly — only fill when absent.
+  for (const fc of inferFromClient) {
+    const clientProp = fc === 'client_secret' ? 'api_key' : fc;
+    if (clientOverrides.has(fc)) {
+      lines.push(
+        `      params[${rubyStringLit(fc)}] = @client.${clientProp} if !params.key?(${rubyStringLit(fc)}) && !@client.${clientProp}.nil?`,
+      );
+    } else {
+      lines.push(`      params[${rubyStringLit(fc)}] = @client.${clientProp} unless @client.${clientProp}.nil?`);
+    }
+  }
+
+  const rubyPath = interpolateRubyPath(op.path, pathParams);
+  lines.push(`      uri = URI.join(@client.base_url, ${rubyPath})`);
+  lines.push('      uri.query = URI.encode_www_form(params) unless params.empty?');
+  lines.push('      uri.to_s');
+  lines.push('    end');
+
+  return lines.join('\n');
 }
 
 /** Build a single Ruby method from an Operation. */

--- a/src/shared/resolved-ops.ts
+++ b/src/shared/resolved-ops.ts
@@ -243,6 +243,24 @@ export function hasHiddenParams(resolvedOp?: ResolvedOperation): boolean {
   return Object.keys(getOpDefaults(resolvedOp)).length > 0 || getOpInferFromClient(resolvedOp).length > 0;
 }
 
+/**
+ * For url-builder operations (client-side URL construction, no HTTP), the
+ * endpoint's client-config-bound query params (e.g. `client_id` on an OAuth
+ * authorize URL) must remain settable per call — a multi-tenant caller builds
+ * URLs for several applications from one configured client. Instead of hiding
+ * these inferFromClient params entirely, emitters surface them as optional
+ * override parameters that fall back to the client's configured value.
+ * Returns the set of query param names to surface this way.
+ */
+export function getUrlBuilderClientOverrides(op: Operation, resolvedOp?: ResolvedOperation): Set<string> {
+  const overrides = new Set<string>();
+  if (!resolvedOp?.urlBuilder) return overrides;
+  for (const field of getOpInferFromClient(resolvedOp)) {
+    if (op.queryParams.some((q) => q.name === field)) overrides.add(field);
+  }
+  return overrides;
+}
+
 // ---------------------------------------------------------------------------
 // Parameter group helpers
 // ---------------------------------------------------------------------------

--- a/test/python/resources.test.ts
+++ b/test/python/resources.test.ts
@@ -1078,4 +1078,68 @@ describe('generateResources', () => {
     // The old identity guard would leave NotGiven in the union → not iterable.
     expect(content).not.toContain('if redirect_uris is not NOT_GIVEN:');
   });
+
+  it('surfaces inferFromClient query params as optional overrides on url-builder ops', () => {
+    const services: Service[] = [
+      {
+        name: 'UserManagement',
+        operations: [
+          {
+            name: 'getAuthorizationUrl',
+            httpMethod: 'get',
+            path: '/user_management/authorize',
+            pathParams: [],
+            queryParams: [
+              {
+                name: 'client_id',
+                type: { kind: 'primitive', type: 'string' },
+                required: true,
+                description: 'The unique identifier of the WorkOS environment client.',
+              },
+              { name: 'redirect_uri', type: { kind: 'primitive', type: 'string' }, required: true },
+              { name: 'state', type: { kind: 'primitive', type: 'string' }, required: false },
+            ],
+            headerParams: [],
+            response: { kind: 'primitive', type: 'unknown' },
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services },
+      resolvedOperations: [
+        {
+          operation: services[0].operations[0],
+          service: services[0],
+          methodName: 'get_authorization_url',
+          mountOn: 'UserManagement',
+          defaults: { response_type: 'code' },
+          inferFromClient: ['client_id'],
+          urlBuilder: true,
+        },
+      ] as any,
+    };
+
+    const files = generateResources(services, ctxWithServices);
+    const content = files[0].content;
+
+    // client_id surfaces as an optional keyword argument, not a required one
+    expect(content).toContain('def get_authorization_url(');
+    expect(content).toContain('client_id: Optional[str] = None,');
+    // Explicit argument lands in params (None is filtered by the comprehension)
+    expect(content).toContain('"client_id": client_id,');
+    // Constant defaults still injected
+    expect(content).toContain('params["response_type"] = "code"');
+    // Client config only fills client_id when the caller did not pass one
+    expect(content).toContain('if "client_id" not in params and self._client.client_id is not None:');
+    // Docstring documents the fallback
+    expect(content).toContain("Defaults to the client's configured client_id.");
+    // Still a client-side URL builder, no HTTP request
+    expect(content).toContain('return self._client.build_url(');
+    expect(content).not.toContain('self._client.request(');
+  });
 });

--- a/test/ruby/resources.test.ts
+++ b/test/ruby/resources.test.ts
@@ -488,4 +488,60 @@ describe('ruby/resources', () => {
     expect(content).toContain('name:');
     expect(content).not.toContain('body_name');
   });
+
+  it('emits url-builder methods with inferFromClient params as optional overrides', () => {
+    const op = makeOp({
+      name: 'getAuthorizationUrl',
+      httpMethod: 'get',
+      path: '/user_management/authorize',
+      queryParams: [
+        {
+          name: 'client_id',
+          type: { kind: 'primitive', type: 'string' },
+          required: true,
+          description: 'The unique identifier of the WorkOS environment client.',
+        },
+        { name: 'redirect_uri', type: { kind: 'primitive', type: 'string' }, required: true },
+        { name: 'state', type: { kind: 'primitive', type: 'string' }, required: false },
+      ],
+      response: { kind: 'primitive', type: 'unknown' },
+    });
+    const services: Service[] = [{ name: 'UserManagement', operations: [op] }];
+    const spec = makeSpec(services);
+    const ctx = makeCtx(spec);
+    ctx.resolvedOperations = [
+      {
+        operation: op,
+        service: services[0],
+        methodName: 'get_authorization_url',
+        mountOn: 'UserManagement',
+        defaults: { response_type: 'code' },
+        inferFromClient: ['client_id'],
+        urlBuilder: true,
+      } as ResolvedOperation,
+    ];
+
+    const files = generateResources(services, ctx);
+    const content = files[0].content;
+
+    // Emits a method (no longer skipped) that builds the URL client-side
+    expect(content).toContain('def get_authorization_url(');
+    expect(content).toContain("uri = URI.join(@client.base_url, '/user_management/authorize')");
+    expect(content).toContain('uri.query = URI.encode_www_form(params) unless params.empty?');
+    expect(content).toContain("require 'uri'");
+    // No HTTP request
+    expect(content).not.toContain('@client.request(');
+    // client_id surfaces as an optional override, not a required kwarg
+    expect(content).toContain('client_id: nil');
+    expect(content).toContain('redirect_uri:,');
+    // Constant defaults injected
+    expect(content).toContain("params['response_type'] = 'code'");
+    // Client config only fills client_id when the caller did not pass one
+    expect(content).toContain(
+      "params['client_id'] = @client.client_id if !params.key?('client_id') && !@client.client_id.nil?",
+    );
+    // YARD documents the fallback and String return
+    expect(content).toContain("Defaults to the client's configured client_id.");
+    expect(content).toContain('# @return [String]');
+  });
 });


### PR DESCRIPTION
## Summary

- URL-builder operations (OAuth authorize, logout) previously hid `inferFromClient` query params entirely, hard-wiring URLs to the client's configured `client_id`. Multi-tenant callers building URLs for several applications from one configured client had no way to override it per call, even though the docs treat `client_id` as a required per-request parameter of the authorize endpoint (workos/workos-python#700).
- **shared**: new `getUrlBuilderClientOverrides()` in `resolved-ops.ts` surfaces `inferFromClient` query params on `urlBuilder` ops as optional override parameters.
- **python**: generated `get_authorization_url` gains an optional `client_id` parameter; the client config only fills the param when the caller did not pass one.
- **ruby**: `urlBuilder` ops are now generated (previously skipped in favor of hand-maintained fence copies), with the same override semantics, RBI sigs, `explode=false` array CSV-joining, and JSON-encoded map params.
