### PR TITLE
feat(android): add Android emitter (kotlinx.serialization + OkHttp, suspend API)

### DIFF
--- a/docs/lang-gen/workspace.md
+++ b/docs/lang-gen/workspace.md
@@ -34,19 +34,24 @@ does not exist, say which one is missing and how to point at it
 | Emitter source        | `src/{lang}/`                           | The only place to fix generated-output defects.                                                                                                                                                              |
 | Emitter tests         | `test/{lang}/`                          | vitest unit tests, including the `non-spec.test.ts` coverage pins.                                                                                                                                           |
 
-Emitters currently in `src/`: `dotnet`, `elixir`, `go`, `ios`, `kotlin`, `node`,
-`php`, `python`, `ruby`, `rust`. Confirm with `ls src` rather than trusting this
-list — and note that `compat`, `shared`, and `snippets` are also directories under
-`src/` but are not emitters. There is no `android` emitter; if someone asks for one
-by name, say so instead of generating something.
+Emitters currently in `src/`: `android`, `dotnet`, `elixir`, `go`, `ios`, `kotlin`,
+`node`, `php`, `python`, `ruby`, `rust`. Confirm with `ls src` rather than trusting
+this list — and note that `compat`, `shared`, and `snippets` are also directories
+under `src/` but are not emitters.
+
+`android` and `kotlin` are both Kotlin emitters and are **not** interchangeable.
+`kotlin` targets the JVM and uses Jackson; `android` uses kotlinx.serialization
+(compile-time serializers, no reflection, no R8 keep rules) and emits `suspend`
+methods. Pick by target runtime, not by language name.
 
 `{lang}` is the **emitter identifier**, not the language name — `dotnet` emits C#
 into `workos-dotnet`, `ios` emits Swift, `node` emits TypeScript.
 
 ### When `docs/sdk-architecture/{lang}.md` is missing
 
-The design docs cover a subset of emitters (currently `dotnet`, `elixir`, `go`,
-`ios`, `node`, `php`, `python`, `rust`; `kotlin` and `ruby` have none). A missing
+The design docs cover a subset of emitters (currently `android`, `dotnet`,
+`elixir`, `go`, `ios`, `node`, `php`, `python`, `rust`; `kotlin` and `ruby` have
+none). A missing
 doc is not a reason to stop, and it is not a licence to guess — derive the same
 facts from code and say that you did:
 
@@ -137,11 +142,14 @@ Notes:
 - `scripts/sdk-generate.sh` accepts only `--lang`, `--output`, `--namespace`,
   `--services`. It hard-errors on anything else, including `--target`.
 - It defaults `--namespace` to `WorkOS` for `php`, `ios`, and `android`, and
-  `workos` elsewhere. Do not override unless the language design doc says to. Two
-  quirks in that branch, both in the spec repo and out of scope here: the `android`
-  case is dead (no such emitter), and `kotlin` is _not_ in the cased list even
-  though the script's own comment says a Kotlin client class needs the cased form —
-  so a kotlin run gets `workos`. If kotlin output looks wrong, check that first.
+  `workos` elsewhere. Do not override unless the language design doc says to.
+  `android` genuinely needs the cased form: the namespace becomes the client type
+  prefix, so `workos` yields `WorkosClient` accessors that do not match the
+  hand-maintained `WorkOSClient` and the SDK will not compile. One quirk remains in
+  that branch, in the spec repo and out of scope here: `kotlin` is _not_ in the
+  cased list even though the script's own comment says a Kotlin client class needs
+  the cased form — so a kotlin run gets `workos`. If kotlin output looks wrong,
+  check that first.
 - The old `npm run sdk:generate:{lang}` scripts and the `--output` staging +
   `--target` live split are **gone**. If you need staging separate from the live
   repo, skip the wrapper and call the CLI directly:

--- a/docs/sdk-architecture/android.md
+++ b/docs/sdk-architecture/android.md
@@ -1,7 +1,7 @@
 # Android / Kotlin SDK Architecture
 
 Design document for the `android` oagen emitter, which generates an idiomatic
-**Kotlin** SDK packaged as an **Android library** from the language-agnostic IR.
+**Kotlin** SDK for **Android consumers** from the language-agnostic IR.
 
 > **Emitter identifier:** `android`. Target language: Kotlin (Android). Emitter
 > source lives in `src/android/`; unit tests in `test/android/`; smoke runner at
@@ -10,12 +10,43 @@ Design document for the `android` oagen emitter, which generates an idiomatic
 This is a **Scenario B (fresh)** emitter: there is no existing published Android
 SDK to preserve. The emitter generates only the **spec-driven surface** — models,
 enums, resources, the client's resource-accessor file, and the per-mount test
-suites. Everything spec-independent (the HTTP runtime: `Configuration`,
-`Transport`, errors, pagination, JSON body building; the test support:
-`MockWebServer` wiring and `testClient`; and the repo resources:
-`build.gradle.kts`, `settings.gradle.kts`, `AndroidManifest.xml`,
-`.editorconfig`, `proguard-rules.pro`) is **hand-maintained in the SDK repo**,
-marked with `// @oagen-ignore-file` so generation never overwrites or prunes it.
+suites. Everything spec-independent is **hand-maintained in the SDK repo**, in two
+categories:
+
+- **Extracted source the emitter once wrote** — the HTTP runtime (`Configuration`,
+  `Transport`, errors, pagination, JSON body building) and the test support
+  (`MockWebServer` wiring and `testClient`). These carry `// @oagen-ignore-file`.
+- **Repo resources the emitter has never written** — `build.gradle.kts`,
+  `settings.gradle.kts`, `.editorconfig`. These carry no marker.
+
+What actually protects both categories today is the same thing: **the emitter does
+not write those paths, so they are absent from `.oagen-manifest.json` and
+`pruneStaleFiles` has no record of them to act on.** The marker is not currently
+load-bearing — it earned its place during the extraction itself, when the paths
+_were_ still in the manifest and prune's "content no longer starts with the autogen
+header" guard was the only thing preserving them, and it stays as insurance in case
+a future emitter change re-emits one of those paths.
+
+Do not infer either category from the marker alone. Intersect the marker grep with
+the manifest:
+
+```bash
+cd "$SDK_TARGET"
+grep -rl 'oagen-ignore-file' src | while read -r f; do
+  node -e "process.exit(require('./.oagen-manifest.json').files.includes('$f')?0:1)" \
+    && echo "in-manifest  $f" || echo "not-emitted  $f"
+done
+```
+
+Every hit should print `not-emitted`. An `in-manifest` hit means the emitter still
+claims that path and only the header guard is keeping the hand-maintained content
+alive — fix the emitter rather than relying on the guard.
+
+Note what is **absent** from that repo-resource list: there is no
+`AndroidManifest.xml` and no `proguard-rules.pro`, because the module builds with
+the `org.jetbrains.kotlin.jvm` plugin rather than the Android Gradle plugin. See
+[Why the JVM plugin, not `com.android.library`](#why-the-jvm-plugin-not-comandroidlibrary).
+
 This matches the iOS and Go emitters' static-code-extraction model.
 
 Throughout this document, `{Namespace}` is `ctx.namespacePascal` (e.g. `WorkOS`)
@@ -37,7 +68,7 @@ every axis that matters for an Android artifact:
 | HTTP        | JVM HTTP stack                        | OkHttp                                      |
 | Async       | `suspend` + `@JvmOverloads`           | `suspend`, no Java-interop overloads        |
 | Package     | hardcoded `com.workos`                | namespace-driven `com.{namespace}.android`  |
-| Layout      | `src/main/kotlin/` JVM library        | Android Gradle library module               |
+| Layout      | `src/main/kotlin/` JVM library        | `src/main/kotlin/`, Android-targeted deps   |
 | Integration | merges into live `workos-kotlin`      | fully generated (Scenario B)                |
 
 The decisive constraint is **Jackson**. It relies on runtime reflection, which
@@ -60,9 +91,9 @@ classpath. The package prefix is overridable via
 | Category                   | Choice                                                                                                                                 |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | **Language / concurrency** | Kotlin, `suspend` functions (coroutines). One `suspend fun` per operation — no callback or `Flow` variants except the auto-pager       |
-| **Package manager**        | Gradle with the Android Library plugin (`com.android.library`)                                                                         |
+| **Package manager**        | Gradle with `org.jetbrains.kotlin.jvm` — **not** `com.android.library`; see the note below                                             |
 | **Build tool**             | Gradle Kotlin DSL (`build.gradle.kts`) — **hand-maintained**, not generated                                                            |
-| **Android baseline**       | `minSdk 24`, `compileSdk 35`, JVM target 17 (declared in the hand-maintained Gradle files)                                             |
+| **Android baseline**       | `jvmTarget`/`jvmToolchain` 17. No `minSdk`/`compileSdk` is declared — there is no Android plugin to declare them to                    |
 | **HTTP client**            | OkHttp — the de-facto Android standard, already present in most apps, and pairs with MockWebServer for wire-level tests                |
 | **JSON**                   | kotlinx.serialization (`@Serializable`, `@SerialName`) — compile-time, reflection-free, R8-safe                                        |
 | **Dates**                  | `kotlinx.datetime.Instant`, ISO-8601 (avoids the `java.time` desugaring requirement below API 26)                                      |
@@ -73,11 +104,27 @@ classpath. The package prefix is overridable via
 | **HTTP mocking (tests)**   | OkHttp `MockWebServer` — records the outgoing request for wire-parity assertions                                                       |
 | **Pagination**             | List methods return `Page<T>`; an opt-in `…AutoPaging` companion returns `Flow<T>`                                                     |
 
+### Why the JVM plugin, not `com.android.library`
+
+The target builds with `org.jetbrains.kotlin.jvm`. Nothing in the generated
+surface requires the Android SDK — OkHttp, kotlinx.serialization, and
+kotlinx.datetime are all plain JVM libraries, and the R8-safety argument for
+kotlinx.serialization over Jackson holds regardless of which plugin builds the
+module. Keeping the JVM plugin means the SDK builds and tests with no Android SDK
+installed, which is what CI actually does.
+
+The consequences to keep in mind when reading the rest of this document:
+`minSdk`/`compileSdk` do not exist as declared properties, and there is no
+`AndroidManifest.xml` or `proguard-rules.pro`. `minSdk 24` survives only as the
+consumer baseline the JVM target is chosen for, noted in a `build.gradle.kts`
+comment. Switching to `com.android.library` to publish an AAR is a build-file
+change in the target repo and needs nothing from this emitter.
+
 ---
 
 ## Architecture Overview
 
-The generated SDK is a single Android library module. A consumer:
+The generated SDK is a single Gradle module. A consumer:
 
 ```kotlin
 import com.workos.android.WorkOSClient
@@ -673,10 +720,10 @@ first attempt and the test blocks waiting for one that was never enqueued.
 ```
 build.gradle.kts                                 # repo resource (hand-maintained)
 settings.gradle.kts                              # repo resource (hand-maintained)
-gradle/libs.versions.toml                        # repo resource (hand-maintained)
-proguard-rules.pro                               # repo resource (hand-maintained)
+gradle.properties                                # repo resource (hand-maintained)
+gradle/wrapper/                                  # repo resource (hand-maintained)
+script/ci                                        # repo resource (hand-maintained)
 .editorconfig                                    # repo resource (hand-maintained)
-src/main/AndroidManifest.xml                     # repo resource (hand-maintained)
 src/main/kotlin/{pkg}/
   {Namespace}Client.kt                           # hand-maintained (@oagen-ignore-file)
   {Namespace}ClientResources.kt                  # client.ts (accessor extensions)
@@ -712,8 +759,19 @@ src/test/kotlin/{pkg}/
   support/
     TestClient.kt                                # hand-maintained (@oagen-ignore-file)
   TransportBehaviorTest.kt                       # hand-maintained (@oagen-ignore-file)
+  ActionsTest.kt                                 # hand-maintained (@oagen-ignore-file) H03
+  HelpersTest.kt                                 # hand-maintained (@oagen-ignore-file) H08-H11, H19
+  IronTest.kt                                    # hand-maintained (@oagen-ignore-file) H06
+  SessionTest.kt                                 # hand-maintained (@oagen-ignore-file) H04, H05, H07, H13
+  SSOAuthKitTest.kt                              # hand-maintained (@oagen-ignore-file) H15
+  VaultCryptoTest.kt                             # hand-maintained (@oagen-ignore-file) H18
+  WebhookVerificationTest.kt                     # hand-maintained (@oagen-ignore-file) H01, H02
   {MountGroup}Test.kt                            # tests.ts (one per mount group)
 ```
+
+Every hand-maintained test above covers a non-spec helper, so the H-ID it proves is
+named inline: that mapping is what `prompt-3` re-derives, and leaving it implicit is
+what made it re-derivable-but-not-checkable.
 
 > Test suites live in the SDK's **root** package, not a `resources` sub-package,
 > because the resource accessors are extension properties declared there —

--- a/docs/sdk-architecture/android.md
+++ b/docs/sdk-architecture/android.md
@@ -850,11 +850,15 @@ call-site noise for a much smaller inlined footprint.
 
 ## Known Limitations
 
-- **Deep-object query params.** A `map`-typed query parameter (e.g. SSO's
-  `provider_query_params`) is serialized with `.toString()`, which is not a valid
-  wire encoding. The iOS emitter has the same gap. Correct handling needs OpenAPI
-  `style`/`explode` deep-object support in the query builder; until then such
-  parameters should be avoided or hand-wrapped in the SDK's helper layer.
+- **Deep-object query params are bracket-expanded, not `style`/`explode`-driven.**
+  A `map`-typed query parameter (e.g. SSO's `provider_query_params`) expands to one
+  bracketed entry per key — `provider_query_params[hd]=example.com` — which is what
+  the API and the other WorkOS SDKs send, and is pinned by the generated
+  `SSOTest`/`UserManagementTest` URL-builder tests. It is hard-coded rather than
+  read from the operation's OpenAPI `style`/`explode`, so a future parameter
+  wanting a different deep-object encoding would need real `style` support in the
+  query builder. Non-string map values go through `.toString()`. The iOS emitter
+  still has the original `.toString()`-the-whole-map gap.
 - **Heterogeneous unions widen to `JsonElement`.** Callers get raw JSON rather
   than a typed variant. Generated tests skip operations whose required body is
   such a union, so those paths are covered only by the live smoke runner.

--- a/docs/sdk-architecture/android.md
+++ b/docs/sdk-architecture/android.md
@@ -1,0 +1,881 @@
+# Android / Kotlin SDK Architecture
+
+Design document for the `android` oagen emitter, which generates an idiomatic
+**Kotlin** SDK packaged as an **Android library** from the language-agnostic IR.
+
+> **Emitter identifier:** `android`. Target language: Kotlin (Android). Emitter
+> source lives in `src/android/`; unit tests in `test/android/`; smoke runner at
+> `smoke/sdk-android.ts`.
+
+This is a **Scenario B (fresh)** emitter: there is no existing published Android
+SDK to preserve. The emitter generates only the **spec-driven surface** — models,
+enums, resources, the client's resource-accessor file, and the per-mount test
+suites. Everything spec-independent (the HTTP runtime: `Configuration`,
+`Transport`, errors, pagination, JSON body building; the test support:
+`MockWebServer` wiring and `testClient`; and the repo resources:
+`build.gradle.kts`, `settings.gradle.kts`, `AndroidManifest.xml`,
+`.editorconfig`, `proguard-rules.pro`) is **hand-maintained in the SDK repo**,
+marked with `// @oagen-ignore-file` so generation never overwrites or prunes it.
+This matches the iOS and Go emitters' static-code-extraction model.
+
+Throughout this document, `{Namespace}` is `ctx.namespacePascal` (e.g. `WorkOS`)
+and `{namespace}` is `ctx.namespace` (e.g. `workos`). **No SDK-specific names are
+hard-coded** — everything flows from `ctx` and the IR. This is a deliberate
+departure from the `kotlin` emitter, which hardcodes `package com.workos`.
+
+---
+
+## Relationship to the `kotlin` emitter
+
+Both emitters target Kotlin, so the split needs justification. They differ on
+every axis that matters for an Android artifact:
+
+| Axis        | `kotlin` (server JVM)                 | `android` (this emitter)                    |
+| ----------- | ------------------------------------- | ------------------------------------------- |
+| JSON        | Jackson (reflection, `@JsonProperty`) | kotlinx.serialization (compile-time plugin) |
+| Dates       | `java.time.OffsetDateTime`            | `kotlinx.datetime.Instant`                  |
+| HTTP        | JVM HTTP stack                        | OkHttp                                      |
+| Async       | `suspend` + `@JvmOverloads`           | `suspend`, no Java-interop overloads        |
+| Package     | hardcoded `com.workos`                | namespace-driven `com.{namespace}.android`  |
+| Layout      | `src/main/kotlin/` JVM library        | Android Gradle library module               |
+| Integration | merges into live `workos-kotlin`      | fully generated (Scenario B)                |
+
+The decisive constraint is **Jackson**. It relies on runtime reflection, which
+costs method count, needs explicit R8/ProGuard keep rules, and is discouraged on
+Android. kotlinx.serialization resolves serializers at compile time via the
+Kotlin compiler plugin — no reflection, no keep rules, R8-shrinkable. That alone
+makes a shared emitter impractical, since the annotation model, serializer
+wiring, and enum forward-compatibility strategy all differ.
+
+`com.{namespace}.android` (rather than `com.{namespace}`) follows the convention
+Stripe uses for its Android SDK (`com.stripe.android`) and avoids a class-name
+collision with the server SDK's `com.workos.WorkOS` if both ever land on one
+classpath. The package prefix is overridable via
+`ctx.emitterOptions.packagePrefix`.
+
+---
+
+## Structural Guidelines
+
+| Category                   | Choice                                                                                                                                 |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Language / concurrency** | Kotlin, `suspend` functions (coroutines). One `suspend fun` per operation — no callback or `Flow` variants except the auto-pager       |
+| **Package manager**        | Gradle with the Android Library plugin (`com.android.library`)                                                                         |
+| **Build tool**             | Gradle Kotlin DSL (`build.gradle.kts`) — **hand-maintained**, not generated                                                            |
+| **Android baseline**       | `minSdk 24`, `compileSdk 35`, JVM target 17 (declared in the hand-maintained Gradle files)                                             |
+| **HTTP client**            | OkHttp — the de-facto Android standard, already present in most apps, and pairs with MockWebServer for wire-level tests                |
+| **JSON**                   | kotlinx.serialization (`@Serializable`, `@SerialName`) — compile-time, reflection-free, R8-safe                                        |
+| **Dates**                  | `kotlinx.datetime.Instant`, ISO-8601 (avoids the `java.time` desugaring requirement below API 26)                                      |
+| **Documentation**          | KDoc (`/** … */`)                                                                                                                      |
+| **Type signatures**        | Inline — Kotlin needs no separate signature files, so `generateTypeSignatures` returns `[]`                                            |
+| **Linting / formatting**   | ktlint via `./gradlew ktlintFormat`; `formatCommand` no-ops when no `gradlew` is present so a missing toolchain never fails generation |
+| **Testing framework**      | JUnit 5 (`org.junit.jupiter`) + `kotlinx-coroutines-test` (`runTest`)                                                                  |
+| **HTTP mocking (tests)**   | OkHttp `MockWebServer` — records the outgoing request for wire-parity assertions                                                       |
+| **Pagination**             | List methods return `Page<T>`; an opt-in `…AutoPaging` companion returns `Flow<T>`                                                     |
+
+---
+
+## Architecture Overview
+
+The generated SDK is a single Android library module. A consumer:
+
+```kotlin
+import com.workos.android.WorkOSClient
+
+val client = WorkOSClient(apiKey = "sk_test_...")
+val org = client.organizations.create(name = "Acme")
+```
+
+Layers:
+
+1. **`{Namespace}Client`** (`{Namespace}Client.kt`, hand-maintained) — the entry
+   point. Holds an immutable `Configuration` and a `Transport`. The generated
+   `{Namespace}ClientResources.kt` exposes one extension property per **mount
+   group** (`client.organizations`, `client.sso`, …).
+2. **Resources** (`resources/{MountGroup}.kt`, generated) — one class per mount
+   group, one `suspend fun` per operation. Methods flatten path/query/body
+   parameters into the Kotlin signature and delegate to `Transport`.
+3. **Transport** (`internal/Transport.kt`, hand-maintained) — OkHttp-based
+   request execution: URL/query/header/body assembly, retry with exponential
+   backoff + jitter, response decoding, and status-code → exception mapping.
+4. **Models** (`models/{Model}.kt`, generated) — `@Serializable data class`es.
+5. **Enums** (`enums/{Enum}.kt`, generated) — forward-compatible sealed classes.
+6. **Errors** (`{Namespace}Exception.kt`, hand-maintained) — the exception hierarchy.
+7. **Support runtime** (hand-maintained) — `JsonBody`, `Page`, `PathEncoding`,
+   `RequestOptions`, `Configuration`.
+
+### Mount-group architecture
+
+Resources, client accessors, and the operations manifest are all derived from
+`ctx.resolvedOperations` grouped by `mountOn` (via the shared `groupByMount` /
+`scopedMountGroups` / `getMountTarget` helpers), **not** by raw IR service. This
+matches the iOS/Kotlin/Go emitters and honors consumer `mountRules` /
+`operationHints`. Method names come from `ResolvedOperation.methodName`
+(snake_case) converted to Kotlin `camelCase`.
+
+---
+
+## Naming Conventions (`naming.ts`)
+
+| IR concept                   | Kotlin form                                           | Function       |
+| ---------------------------- | ----------------------------------------------------- | -------------- |
+| Model / Enum / Resource type | `PascalCase` (acronyms upper-cased via `ACRONYM_SET`) | `typeName`     |
+| File name                    | matches type name + `.kt`                             | `fileName`     |
+| Method name                  | `camelCase`                                           | `methodName`   |
+| Property / parameter         | `camelCase`, reserved words back-tick escaped         | `propertyName` |
+| Resource accessor property   | `camelCase` of mount group                            | `accessorName` |
+| Enum member                  | `UPPER_SNAKE_CASE` object name, raw value preserved   | `enumCaseName` |
+
+- **Acronyms:** reuse `toPascalCase`/`toCamelCase` from `@workos/oagen` (they
+  merge `ACRONYM_SET` = SSO, FGA, SAML, SCIM, JWT, HMAC, M2M).
+- **Reserved words:** Kotlin keywords used as identifiers are wrapped in
+  back-ticks (`` `object` ``, `` `is` ``, `` `in` ``, `` `when` ``, `` `val` ``, …).
+  Note `object` **is** reserved in Kotlin (unlike Swift), and it is a common wire
+  field name — so back-tick escaping matters more here than in the iOS emitter.
+- **Wire keys:** a field's `@SerialName` is always the IR `field.name` (the wire
+  name). The Kotlin property is `camelCase(field.domainName ?? field.name)`.
+- **Method-name resolution:** prefer `ctx.resolvedOperations` (via the shared
+  `buildResolvedLookup`/`lookupResolved`), fall back to `resolveOperations(ctx.spec)`
+  when the context has none (unit tests). Uniqueness within a mount is enforced
+  upstream by `assertUniqueResolvedMethods`.
+- **Mount-noun trimming (`trimMountResource`):** delegates to the shared
+  `trimMountedResourceFromMethod`, so method names agree across languages —
+  `listOrganizations` on `Organizations` → `list`, `getUserByExternalId` on
+  `UserManagement` → `getByExternalId`.
+- **Resource-name collisions:** Kotlin allows a class and a file to share a
+  basename across packages, but a resource in `resources/` whose name matches a
+  model in `models/` still produces confusing imports, so a colliding mount gets
+  a `Resource` suffix (mirroring the iOS `resourceTypeName` rule).
+
+---
+
+## Type Mapping (`type-map.ts`)
+
+Implemented with the IR's `mapTypeRef` (`irMapTypeRef`) visitor.
+
+| IR `TypeRef`                                       | Kotlin type                                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `primitive` string                                 | `String`                                                                       |
+| `primitive` string, `format: date-time` / `date`   | `Instant` (`kotlinx.datetime.Instant`)                                         |
+| `primitive` string, `format: byte` / `binary`      | `ByteArray`                                                                    |
+| `primitive` string, `format: uuid` / `uri` / `url` | `String` (lossless wire round-trip)                                            |
+| `primitive` integer                                | `Long` (`Int` when `format: int32`)                                            |
+| `primitive` number                                 | `Double`                                                                       |
+| `primitive` boolean                                | `Boolean`                                                                      |
+| `primitive` unknown                                | `JsonElement`                                                                  |
+| `array` of `T`                                     | `List<T>`                                                                      |
+| `model` `Foo`                                      | `Foo`                                                                          |
+| `enum` `Foo`                                       | `Foo`                                                                          |
+| `literal`                                          | underlying scalar (`String`/`Long`/`Double`/`Boolean`); `null` → `JsonElement` |
+| `map` of `V`                                       | `Map<String, V>`                                                               |
+| `nullable` of `T`                                  | `T?`                                                                           |
+| `union` (single unique variant)                    | that variant                                                                   |
+| `union` (`allOf`)                                  | first variant (merged shape)                                                   |
+| `union` (other / heterogeneous / discriminated)    | `JsonElement`                                                                  |
+
+`JsonElement` (from kotlinx.serialization) is the `unknown` carrier, chosen over
+`Any` because it is `@Serializable` out of the box — `Any` would need a custom
+serializer at every use site.
+
+**Optionality:** a field/parameter is nullable (`T?`) when `!required` **or** the
+type is `nullable`. Nullable constructor/method parameters get a `= null`
+default, which is what lets Kotlin callers use named arguments freely.
+
+> **Discriminated unions (v1):** modeled as **flat data classes** — the base
+> model carries the superset of variant fields (all variant-specific fields
+> nullable), using `enrichModelsFromSpec` + `flattenDiscriminatedUnionFields`
+> (same approach as the iOS/Go/Kotlin base models). This decodes any variant
+> losslessly and always compiles. Native Kotlin sealed-interface unions with a
+> kotlinx.serialization polymorphic serializer are a **documented future
+> enhancement** — deferred because a slightly-wrong custom serializer would fail
+> wire-parity smoke tests, whereas a nullable-field data class never does.
+
+---
+
+## Model Pattern (`models.ts`)
+
+Each IR `Model` → one `@Serializable public data class` file.
+
+```kotlin
+package com.workos.android.models
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** An organization. */
+@Serializable
+public data class Organization(
+    /** The unique identifier of the organization. */
+    @SerialName("id") public val id: String,
+    /** The name of the organization. */
+    @SerialName("name") public val name: String,
+    /** The timestamp when the organization was created. */
+    @SerialName("created_at") public val createdAt: Instant? = null,
+)
+```
+
+Rules:
+
+- **`data class`** gives `equals`/`hashCode`/`copy`/`toString` for free — no
+  hand-written equivalent of Swift's `Equatable` conformance needed.
+- **Primary-constructor properties** are ordered **required first, then nullable**
+  (nullables get `= null`), so callers can rely on named arguments and omit optionals.
+- **`@SerialName` is always emitted** (deterministic) so wire keys survive
+  property renaming; the value is the IR wire name.
+- **`@Serializable` on every model**; the kotlinx plugin generates the serializer
+  at compile time.
+- **Deprecated fields** → `@Deprecated("…")` on the property.
+- **Empty models** → an `@Serializable public class Foo` with no body (a Kotlin
+  `data class` requires at least one constructor parameter, so empty models
+  degrade to a plain class).
+- **Property de-duplication:** flattening discriminated-union variants can repeat
+  a field; duplicates by Kotlin property name are dropped so the constructor
+  doesn't declare the same parameter twice.
+- Discriminated-union base models are emitted as flat data classes (see Type Mapping).
+
+---
+
+## Enum Pattern (`enums.ts`)
+
+Forward-compatible **sealed classes** — a server-added value must not crash
+decoding, _and_ must round-trip losslessly:
+
+```kotlin
+package com.workos.android.enums
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/** Enumeration of valid ConnectionState values. */
+@Serializable(with = ConnectionState.Serializer::class)
+public sealed class ConnectionState(public val rawValue: String) {
+    public data object Active : ConnectionState("active")
+    public data object Inactive : ConnectionState("inactive")
+
+    /** A value not known at SDK generation time. */
+    public data class Unknown(public val value: String) : ConnectionState(value)
+
+    public companion object {
+        public val allKnownValues: List<ConnectionState> = listOf(Active, Inactive)
+
+        public fun fromRawValue(rawValue: String): ConnectionState =
+            when (rawValue) {
+                "active" -> Active
+                "inactive" -> Inactive
+                else -> Unknown(rawValue)
+            }
+    }
+
+    internal object Serializer : KSerializer<ConnectionState> {
+        override val descriptor = PrimitiveSerialDescriptor("ConnectionState", PrimitiveKind.STRING)
+        override fun deserialize(decoder: Decoder): ConnectionState = fromRawValue(decoder.decodeString())
+        override fun serialize(encoder: Encoder, value: ConnectionState) = encoder.encodeString(value.rawValue)
+    }
+}
+```
+
+- A **sealed class, not an `enum class`**. A Kotlin `enum class` cannot carry the
+  unrecognized wire string, so an unknown value would re-serialize as the wrong
+  token and break wire parity on round-trip. The sealed class preserves the raw
+  value in `Unknown(value)` — exact parity with the iOS emitter's
+  `case unknown(String)`.
+- `when` over a sealed class is still exhaustiveness-checked, so this costs
+  nothing versus an enum at the call site.
+- `fromRawValue` is **total** — unknown wire values map to `Unknown` instead of throwing.
+- A generated `Serializer` is always emitted rather than relying on any implicit
+  conformance.
+- `allKnownValues` mirrors the iOS `allKnownCases` convenience.
+- Integer-valued enums use an `Int` `rawValue` with `PrimitiveKind.INT` and the
+  same shape.
+- Member names: `PascalCase` object names derived from the wire value; collisions
+  get a numeric suffix; numeric-leading values get a `Value` prefix. The
+  sentinel name `Unknown` is reserved so a real `unknown` wire value is suffixed
+  rather than colliding.
+
+---
+
+## Resource / Client Pattern (`resources.ts`, `client.ts`)
+
+### Client
+
+The client class core lives in the SDK repo (hand-maintained,
+`@oagen-ignore-file`); the emitter generates only the spec-driven accessors as
+**extension properties**, which is the closest Kotlin analogue to the Swift
+extension the iOS emitter emits:
+
+```kotlin
+// WorkOSClientResources.kt (generated)
+package com.workos.android
+
+import com.workos.android.resources.Organizations
+import com.workos.android.resources.SSO
+
+/** Operations for the Organizations API. */
+public val WorkOSClient.organizations: Organizations
+    get() = Organizations(transport)
+
+/** Operations for the SSO API. */
+public val WorkOSClient.sso: SSO
+    get() = SSO(transport)
+```
+
+- `generateClient` returns the accessor file (with `overwriteExisting: true`, the
+  Go/iOS pattern) plus the staging-only smoke-plan sidecar.
+- Extension properties in the same module can read the client's `internal val
+transport`, so the runtime stays hand-maintained without widening its visibility.
+- Accessors construct a fresh resource object per access. Resource classes hold
+  only a `Transport` reference, so this is as cheap as the Swift value-type
+  structs and avoids caching/retain-cycle bookkeeping.
+
+### Resource + method
+
+```kotlin
+public class Organizations internal constructor(
+    private val transport: Transport,
+) {
+    /**
+     * Creates a new organization.
+     *
+     * @param name The name of the organization.
+     * @param requestOptions Per-request overrides (idempotency key, API key, headers, timeout).
+     * @return The created [Organization].
+     */
+    public suspend fun create(
+        name: String,
+        domains: List<String>? = null,
+        requestOptions: RequestOptions? = null,
+    ): Organization {
+        val path = "organizations"
+        val body = JsonBody()
+        body.set("name", name)
+        body.set("domains", domains)
+        return transport.request(
+            method = "POST",
+            path = path,
+            query = emptyList(),
+            body = body,
+            options = requestOptions,
+        )
+    }
+
+    public suspend fun get(
+        id: String,
+        requestOptions: RequestOptions? = null,
+    ): Organization {
+        val path = "organizations/${PathEncoding.segment(id)}"
+        return transport.request(
+            method = "GET",
+            path = path,
+            query = emptyList(),
+            body = null,
+            options = requestOptions,
+        )
+    }
+
+    public suspend fun delete(
+        id: String,
+        requestOptions: RequestOptions? = null,
+    ) {
+        val path = "organizations/${PathEncoding.segment(id)}"
+        transport.requestVoid(
+            method = "DELETE",
+            path = path,
+            query = emptyList(),
+            body = null,
+            options = requestOptions,
+        )
+    }
+}
+```
+
+Method construction (driven by `planOperation(op)`):
+
+- **Path params** → interpolated into a Kotlin template string, each wrapped in
+  `PathEncoding.segment(...)` (SSRF-safe per-segment percent-encoding; see the
+  security note in `shared/path-template.ts`). Segments come from the shared
+  `parsePathTemplate`.
+- **Query params** → appended to a `MutableList<QueryParam>`, honoring `explode`
+  for arrays (repeat key vs comma-join).
+- **Body** → a `JsonBody` builder; `set` is a no-op for `null`, so optional
+  fields are omitted rather than sent as JSON `null`.
+  `requestBodyEncoding` selects JSON (default) vs form-urlencoded.
+- **Return type** → from `planOperation`: model, `List<Model>` (array response),
+  `Page<Item>` (paginated), or `Unit` (delete / no model). `transport.request` is
+  `reified` on the return type, so no explicit type token is passed.
+- **`requestOptions: RequestOptions? = null`** is always the last parameter.
+  Per `docs/lang-gen/sdk-runtime-contract.md` §1, the hand-maintained
+  `RequestOptions` must carry **all five** overrides, and the transport must
+  actually honor each (§7 — a typed field that the runtime ignores does not count):
+
+  ```kotlin
+  public data class RequestOptions(
+      val headers: Map<String, String>? = null,  // extra headers
+      val timeoutSeconds: Long? = null,          // timeout override
+      val maxRetries: Int? = null,               // retry override
+      val baseUrl: String? = null,               // base URL override
+      val idempotencyKey: String? = null,        // idempotency key override
+  )
+  ```
+
+- **No `@JvmOverloads`** — Kotlin default arguments serve Kotlin callers, and
+  Android consumers are Kotlin-first. This is a deliberate difference from the
+  `kotlin` emitter, which targets Java interop too.
+
+### Wrappers (union-split operations)
+
+When a `ResolvedOperation` has `wrappers` (from consumer `split` hints, e.g.
+`authenticate` → `authenticateWithPassword`/`authenticateWithCode`), one
+`suspend fun` is emitted per wrapper, each exposing only its variant's fields and
+injecting `defaults` + `inferFromClient` values (read from the client
+configuration, e.g. `transport.configuration.clientId`). Built from
+`ResolvedWrapper` fields via the shared `wrapper-utils`.
+
+### URL builders (browser-redirect operations)
+
+`urlBuilder` operations (e.g. `GET /sso/authorize`, `GET /sso/logout`) never
+issue an HTTP request: `generateResources` emits a **non-suspend** function
+returning the assembled URL `String` via `transport.buildUrl(path, query)`.
+Hidden `defaults` (`response_type=code`) and `inferFromClient` values
+(`client_id`, appended only when `Configuration.clientId` is set) join the
+caller's query parameters, mirroring the iOS and Go emitters. They are skipped in
+`buildOperationsMap` and the smoke plan — there is no live HTTP call to verify.
+
+---
+
+## Serialization Pattern (hand-maintained `internal/Json.kt`, `internal/JsonBody.kt`)
+
+- A single `Json { ignoreUnknownKeys = true; explicitNulls = false; encodeDefaults = false }`
+  instance configured in the runtime. `ignoreUnknownKeys` is essential for
+  forward compatibility — a server-added response field must not throw.
+- **`JsonBody`** — a small builder wrapping a `MutableMap<String, JsonElement>`.
+  Serves the same role as the iOS emitter's `EncodableBody`. Required surface:
+
+  | Method                                               | Contract                                                                         |
+  | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+  | `set(key: String, value: Any?)`                      | Add one field. **Ignores `null`**, which is how optional body fields are omitted |
+  | `setRaw(serializer: SerializationStrategy<T>, v: T)` | Replace the whole body with a serialized object (raw, unexpanded bodies)         |
+  | `setRawJson(value: JsonElement)`                     | Replace the whole body with a pre-built element                                  |
+  | `toJsonElement()`                                    | The raw override if set, else the accumulated field map                          |
+
+  `setRaw`/`setRawJson` exist because an operation whose request body is a
+  field-less model (or a non-object schema) cannot be flattened into named
+  parameters — it is passed whole. Handing that object straight to
+  `transport.request(body = …)` does not typecheck, since the transport takes a
+  `JsonBody`. `set` alone cannot express it either, because there is no field key.
+  The emitter names the compile-time serializer for a model body
+  (`Foo.serializer()`); any other raw shape is exposed to callers as a
+  `JsonElement` parameter, since no named serializer can be derived.
+
+- **Dates** — `kotlinx.datetime.Instant` serializes as ISO-8601 by default.
+
+---
+
+## Pagination Pattern (hand-maintained `Page.kt`, `internal/AutoPaging.kt`)
+
+```kotlin
+@Serializable
+public data class Page<T>(
+    @SerialName("data") public val data: List<T>,
+    @SerialName("list_metadata") public val listMetadata: ListMetadata,
+)
+
+@Serializable
+public data class ListMetadata(
+    @SerialName("before") public val before: String? = null,
+    @SerialName("after") public val after: String? = null,
+)
+```
+
+- Paginated list methods return `Page<Item>` (item type from
+  `plan.paginatedItemModelName`, unwrapped through the shared `unwrapListModel`
+  so the element type is `Organization`, not `OrganizationList`).
+- Each cursor-paginated operation also gets a generated `…AutoPaging` companion
+  returning `Flow<Item>`, which walks successive pages by feeding
+  `listMetadata.after` back into the cursor parameter:
+
+```kotlin
+public fun listAutoPaging(
+    limit: Long? = null,
+    requestOptions: RequestOptions? = null,
+): Flow<Organization> = autoPagingFlow { cursor ->
+    list(limit = limit, after = cursor, requestOptions = requestOptions)
+}
+```
+
+- The companion is only generated when the cursor parameter is an optional string
+  query param the wrapper can drive (same guard as the iOS `planAutoPaging`).
+- `Flow` is cold and cancellable, so it is the correct Kotlin analogue of the
+  Swift `AutoPagingSequence` (`AsyncSequence`).
+
+---
+
+## Error Handling (hand-maintained `{Namespace}Exception.kt`)
+
+Hand-maintained in the SDK repo (`generateErrors` returns `[]`). The hierarchy
+mirrors `ctx.spec.sdk.errors` (the `ErrorPolicy.statusCodeMap`) as of extraction.
+Kotlin/JVM convention is a `Throwable` hierarchy rather than a sum type, so this
+diverges structurally from the Swift `enum WorkOSError`:
+
+Per `docs/lang-gen/sdk-runtime-contract.md` §3, the error type must preserve
+status code, request ID, message, API error code, **parameter name**, and the raw
+response body:
+
+```kotlin
+public open class WorkOSException(
+    public val statusCode: Int,
+    override val message: String,
+    public val code: String? = null,
+    public val requestId: String? = null,
+    /** The offending request parameter, when the API attributes the error to one. */
+    public val param: String? = null,
+    public val raw: JsonElement? = null,
+) : Exception(message)
+
+/** 400 — the request was malformed. */
+public class BadRequestException(…) : WorkOSException(…)
+
+/** 401 — authentication failed. */
+public class AuthenticationException(…) : WorkOSException(…)
+
+/** 404 — the resource was not found. */
+public class NotFoundException(…) : WorkOSException(…)
+
+// …one subclass per statusCodeMap entry
+
+/** 5xx — a server error. */
+public class ServerException(…) : WorkOSException(…)
+
+/** A transport/connection failure. */
+public class NetworkException(cause: IOException) : WorkOSException(…)
+
+/** The response body could not be decoded. */
+public class DecodingException(cause: Throwable) : WorkOSException(…)
+```
+
+`Transport` inspects the HTTP status, decodes the error envelope, and throws the
+appropriate subclass via the status-code map. `errorDocUrlTemplate` (if present)
+is surfaced in the message. Subclassing (rather than sealed) keeps the hierarchy
+extensible without a breaking change when the spec adds a status code.
+
+---
+
+## Retry Logic (hand-maintained `internal/Transport.kt`)
+
+Hand-maintained; behavior mirrors `ctx.spec.sdk.retry` (`RetryPolicy`) as of
+extraction:
+
+- Retry on `retryableStatusCodes` (default `[429, 500, 502, 503, 504]`), and on
+  connection errors / timeouts per policy flags.
+- Up to `maxRetries` (default 3) attempts.
+- Exponential backoff: `initialDelay * multiplier^attempt`, capped at `maxDelay`,
+  with `± jitterFactor` randomization, awaited with `kotlinx.coroutines.delay`
+  (non-blocking — never `Thread.sleep`, which would stall the calling
+  dispatcher). The generated Kotlin may use randomness; **the emitter itself must
+  not** — emitters stay pure and deterministic.
+- Honors a `Retry-After` header when present.
+- Idempotency: for retryable POSTs (`IdempotencyPolicy.autoGenerateForPost`), a
+  UUID is generated once and sent under `IdempotencyPolicy.headerName` on every attempt.
+
+---
+
+## Configuration (hand-maintained `Configuration.kt`)
+
+```kotlin
+public data class Configuration(
+    public val apiKey: String,
+    public val baseUrl: String = "https://api.workos.com",
+    public val timeoutSeconds: Long = 60,
+    public val maxRetries: Int = 3,
+    public val clientId: String? = null,
+    // …fields inferred from ctx.spec.auth + SdkBehavior
+)
+```
+
+Hand-maintained; the defaults captured at extraction time came from the spec
+policy (`baseUrl` from `ctx.spec.baseUrl`, bearer auth from `ctx.spec.auth`,
+User-Agent from `SdkBehavior.userAgent.sdkIdentifierTemplate`, timeout from
+`SdkBehavior.timeout.defaultTimeoutSeconds`). Policy changes are applied by hand
+in the SDK repo.
+
+---
+
+## Test Pattern (`tests.ts`)
+
+JUnit 5 + MockWebServer + `runTest`:
+
+```kotlin
+package com.workos.android.resources
+
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class OrganizationsTest {
+    @Test
+    fun `create sends expected request`() = runTest {
+        val (client, server) = testClient("""{"id":"org_1","name":"Acme"}""")
+
+        val org = client.organizations.create(name = "Acme")
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/organizations", request.path?.substringBefore('?'))
+        assertEquals("org_1", org.id)
+    }
+}
+```
+
+The generated suites depend on a small hand-maintained support surface
+(`support/TestClient.kt`, `@oagen-ignore-file`). Keeping MockWebServer's API
+behind these helpers means a MockWebServer upgrade is a one-file edit rather than
+a regeneration of every suite:
+
+| Helper                                                   | Contract                                                                                              |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `testClient(responding: String = "{}")`                  | Starts a `MockWebServer`, enqueues one 200 response, returns `Pair<{Namespace}Client, MockWebServer>` |
+| `testClientWithStubs(stubs: List<String>)`               | Same, enqueuing one 200 response per stub (drives the pagination test)                                |
+| `testClientWithStatus(code, body, headers = emptyMap())` | Enqueues one failure response — drives the §6 error-path tests                                        |
+| `RecordedRequest.pathOnly()`                             | Request path with the query string stripped                                                           |
+| `RecordedRequest.queryParam(name)`                       | Single query-parameter value, **percent-decoded**                                                     |
+| `RecordedRequest.headerValue(name)`                      | Single request-header value — proves per-request options reached the wire                             |
+| `RecordedRequest.bodyJson()`                             | Request body parsed into a `JsonObject`                                                               |
+
+Every client these helpers return must be configured `maxRetries = 0`. Otherwise
+the retryable statuses (429 and 5xx) consume the single enqueued response on the
+first attempt and the test blocks waiting for one that was never enqueued.
+
+- One `@Test` per operation per mount group asserts: HTTP method, path, and that
+  the response decodes into the expected type.
+- **Backtick test names** (``fun `create sends expected request`()``) are the
+  Kotlin convention and read better in reports than camelCase.
+- **Union-split wrappers** get one `@Test` each, asserting the discriminating
+  default (`grant_type` / `application_type`) landed in the request body.
+- **URL builders** get a non-suspend `builds expected url` test asserting the
+  assembled URL's path and query — no mock traffic.
+- **Nested model bodies** are sample-constructed through the generated data
+  classes' constructors (required fields only, recursion-depth capped), so
+  operations like `createEvent` are exercised rather than skipped; only
+  heterogeneous-union bodies remain untestable.
+- The transport behavior suite (auth header, request options, typed errors,
+  retries, idempotency) is hand-maintained alongside the transport it tests.
+
+---
+
+## Directory Structure (emitted `GeneratedFile` paths, target-root-relative)
+
+`{pkg}` is the package path (`com/workos/android` by default).
+
+```
+build.gradle.kts                                 # repo resource (hand-maintained)
+settings.gradle.kts                              # repo resource (hand-maintained)
+gradle/libs.versions.toml                        # repo resource (hand-maintained)
+proguard-rules.pro                               # repo resource (hand-maintained)
+.editorconfig                                    # repo resource (hand-maintained)
+src/main/AndroidManifest.xml                     # repo resource (hand-maintained)
+src/main/kotlin/{pkg}/
+  {Namespace}Client.kt                           # hand-maintained (@oagen-ignore-file)
+  {Namespace}ClientResources.kt                  # client.ts (accessor extensions)
+  Configuration.kt                               # hand-maintained (@oagen-ignore-file)
+  RequestOptions.kt                              # hand-maintained (@oagen-ignore-file)
+  {Namespace}Exception.kt                        # hand-maintained (@oagen-ignore-file)
+  Page.kt                                        # hand-maintained (@oagen-ignore-file)
+  helpers/                                       # hand-maintained (@oagen-ignore-file)
+    Pkce.kt                                      #   H08 + `val {Namespace}Client.pkce`
+    AuthKit.kt                                   #   H10 (composes the generated URL builder)
+    PublicClient.kt                              #   H19 public/PKCE-only facade
+    Passwordless.kt                              #   non-spec + `val {Namespace}Client.passwordless`
+    Signing.kt                                   #   HMAC-SHA256 signature primitives (H02)
+    WebhookVerification.kt                       #   H01, H02
+    Actions.kt                                   #   H03 + `val {Namespace}Client.actions`
+    Iron.kt                                      #   H06 Fe26.2 seal/unseal
+    Session.kt                                   #   H04, H05, H07 + `val {Namespace}Client.session`
+    VaultCrypto.kt                               #   H18 + `val {Namespace}Client.vaultCrypto`
+  models/
+    {Model}.kt                                   # models.ts (one per model)
+  enums/
+    {Enum}.kt                                    # enums.ts (one per enum)
+  resources/
+    {MountGroup}.kt                              # resources.ts (one per mount group)
+  internal/
+    Transport.kt                                 # hand-maintained (@oagen-ignore-file)
+    Json.kt                                      # hand-maintained (@oagen-ignore-file)
+    JsonBody.kt                                  # hand-maintained (@oagen-ignore-file)
+    PathEncoding.kt                              # hand-maintained (@oagen-ignore-file)
+    AutoPaging.kt                                # hand-maintained (@oagen-ignore-file)
+src/test/kotlin/{pkg}/
+  support/
+    TestClient.kt                                # hand-maintained (@oagen-ignore-file)
+  TransportBehaviorTest.kt                       # hand-maintained (@oagen-ignore-file)
+  {MountGroup}Test.kt                            # tests.ts (one per mount group)
+```
+
+> Test suites live in the SDK's **root** package, not a `resources` sub-package,
+> because the resource accessors are extension properties declared there —
+> a suite in the same package resolves `client.organizations` with no import.
+
+### Namespace casing
+
+`namespacePascal` is passed through verbatim from `--namespace`, and it names the
+client class (`{Namespace}Client`). Generate with **`--namespace WorkOS`** to get
+exact acronym casing; a lower-case namespace is capitalized (`workos` →
+`WorkosClient`) so output is always a legal Kotlin identifier, but the `OS`
+casing cannot be recovered. The package segment is independent: it lower-cases
+and strips separators from `ctx.namespace`, so both spellings yield
+`com.workos.android`.
+
+> **No barrel file** — Kotlin has no re-export mechanism, so the public surface is
+> every `public` declaration reachable from the package. Consumers import from the
+> concrete package (`com.workos.android.models.Organization`). An extractor would
+> treat the whole `src/main/kotlin/{pkg}/` tree as the surface.
+
+---
+
+## Emitter File Layout (`src/android/`)
+
+| File           | Responsibility                                                                                       |
+| -------------- | ---------------------------------------------------------------------------------------------------- |
+| `index.ts`     | `androidEmitter: Emitter` — wires enrichment + sub-generators, `fileHeader`, `formatCommand`         |
+| `naming.ts`    | Kotlin identifier casing, reserved-word escaping, method-name resolution, package/path helpers       |
+| `type-map.ts`  | IR `TypeRef` → Kotlin type string (via `irMapTypeRef`) + implied imports                             |
+| `models.ts`    | `generateModels` — `@Serializable data class`es with `@SerialName`                                   |
+| `enums.ts`     | `generateEnums` — forward-compatible sealed classes + generated `KSerializer`                        |
+| `resources.ts` | `generateResources` — mount-group resource classes, `suspend fun` methods, URL builders, auto-pagers |
+| `wrappers.ts`  | union-split wrapper method rendering                                                                 |
+| `client.ts`    | `generateClient` — `{Namespace}ClientResources.kt` extension properties + smoke-plan sidecar         |
+| `tests.ts`     | `generateTests` — per-mount JUnit 5 suites (support files are hand-maintained in the SDK repo)       |
+| `manifest.ts`  | `buildOperationsMap` — `"METHOD /path"` → `{ sdkMethod, service }`                                   |
+| `imports.ts`   | Deterministic import-block collection and ktlint-compatible ordering                                 |
+
+---
+
+## Non-spec accessors: why Kotlin sidesteps the base-class hazard
+
+`prompt-4-cleanup` warns that compat accessors (passwordless, vault, actions, pkce)
+must live in the **generated** client file rather than a hand-maintained base class,
+because their constructors type-hint the full subclass and `self` in the base does
+not satisfy that constraint — it produced
+`"WorkOSClient*" is not assignable to "WorkOSClient"` during the Python extraction.
+
+That hazard does not exist here, and the reason is structural rather than lucky.
+Kotlin mounts these as **extension properties on the concrete class**:
+
+```kotlin
+public val WorkOSClient.passwordless: Passwordless
+    get() = Passwordless(this)
+```
+
+`this` is a `WorkOSClient` — the concrete type — so there is no base/subclass
+variance to violate. Consequently the accessors live in hand-maintained
+`helpers/` files rather than the generated client file, which is the opposite of
+the Python arrangement and is correct for this language.
+
+Two invariants keep it safe, both pinned by tests:
+
+1. The emitter never generates an accessor for a `NON_SPEC_SERVICES` entry
+   (`test/android/non-spec.test.ts`) — a generated accessor would reference a type
+   that only exists in the SDK repo and break the standalone staging build.
+2. Generated and hand-maintained accessor names are disjoint. They share one
+   namespace (both are `val {Namespace}Client.x` in the same package), so a
+   collision is a redeclaration **compile** error, not a silent shadow.
+
+---
+
+## Session cookies: why the wire shape is Node's, not `workos-kotlin`'s
+
+Sealed session cookies are a cross-SDK contract, and the two Kotlin SDKs disagree
+on it. `workos-kotlin` serializes `SessionCookieData` with the SDK's shared Jackson
+mapper, which has no naming strategy — so its own fields come out camelCase, while
+the nested `user` comes out **snake_case**, because the generated models carry
+`@JsonProperty("email_verified")` and friends. `workos-node` writes camelCase at
+every level.
+
+The consequence is that a cookie sealed by a Node backend does not open in
+`workos-kotlin`: Jackson looks for `email_verified`, does not find it, and the
+Kotlin module rejects the missing non-null constructor parameter.
+
+That asymmetry matters more for `android` than for any server SDK, because on
+Android the seal is almost never produced locally — a backend seals it and the app
+opens it. So `helpers/Session.kt` deliberately does **not** mirror
+`workos-kotlin` here:
+
+- **Writes** the `workos-node` shape — camelCase at every level.
+- **Reads** either shape, accepting each key in camelCase or snake_case.
+
+The mechanism is a shallow key rename applied to the model sub-objects only.
+Shallow is load-bearing: `User.metadata` holds caller-supplied keys, so recursing
+would rewrite application data (`tenant_id` → `tenantId`). `User` and
+`AuthenticateResponseImpersonator` are flat apart from `metadata`, and `metadata`
+itself is unchanged by either transform, so one level is both sufficient and safe.
+`test/../SessionTest.kt` pins all three properties: the Node shape, the
+`workos-kotlin` shape, and metadata surviving a round trip.
+
+`authenticate()` and `refresh()` are `suspend` here where `workos-kotlin`'s block.
+JWKS retrieval is network I/O and must not run on Android's main thread; the
+JWKS-backed verifier confines it to `Dispatchers.IO`.
+
+---
+
+## Compiler heap (required in `gradle.properties`)
+
+`Transport.request` is a `suspend inline fun <reified T>`, so it is inlined at
+**every** operation call site — 261 of them — and each reified instantiation
+materializes a distinct `kotlinx.serialization` serializer. The default Kotlin
+compiler heap is not enough for that, and the failure is badly misreported:
+
+```
+e: org.jetbrains.kotlin.codegen.CompilationException:
+   Back-end (JVM) Internal error: Couldn't transform method node:
+Caused by: java.lang.OutOfMemoryError: GC overhead limit exceeded
+```
+
+The "Internal error" and the file it names (some arbitrary model) are both red
+herrings — it is purely an out-of-memory condition. The hand-maintained
+`gradle.properties` must raise the heap:
+
+```properties
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g
+kotlin.daemon.jvmargs=-Xmx6g
+```
+
+If a future SDK grows past this, the alternative is to drop `reified` and pass an
+explicit `KSerializer<T>` from the generated call site, trading a little
+call-site noise for a much smaller inlined footprint.
+
+---
+
+## Known Limitations
+
+- **Deep-object query params.** A `map`-typed query parameter (e.g. SSO's
+  `provider_query_params`) is serialized with `.toString()`, which is not a valid
+  wire encoding. The iOS emitter has the same gap. Correct handling needs OpenAPI
+  `style`/`explode` deep-object support in the query builder; until then such
+  parameters should be avoided or hand-wrapped in the SDK's helper layer.
+- **Heterogeneous unions widen to `JsonElement`.** Callers get raw JSON rather
+  than a typed variant. Generated tests skip operations whose required body is
+  such a union, so those paths are covered only by the live smoke runner.
+
+---
+
+## Future Enhancements (documented, not in v1)
+
+- **Native sealed-interface unions:** emit discriminated unions as sealed
+  interfaces with a kotlinx.serialization polymorphic serializer keyed on the
+  discriminator, instead of flattened nullable-field data classes.
+- **Kotlin Multiplatform:** swap OkHttp for Ktor and `src/main/kotlin` for
+  `src/commonMain/kotlin` so one emitter serves Android _and_ iOS. This is the
+  main reason to keep the runtime hand-maintained and the emitter output
+  dependency-agnostic.
+- **Structural dedup / typealias:** collapse structurally-identical models and
+  enums to `typealias` (the Kotlin emitter's two-pass dedup), reducing duplicate types.
+- **Aggregate event sealed interface:** a `{Namespace}Event` sum type over all
+  webhook event envelopes for exhaustive `when` handling.
+- **PATCH tri-state:** a `PatchField<T>` wrapper distinguishing "absent" from
+  "explicitly null" for PATCH bodies.
+- **Explicit API mode:** enable Kotlin's `explicitApi()` in the generated Gradle
+  config and assert every generated declaration carries an explicit visibility
+  modifier (the emitter already emits `public` everywhere).

--- a/docs/sdk-architecture/android.md
+++ b/docs/sdk-architecture/android.md
@@ -687,6 +687,7 @@ src/main/kotlin/{pkg}/
   helpers/                                       # hand-maintained (@oagen-ignore-file)
     Pkce.kt                                      #   H08 + `val {Namespace}Client.pkce`
     AuthKit.kt                                   #   H10 (composes the generated URL builder)
+    SSOAuthKit.kt                                #   H15 (H16 is impossible — see the file)
     PublicClient.kt                              #   H19 public/PKCE-only facade
     Passwordless.kt                              #   non-spec + `val {Namespace}Client.passwordless`
     Signing.kt                                   #   HMAC-SHA256 signature primitives (H02)

--- a/smoke/sdk-android.ts
+++ b/smoke/sdk-android.ts
@@ -1,0 +1,1027 @@
+#!/usr/bin/env npx tsx
+/**
+ * Android / Kotlin SDK smoke test — captures wire-level HTTP exchanges from the
+ * generated Android SDK and outputs SmokeResults JSON for diff comparison.
+ *
+ * Kotlin is compiled, so (like Go/Swift) the SDK is driven out-of-process:
+ *   1. A local capture proxy (this process) forwards requests to the real API,
+ *      recording each request/response pair. The driver points its baseUrl at
+ *      the proxy; the proxy injects the real Authorization header.
+ *   2. Per wave, a `Main.kt` driver is generated that makes literal SDK calls
+ *      wrapped in stderr markers, built and run via Gradle.
+ *
+ * The SDK ships as an Android library (`com.android.library`), but nothing in the
+ * GENERATED code touches Android APIs — it is OkHttp + kotlinx.serialization +
+ * kotlinx.datetime, all pure JVM. So the driver compiles the SDK's
+ * `src/main/kotlin` as a plain `kotlin("jvm")` source set (the same trick
+ * `sdk-kotlin.ts` uses), which avoids needing the Android SDK, an emulator, or an
+ * instrumented test run just to observe HTTP traffic.
+ *
+ * Resource methods take flattened named arguments, so the driver reconstructs each
+ * call from the emitter's own `.oagen-android-smoke.json` sidecar — guaranteeing
+ * the generated calls match the generated methods exactly.
+ *
+ * Usage:
+ *   npx tsx smoke/sdk-android.ts --spec ../openapi-spec/spec/open-api-spec.yaml --sdk-path ./sdk
+ *
+ * Requires API_KEY or WORKOS_API_KEY env var.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import {
+  parseSpec,
+  planOperations,
+  planWaves,
+  generateCamelPayload,
+  generateCamelQueryParams,
+  IdRegistry,
+  delay,
+  parseCliArgs,
+  loadSmokeConfig,
+  getExpectedStatusCodes,
+  isUnexpectedStatus,
+  toCamelCase,
+} from '@workos/oagen/smoke';
+import type { CapturedExchange, SmokeResults, ExchangeProvenance, OperationWave } from '@workos/oagen/smoke';
+import type { ApiSpec, Operation } from '@workos/oagen';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// The `.oagen-android-smoke.json` sidecar shape (authoritative, transform-aware).
+type Serialize =
+  | { kind: 'string' | 'int' | 'long' | 'double' | 'bool' | 'instant' | 'bytes' | 'json' | 'unsupported' }
+  | { kind: 'enum'; enumType: string }
+  | { kind: 'array'; element: Serialize }
+  | { kind: 'map'; value: Serialize };
+
+interface SmokePlanParam {
+  label: string;
+  wire: string;
+  source: 'path' | 'query' | 'body' | 'bodyRaw';
+  optional: boolean;
+  serialize: Serialize;
+}
+
+interface SmokePlanEntry {
+  service: string;
+  method: string;
+  params: SmokePlanParam[];
+}
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  queryParams: Record<string, string>;
+  body: unknown | null;
+}
+
+interface CapturedResponse {
+  status: number;
+  body: unknown | null;
+}
+
+interface MethodResolution {
+  service: string;
+  method: string;
+  tier: ExchangeProvenance['resolutionTier'];
+  confidence: number;
+}
+
+interface ProxyCapture {
+  request: CapturedRequest;
+  response: CapturedResponse;
+}
+
+/** Where the generated SDK lives, and what the driver must supply itself. */
+interface SdkLayout {
+  /** Root package of the generated SDK (e.g. `com.workos.android`). */
+  basePackage: string;
+  /** Client class name (e.g. `WorkOSClient`). */
+  clientClass: string;
+  /** Absolute path to the SDK's Kotlin source root. */
+  sourceRoot: string;
+  /** True when the SDK repo provides the hand-maintained HTTP runtime. */
+  hasRuntime: boolean;
+}
+
+// Module-scoped smoke plan (from .oagen-android-smoke.json), initialized in main().
+let smokePlan: Map<string, SmokePlanEntry> = new Map();
+
+// ---------------------------------------------------------------------------
+// Proxy server (man-in-the-middle to the real API; records exchanges)
+// ---------------------------------------------------------------------------
+
+function createProxyServer(
+  apiKey: string,
+  targetHost: string,
+  captures: ProxyCapture[],
+): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolvePromise) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        let body: unknown = null;
+        if (chunks.length > 0) {
+          try {
+            body = JSON.parse(Buffer.concat(chunks).toString());
+          } catch {
+            body = Buffer.concat(chunks).toString();
+          }
+        }
+        const url = new URL(req.url ?? '/', 'http://localhost');
+        const queryParams: Record<string, string> = {};
+        url.searchParams.forEach((v, k) => {
+          queryParams[k] = v;
+        });
+
+        const options = {
+          hostname: targetHost,
+          port: 443,
+          path: req.url,
+          method: req.method,
+          headers: {
+            ...req.headers,
+            host: targetHost,
+            authorization: `Bearer ${apiKey}`,
+          },
+        };
+
+        const proxyReq = httpsRequest(options, (proxyRes) => {
+          const resChunks: Buffer[] = [];
+          proxyRes.on('data', (c: Buffer) => resChunks.push(c));
+          proxyRes.on('end', () => {
+            let resBody: unknown = null;
+            if (resChunks.length > 0) {
+              try {
+                resBody = JSON.parse(Buffer.concat(resChunks).toString());
+              } catch {
+                resBody = Buffer.concat(resChunks).toString();
+              }
+            }
+            captures.push({
+              request: { method: req.method ?? 'GET', path: url.pathname, queryParams, body },
+              response: { status: proxyRes.statusCode ?? 0, body: resBody },
+            });
+            res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+            res.end(Buffer.concat(resChunks));
+          });
+        });
+
+        proxyReq.on('error', (err) => {
+          captures.push({
+            request: { method: req.method ?? 'GET', path: url.pathname, queryParams, body },
+            response: { status: 502, body: { error: err.message } },
+          });
+          res.writeHead(502);
+          res.end('Proxy error');
+        });
+
+        if (chunks.length > 0) proxyReq.write(Buffer.concat(chunks));
+        proxyReq.end();
+      });
+    });
+
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = addr && typeof addr === 'object' ? addr.port : 0;
+      resolvePromise({
+        port,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar loading + SDK layout detection
+// ---------------------------------------------------------------------------
+
+function loadSmokePlan(sdkPath: string): Map<string, SmokePlanEntry> {
+  const planPath = resolve(sdkPath, '.oagen-android-smoke.json');
+  if (!existsSync(planPath)) {
+    console.warn(`Warning: No .oagen-android-smoke.json found at ${planPath}`);
+    console.warn('  Regenerate the SDK with a current android emitter; most operations will be skipped.');
+    return new Map();
+  }
+  const parsed: unknown = JSON.parse(readFileSync(planPath, 'utf-8'));
+  const plan = new Map<string, SmokePlanEntry>();
+  if (parsed && typeof parsed === 'object' && 'operations' in parsed) {
+    const operations = (parsed as { operations?: unknown }).operations;
+    if (operations && typeof operations === 'object') {
+      for (const [httpKey, entry] of Object.entries(operations)) {
+        plan.set(httpKey, entry as SmokePlanEntry);
+      }
+    }
+  }
+  return plan;
+}
+
+/**
+ * Locate the generated SDK's root package by finding the directory under
+ * `src/main/kotlin` that contains the generated `models/` folder.
+ */
+function detectLayout(sdkPath: string): SdkLayout {
+  const sourceRoot = resolve(sdkPath, 'src', 'main', 'kotlin');
+  const fallback: SdkLayout = {
+    basePackage: 'com.workos.android',
+    clientClass: 'WorkOSClient',
+    sourceRoot,
+    hasRuntime: false,
+  };
+  if (!existsSync(sourceRoot)) return fallback;
+
+  const found = findPackageDir(sourceRoot, []);
+  if (!found) return fallback;
+
+  const { dir, segments } = found;
+  const basePackage = segments.join('.');
+  const clientResources = readdirSync(dir).find((f) => f.endsWith('ClientResources.kt'));
+  const clientClass = clientResources ? clientResources.replace(/Resources\.kt$/, '') : `${fallback.clientClass}`;
+  const hasRuntime = existsSync(join(dir, 'internal', 'Transport.kt'));
+
+  return { basePackage, clientClass, sourceRoot, hasRuntime };
+}
+
+/** Depth-first search for the package directory containing a `models` subdir. */
+function findPackageDir(dir: string, segments: string[]): { dir: string; segments: string[] } | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+  if (entries.includes('models') && statSync(join(dir, 'models')).isDirectory()) {
+    return { dir, segments };
+  }
+  for (const entry of entries) {
+    if (entry.startsWith('.')) continue;
+    const child = join(dir, entry);
+    if (!statSync(child).isDirectory()) continue;
+    const found = findPackageDir(child, [...segments, entry]);
+    if (found) return found;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Method resolution — sidecar only (it is authoritative and transform-aware)
+// ---------------------------------------------------------------------------
+
+function resolveMethod(op: Operation): MethodResolution | null {
+  const entry = smokePlan.get(`${op.httpMethod.toUpperCase()} ${op.path}`);
+  if (!entry) return null; // absent = URL-builder / split / unsupported op
+  return { service: entry.service, method: entry.method, tier: 'manifest', confidence: 1.0 };
+}
+
+// ---------------------------------------------------------------------------
+// Kotlin argument construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a value as a Kotlin string literal. `$` MUST be escaped — Kotlin
+ * interpolates `$name`/`${expr}` inside string literals, so an unescaped `$` in
+ * spec-derived fixture data would become live code in the driver.
+ */
+function kotlinString(value: unknown): string {
+  const escaped = String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/\$/g, '\\$')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+  return `"${escaped}"`;
+}
+
+/** Serialize a JS value to a Kotlin literal per the sidecar descriptor, or null. */
+function serializeValue(value: unknown, s: Serialize, basePackage: string): string | null {
+  switch (s.kind) {
+    case 'string':
+      return kotlinString(value);
+    case 'int':
+      if (typeof value === 'number') return String(Math.trunc(value));
+      if (typeof value === 'string' && /^-?\d+$/.test(value)) return value;
+      return null;
+    case 'long':
+      if (typeof value === 'number') return `${Math.trunc(value)}L`;
+      if (typeof value === 'string' && /^-?\d+$/.test(value)) return `${value}L`;
+      return null;
+    case 'double':
+      if (typeof value === 'number') return String(value);
+      if (typeof value === 'string' && value !== '' && !Number.isNaN(Number(value))) return value;
+      return null;
+    case 'bool':
+      if (typeof value === 'boolean') return String(value);
+      if (value === 'true' || value === 'false') return value;
+      return null;
+    case 'instant': {
+      if (value instanceof Date) return `kotlinx.datetime.Instant.parse(${kotlinString(value.toISOString())})`;
+      if (typeof value === 'string') {
+        const ms = Date.parse(value);
+        if (!Number.isNaN(ms)) {
+          return `kotlinx.datetime.Instant.parse(${kotlinString(new Date(ms).toISOString())})`;
+        }
+      }
+      return null;
+    }
+    case 'bytes':
+      return typeof value === 'string' ? `${kotlinString(value)}.toByteArray()` : null;
+    case 'enum':
+      // The generated sealed classes expose a total `fromRawValue`, so an
+      // unrecognized fixture value degrades to Unknown rather than throwing.
+      if (typeof value === 'string') {
+        return `${basePackage}.enums.${s.enumType}.fromRawValue(${kotlinString(value)})`;
+      }
+      if (typeof value === 'number') {
+        return `${basePackage}.enums.${s.enumType}.fromRawValue(${Math.trunc(value)})`;
+      }
+      return null;
+    case 'json':
+      if (typeof value === 'string') return `kotlinx.serialization.json.JsonPrimitive(${kotlinString(value)})`;
+      if (typeof value === 'number' || typeof value === 'boolean') {
+        return `kotlinx.serialization.json.JsonPrimitive(${value})`;
+      }
+      return null;
+    case 'array': {
+      if (!Array.isArray(value)) return null;
+      const items = value.map((v) => serializeValue(v, s.element, basePackage));
+      if (items.some((i) => i === null)) return null;
+      return `listOf(${items.join(', ')})`;
+    }
+    case 'map': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+      const entries = Object.entries(value).map(([k, v]) => {
+        const lit = serializeValue(v, s.value, basePackage);
+        return lit === null ? null : `${kotlinString(k)} to ${lit}`;
+      });
+      if (entries.some((e) => e === null)) return null;
+      return entries.length ? `mapOf(${entries.join(', ')})` : 'emptyMap()';
+    }
+    case 'unsupported':
+      return null;
+  }
+}
+
+function pickValue(source: Record<string, unknown>, param: SmokePlanParam): unknown {
+  const label = param.label.replace(/`/g, '');
+  if (label in source) return source[label];
+  if (param.wire in source) return source[param.wire];
+  const camel = toCamelCase(param.wire);
+  if (camel in source) return source[camel];
+  return undefined;
+}
+
+/** Build the Kotlin named-argument list from the sidecar plan, or a skip reason. */
+function buildCallArgs(
+  op: Operation,
+  pathParams: Record<string, string>,
+  spec: ApiSpec,
+  basePackage: string,
+): { args: string[] } | { skip: string } {
+  const entry = smokePlan.get(`${op.httpMethod.toUpperCase()} ${op.path}`);
+  if (!entry) return { skip: 'not in smoke plan' };
+
+  const payload = op.requestBody ? (generateCamelPayload(op, spec) ?? {}) : {};
+  const query: Record<string, unknown> = { ...generateCamelQueryParams(op, spec) };
+  if (op.pagination) query['limit'] = 1;
+
+  const args: string[] = [];
+  for (const p of entry.params) {
+    if (p.source === 'bodyRaw') return { skip: 'raw request body not supported by smoke driver' };
+
+    let value: unknown;
+    if (p.source === 'path') value = pathParams[p.wire];
+    else if (p.source === 'body') value = pickValue(payload, p);
+    else value = pickValue(query, p);
+
+    if (value === undefined || value === null) {
+      if (p.optional) continue;
+      return { skip: `no value for required parameter '${p.label}'` };
+    }
+
+    const literal = serializeValue(value, p.serialize, basePackage);
+    if (literal === null) {
+      if (p.optional) continue;
+      return { skip: `cannot serialize required parameter '${p.label}'` };
+    }
+    // Kotlin named arguments are order-insensitive, so emitting in plan order is
+    // safe even if the generated signature reorders required-before-optional.
+    args.push(`${p.label} = ${literal}`);
+  }
+  return { args };
+}
+
+// ---------------------------------------------------------------------------
+// Kotlin driver generation
+// ---------------------------------------------------------------------------
+
+interface PlannedCall {
+  index: number;
+  op: Operation;
+  irService: string;
+  resolution: MethodResolution;
+  callArgs: string[];
+}
+
+function buildDriverKotlin(port: number, layout: SdkLayout, calls: PlannedCall[]): string {
+  const lines: string[] = [];
+  lines.push(`import ${layout.basePackage}.*`);
+  lines.push('import kotlinx.coroutines.runBlocking');
+  lines.push('');
+  lines.push('fun main() = runBlocking {');
+  lines.push(
+    `    val client = ${layout.clientClass}(Configuration(apiKey = "api_key", baseUrl = "http://localhost:${port}", maxRetries = 0))`,
+  );
+  lines.push('    fun mark(s: String) { System.err.println(s); System.err.flush() }');
+  lines.push('');
+
+  for (const call of calls) {
+    const argStr = call.callArgs.join(', ');
+    lines.push(`    mark("OAGEN_CALL_START:${call.index}")`);
+    lines.push('    try {');
+    lines.push(`        client.${call.resolution.service}.${call.resolution.method}(${argStr})`);
+    lines.push(`        mark("OAGEN_CALL_OK:${call.index}")`);
+    lines.push('    } catch (e: Throwable) {');
+    lines.push(`        mark("OAGEN_CALL_ERROR:${call.index}:\${e.javaClass.name}: \${e.message}")`);
+    lines.push('    }');
+    lines.push(`    mark("OAGEN_CALL_END:${call.index}")`);
+    lines.push('    Thread.sleep(50)');
+    lines.push('');
+  }
+
+  lines.push('}');
+  return lines.join('\n');
+}
+
+function writeGradleProject(tmpDir: string, layout: SdkLayout, mainKt: string): void {
+  const srcDir = join(tmpDir, 'src', 'main', 'kotlin');
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(join(srcDir, 'Main.kt'), mainKt);
+
+  if (!layout.hasRuntime) {
+    writeStubRuntime(srcDir, layout.basePackage, layout.clientClass);
+  }
+
+  const sdkSrcDir = layout.sourceRoot.replace(/\\/g, '/');
+  // The SDK is an Android library, but the generated code is pure JVM (OkHttp +
+  // kotlinx), so compiling it as a `kotlin("jvm")` source set avoids needing the
+  // Android SDK or an emulator just to observe HTTP traffic.
+  const buildGradle = `plugins {
+    kotlin("jvm") version "2.1.10"
+    kotlin("plugin.serialization") version "2.1.10"
+    application
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir("${sdkSrcDir}")
+        }
+    }
+}
+
+dependencies {
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+application {
+    mainClass.set("MainKt")
+}
+`;
+  writeFileSync(join(tmpDir, 'build.gradle.kts'), buildGradle);
+  writeFileSync(join(tmpDir, 'settings.gradle.kts'), 'rootProject.name = "smoke-driver"\n');
+}
+
+/**
+ * Emit a minimal HTTP runtime so the smoke test can run before the SDK repo's
+ * hand-maintained runtime exists.
+ *
+ * The `android` emitter deliberately does NOT generate `Transport`,
+ * `Configuration`, `JsonBody`, `Page`, `PathEncoding`, or the exception
+ * hierarchy — those live in the SDK repo behind `@oagen-ignore-file` (see
+ * `docs/sdk-architecture/android.md`). Without them the generated sources cannot
+ * compile, so a Scenario B bootstrap would have no way to observe wire traffic at
+ * all. This stub implements exactly the surface the generated code calls, and
+ * nothing more: it does not model retries, telemetry, or typed errors, so it is
+ * only ever used to verify the REQUEST the SDK builds. When the SDK repo provides
+ * a real runtime (`internal/Transport.kt`), that one is used instead.
+ */
+function writeStubRuntime(srcDir: string, basePackage: string, clientClass: string): void {
+  const rootDir = join(srcDir, ...basePackage.split('.'));
+  const internalDir = join(rootDir, 'internal');
+  mkdirSync(internalDir, { recursive: true });
+
+  writeFileSync(
+    join(rootDir, 'SmokeRuntime.kt'),
+    `package ${basePackage}
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+data class Configuration(
+    val apiKey: String,
+    val baseUrl: String,
+    val timeoutSeconds: Long = 60,
+    val maxRetries: Int = 0,
+    val clientId: String? = null,
+)
+
+data class RequestOptions(
+    val idempotencyKey: String? = null,
+    val apiKey: String? = null,
+)
+
+@Serializable
+data class ListMetadata(
+    @SerialName("before") val before: String? = null,
+    @SerialName("after") val after: String? = null,
+)
+
+@Serializable
+data class Page<T>(
+    @SerialName("data") val data: List<T>,
+    @SerialName("list_metadata") val listMetadata: ListMetadata = ListMetadata(),
+)
+
+class ${clientClass}(configuration: Configuration) {
+    internal val transport: ${basePackage}.internal.Transport =
+        ${basePackage}.internal.Transport(configuration)
+}
+`,
+  );
+
+  writeFileSync(
+    join(internalDir, 'SmokeTransport.kt'),
+    `package ${basePackage}.internal
+
+import java.net.URLEncoder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import ${basePackage}.Configuration
+import ${basePackage}.Page
+import ${basePackage}.RequestOptions
+
+// Public, not internal: \`Transport.request\` is a public inline function, and a
+// public inline function cannot reference non-public-API declarations.
+val smokeJson: Json = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+    encodeDefaults = false
+    coerceInputValues = true
+}
+
+data class QueryParam(val name: String, val value: String)
+
+object PathEncoding {
+    fun segment(value: String): String = URLEncoder.encode(value, "UTF-8").replace("+", "%20")
+    fun segment(value: Any): String = segment(value.toString())
+}
+
+class JsonBody {
+    private val fields = LinkedHashMap<String, JsonElement>()
+    private var rawElement: JsonElement? = null
+
+    fun set(key: String, value: Any?) {
+        if (value == null) return
+        fields[key] = convert(value)
+    }
+
+    /** Serialize a whole-object request body (an operation with a raw, unexpanded body). */
+    fun <T> setRaw(serializer: kotlinx.serialization.SerializationStrategy<T>, value: T) {
+        rawElement = smokeJson.encodeToJsonElement(serializer, value)
+    }
+
+    /** Use a pre-built JSON element as the entire request body. */
+    fun setRawJson(value: JsonElement) {
+        rawElement = value
+    }
+
+    fun toJsonElement(): JsonElement = rawElement ?: JsonObject(fields)
+
+    fun toJsonObject(): JsonObject = JsonObject(fields)
+
+    private fun convert(value: Any): JsonElement = when (value) {
+        is JsonElement -> value
+        is String -> JsonPrimitive(value)
+        is Number -> JsonPrimitive(value)
+        is Boolean -> JsonPrimitive(value)
+        is ByteArray -> JsonPrimitive(java.util.Base64.getEncoder().encodeToString(value))
+        is List<*> -> JsonArray(value.filterNotNull().map { convert(it) })
+        is Map<*, *> -> JsonObject(
+            value.entries.filter { it.key != null && it.value != null }
+                .associate { it.key.toString() to convert(it.value!!) },
+        )
+        // Generated sealed-class enums carry the wire value in \`rawValue\`;
+        // toString() would yield the object name ("Active" instead of "active").
+        else -> JsonPrimitive(rawValueOf(value) ?: value.toString())
+    }
+
+    private fun rawValueOf(value: Any): String? = try {
+        value.javaClass.getMethod("getRawValue").invoke(value)?.toString()
+    } catch (e: ReflectiveOperationException) {
+        null
+    }
+}
+
+class Transport(val configuration: Configuration) {
+    private val client = OkHttpClient()
+
+    fun buildUrl(path: String, query: List<QueryParam>): String {
+        val base = configuration.baseUrl.trimEnd('/')
+        val qs = query.joinToString("&") {
+            URLEncoder.encode(it.name, "UTF-8") + "=" + URLEncoder.encode(it.value, "UTF-8")
+        }
+        return if (qs.isEmpty()) "$base/$path" else "$base/$path?$qs"
+    }
+
+    suspend fun execute(
+        method: String,
+        path: String,
+        query: List<QueryParam>,
+        body: JsonBody?,
+    ): String = withContext(Dispatchers.IO) {
+        val payload = body?.let { smokeJson.encodeToString(JsonElement.serializer(), it.toJsonElement()) }
+        val requestBody = when {
+            payload != null -> payload.toRequestBody("application/json".toMediaTypeOrNull())
+            method == "POST" || method == "PUT" || method == "PATCH" -> "".toRequestBody(null)
+            else -> null
+        }
+        val request = Request.Builder()
+            .url(buildUrl(path, query))
+            .method(method, requestBody)
+            .header("Authorization", "Bearer " + configuration.apiKey)
+            .header("Content-Type", "application/json")
+            .build()
+        client.newCall(request).execute().use { response ->
+            response.body?.string() ?: ""
+        }
+    }
+
+    suspend inline fun <reified T> request(
+        method: String,
+        path: String,
+        query: List<QueryParam>,
+        body: JsonBody?,
+        options: RequestOptions?,
+    ): T {
+        val text = execute(method, path, query, body)
+        return smokeJson.decodeFromString<T>(if (text.isBlank()) "{}" else text)
+    }
+
+    suspend fun requestVoid(
+        method: String,
+        path: String,
+        query: List<QueryParam>,
+        body: JsonBody?,
+        options: RequestOptions?,
+    ) {
+        execute(method, path, query, body)
+    }
+}
+
+internal fun <T> autoPagingFlow(fetch: suspend (String?) -> Page<T>): Flow<T> = flow {
+    var cursor: String? = null
+    while (true) {
+        val page = fetch(cursor)
+        for (item in page.data) emit(item)
+        cursor = page.listMetadata.after ?: break
+    }
+}
+`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exchange helpers
+// ---------------------------------------------------------------------------
+
+function makeSkippedExchange(op: Operation, service: string, reason: string): CapturedExchange {
+  return {
+    operationId: op.name,
+    service,
+    operationName: op.name,
+    request: { method: op.httpMethod.toUpperCase(), path: op.path, queryParams: {}, body: null },
+    response: { status: 0, body: null },
+    outcome: 'skipped',
+    error: reason,
+    durationMs: 0,
+  };
+}
+
+function buildExchange(
+  op: Operation,
+  service: string,
+  capture: ProxyCapture,
+  durationMs: number,
+  resolution: MethodResolution,
+): CapturedExchange {
+  const status = capture.response.status;
+  return {
+    operationId: op.name,
+    service,
+    operationName: op.name,
+    request: capture.request,
+    response: capture.response,
+    outcome: status >= 200 && status < 300 ? 'success' : 'api-error',
+    unexpectedStatus: isUnexpectedStatus(status, op) || undefined,
+    expectedStatusCodes: getExpectedStatusCodes(op),
+    durationMs,
+    provenance: {
+      resolutionTier: resolution.tier,
+      resolutionConfidence: resolution.confidence,
+      sdkMethodName: `${resolution.service}.${resolution.method}`,
+      captureIndex: 0,
+      totalCaptures: 1,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { spec: specPath, sdkPath, smokeConfig } = parseCliArgs();
+  if (!sdkPath) {
+    console.error('--sdk-path is required');
+    process.exit(1);
+  }
+  const apiKey = process.env.WORKOS_API_KEY || process.env.API_KEY;
+  if (!apiKey) {
+    console.error('API key required. Set WORKOS_API_KEY or API_KEY env var.');
+    process.exit(1);
+  }
+
+  loadSmokeConfig(smokeConfig);
+
+  console.log('Parsing spec...');
+  const spec = await parseSpec(specPath);
+  console.log(`Spec: ${spec.name} v${spec.version}`);
+
+  const layout = detectLayout(sdkPath);
+  console.log(`Kotlin package: ${layout.basePackage} (client: ${layout.clientClass})`);
+  if (!layout.hasRuntime) {
+    console.warn('Warning: SDK provides no internal/Transport.kt — using the smoke stub runtime.');
+    console.warn('  Wire capture is valid; retry/telemetry/typed-error behavior is NOT exercised.');
+  }
+
+  smokePlan = loadSmokePlan(sdkPath);
+  console.log(`Smoke plan: ${smokePlan.size} operations`);
+
+  let targetHost = 'api.workos.com';
+  try {
+    targetHost = new URL(spec.baseUrl).hostname || targetHost;
+  } catch {
+    /* keep default */
+  }
+
+  const captures: ProxyCapture[] = [];
+  const proxy = await createProxyServer(apiKey, targetHost, captures);
+  console.log(`Proxy listening on port ${proxy.port} -> ${targetHost}`);
+
+  const groups = planOperations(spec);
+  const ids = new IdRegistry();
+  const exchanges: CapturedExchange[] = [];
+
+  let successCount = 0;
+  let errorCount = 0;
+  let skipCount = 0;
+  let unexpectedCount = 0;
+
+  const tmpDir = join(tmpdir(), 'oagen-android-smoke');
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+
+  let globalCallIndex = 0;
+  const waveIterator = planWaves(groups, ids, (op) => resolveMethod(op) !== null);
+  let waveResult = waveIterator.next();
+  let waveNumber = 0;
+
+  try {
+    while (!waveResult.done) {
+      const wave: OperationWave = waveResult.value;
+      waveNumber++;
+
+      const plannedCalls: PlannedCall[] = [];
+      for (const { op, irService, pathParams } of wave.calls) {
+        const resolution = resolveMethod(op);
+        if (!resolution) {
+          exchanges.push(makeSkippedExchange(op, irService, 'Not in smoke plan (URL-builder / split op)'));
+          skipCount++;
+          continue;
+        }
+        const built = buildCallArgs(op, pathParams, spec, layout.basePackage);
+        if ('skip' in built) {
+          exchanges.push(makeSkippedExchange(op, irService, built.skip));
+          skipCount++;
+          console.log(`  SKIP ${op.name} -- ${built.skip}`);
+          continue;
+        }
+        plannedCalls.push({ index: globalCallIndex++, op, irService, resolution, callArgs: built.args });
+      }
+
+      if (plannedCalls.length === 0) {
+        waveResult = waveIterator.next();
+        continue;
+      }
+
+      console.log(`\n=== Wave ${waveNumber} (${plannedCalls.length} operations) ===`);
+
+      const mainKt = buildDriverKotlin(proxy.port, layout, plannedCalls);
+      writeGradleProject(tmpDir, layout, mainKt);
+
+      const callResults = new Map<
+        number,
+        { captureIndexBefore: number; captureIndexAfter: number; error?: string; startTime: number; endTime: number }
+      >();
+      let currentCallStart = Date.now();
+      let currentCapturesBefore = 0;
+
+      try {
+        await new Promise<void>((resolvePromise, rejectPromise) => {
+          const child = spawn('gradle', ['run', '--quiet'], {
+            cwd: tmpDir,
+            env: { ...process.env },
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+
+          const timeout = setTimeout(() => {
+            child.kill('SIGKILL');
+            rejectPromise(new Error('Gradle driver timed out after 600s'));
+          }, 600_000);
+
+          let stderrBuf = '';
+          child.stderr.on('data', (data: Buffer) => {
+            stderrBuf += data.toString();
+            const lines = stderrBuf.split('\n');
+            stderrBuf = lines.pop() || '';
+            for (const raw of lines) {
+              const line = raw.trim();
+              if (line.startsWith('OAGEN_CALL_START:')) {
+                currentCallStart = Date.now();
+                currentCapturesBefore = captures.length;
+              } else if (line.startsWith('OAGEN_CALL_OK:')) {
+                const idx = parseInt(line.slice('OAGEN_CALL_OK:'.length), 10);
+                if (!callResults.has(idx)) {
+                  callResults.set(idx, {
+                    captureIndexBefore: currentCapturesBefore,
+                    captureIndexAfter: captures.length,
+                    startTime: currentCallStart,
+                    endTime: Date.now(),
+                  });
+                }
+              } else if (line.startsWith('OAGEN_CALL_ERROR:')) {
+                const rest = line.slice('OAGEN_CALL_ERROR:'.length);
+                const colon = rest.indexOf(':');
+                const idx = parseInt(rest.slice(0, colon), 10);
+                if (!callResults.has(idx)) {
+                  callResults.set(idx, {
+                    captureIndexBefore: currentCapturesBefore,
+                    captureIndexAfter: captures.length,
+                    error: rest.slice(colon + 1),
+                    startTime: currentCallStart,
+                    endTime: Date.now(),
+                  });
+                }
+              } else if (line.startsWith('OAGEN_CALL_END:')) {
+                const idx = parseInt(line.slice('OAGEN_CALL_END:'.length), 10);
+                const existing = callResults.get(idx);
+                if (existing) {
+                  existing.captureIndexAfter = captures.length;
+                  existing.endTime = Date.now();
+                }
+              }
+            }
+          });
+
+          child.on('close', () => {
+            clearTimeout(timeout);
+            resolvePromise();
+          });
+          child.on('error', (err) => {
+            clearTimeout(timeout);
+            rejectPromise(err);
+          });
+        });
+      } catch (err) {
+        console.error(`Wave execution error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      await delay(200);
+
+      for (const call of plannedCalls) {
+        const { index, op, irService, resolution } = call;
+        const isTopLevel = op.pathParams.length === 0;
+        const result = callResults.get(index);
+
+        if (!result) {
+          exchanges.push({
+            ...makeSkippedExchange(op, irService, 'Call did not execute (driver may have failed to build)'),
+            outcome: 'api-error',
+          });
+          errorCount++;
+          console.log(`  X ${op.name} -- did not execute`);
+          continue;
+        }
+
+        const elapsed = result.endTime - result.startTime;
+        if (result.captureIndexAfter <= result.captureIndexBefore) {
+          if (result.error) {
+            exchanges.push({
+              ...makeSkippedExchange(op, irService, result.error),
+              outcome: 'api-error',
+              durationMs: elapsed,
+            });
+            errorCount++;
+            console.log(`  X ${op.name} -- ${result.error.split('\n')[0]}`);
+          } else {
+            exchanges.push(makeSkippedExchange(op, irService, 'No HTTP capture'));
+            skipCount++;
+            console.log(`  SKIP ${op.name} -- no HTTP capture`);
+          }
+          continue;
+        }
+
+        const capture = captures[result.captureIndexAfter - 1];
+        const exchange = buildExchange(op, irService, capture, elapsed, resolution);
+        if (result.error) exchange.error = result.error;
+        ids.extractAndStore(irService, capture.response.body, isTopLevel);
+
+        if (exchange.unexpectedStatus) {
+          unexpectedCount++;
+          console.log(`  ! ${op.name} -> ${capture.response.status} (unexpected)`);
+        } else if (exchange.outcome === 'api-error') {
+          errorCount++;
+          console.log(`  X ${op.name} -> ${capture.response.status}`);
+        } else {
+          successCount++;
+          console.log(`  OK ${op.name} -> ${capture.response.status} (${elapsed}ms)`);
+        }
+        exchanges.push(exchange);
+      }
+
+      waveResult = waveIterator.next();
+    }
+  } finally {
+    if (existsSync(tmpDir) && !process.env.OAGEN_SMOKE_KEEP_TMP) rmSync(tmpDir, { recursive: true, force: true });
+    await proxy.close();
+  }
+
+  if (waveResult.done && waveResult.value) {
+    for (const unresolved of waveResult.value) {
+      exchanges.push(makeSkippedExchange(unresolved.operation, unresolved.service, 'Missing path param IDs'));
+      skipCount++;
+    }
+  }
+
+  const results: SmokeResults = {
+    source: 'sdk-android',
+    timestamp: new Date().toISOString(),
+    specVersion: spec.version,
+    exchanges,
+  };
+  const outputPath = 'smoke-results-sdk-android.json';
+  writeFileSync(outputPath, JSON.stringify(results, null, 2));
+  console.log(`\nResults written to ${outputPath}`);
+
+  console.log('\n=== Summary ===');
+  console.log(`  Total:      ${exchanges.length}`);
+  console.log(`  Success:    ${successCount}`);
+  console.log(`  API errors: ${errorCount}`);
+  console.log(`  Skipped:    ${skipCount}`);
+  if (unexpectedCount > 0) console.log(`  Unexpected: ${unexpectedCount}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/src/android/client.ts
+++ b/src/android/client.ts
@@ -1,0 +1,74 @@
+import type { EmitterContext, GeneratedFile } from '@workos/oagen';
+import { groupByMount } from '../shared/resolved-ops.js';
+import { renderImportBlock } from './imports.js';
+import {
+  clientClassName,
+  resourceTypeName,
+  accessorName,
+  subPackage,
+  mainSourcePath,
+  withResolvedOps,
+} from './naming.js';
+import { generateSmokePlan } from './smoke-plan.js';
+
+/**
+ * Generate the spec-driven client surface: a `{Namespace}ClientResources.kt` file
+ * of extension properties, one per mount group, plus the smoke-plan sidecar.
+ *
+ * The client class core (configuration, transport, constructors) and the rest of
+ * the HTTP runtime (Configuration, Transport, exceptions, pagination, JSON) are
+ * hand-maintained in the SDK repo with `@oagen-ignore-file`, as are the repo
+ * resources (`build.gradle.kts`, `AndroidManifest.xml`, `proguard-rules.pro`).
+ *
+ * Extension properties are used rather than members because a generated file
+ * cannot add members to a hand-maintained class. Same-module extensions can still
+ * read the client's `internal val transport`, so the runtime keeps its narrow
+ * visibility. This is the Kotlin analogue of the Swift `extension` the iOS
+ * emitter emits.
+ */
+export function generateClient(ctx: EmitterContext): GeneratedFile[] {
+  const rctx = withResolvedOps(ctx);
+  return [
+    {
+      path: mainSourcePath(rctx, '', `${clientClassName(rctx)}Resources`),
+      content: renderResourceAccessors(rctx),
+      overwriteExisting: true,
+    },
+    generateSmokePlan(rctx),
+  ];
+}
+
+function renderResourceAccessors(ctx: EmitterContext): string {
+  const clientName = clientClassName(ctx);
+  const pkg = subPackage(ctx, '');
+  const groups = [...groupByMount(ctx).values()].sort((a, b) => a.name.localeCompare(b.name));
+
+  const imports = new Set<string>();
+  for (const group of groups) {
+    imports.add(`${subPackage(ctx, 'resources')}.${resourceTypeName(group.name, ctx)}`);
+  }
+
+  const lines: string[] = [];
+  lines.push(`package ${pkg}`);
+  lines.push('');
+  const importLines = renderImportBlock(imports, pkg);
+  if (importLines.length > 0) {
+    lines.push(...importLines);
+    lines.push('');
+  }
+  lines.push(`// The spec-driven resource accessors for [${clientName}]. The client class`);
+  lines.push(`// itself is hand-maintained in ${clientName}.kt.`);
+
+  let first = true;
+  for (const group of groups) {
+    const resource = resourceTypeName(group.name, ctx);
+    const accessor = accessorName(group.name);
+    if (!first) lines.push('');
+    first = false;
+    lines.push('');
+    lines.push(`/** Operations for the ${resource} API. */`);
+    lines.push(`public val ${clientName}.${accessor}: ${resource}`);
+    lines.push(`    get() = ${resource}(transport)`);
+  }
+  return lines.join('\n');
+}

--- a/src/android/doc-comments.ts
+++ b/src/android/doc-comments.ts
@@ -1,0 +1,80 @@
+import { escapeBlockComment } from '@workos/oagen';
+
+export interface DocParameter {
+  name: string;
+  description?: string;
+  deprecated?: boolean;
+}
+
+/**
+ * Render a KDoc block from a free-form description.
+ *
+ * Spec descriptions are attacker-influenceable free text and KDoc is a `/* … *\/`
+ * block comment, so every description passes through `escapeBlockComment` — an
+ * embedded comment terminator would otherwise close the comment and turn the
+ * remainder of the text into live Kotlin source.
+ */
+export function renderDocComment(description: string | undefined, indent: string): string[] {
+  const lines = docBodyLines(description);
+  if (lines.length === 0) return [];
+  if (lines.length === 1) return [`${indent}/** ${lines[0]} */`];
+  return [`${indent}/**`, ...lines.map((line) => (line ? `${indent} * ${line}` : `${indent} *`)), `${indent} */`];
+}
+
+/**
+ * Render a KDoc block for a method: a description plus `@param` / `@return` tags.
+ * Returns an empty array when there is nothing to document.
+ */
+export function renderMethodDoc(
+  description: string | undefined,
+  params: DocParameter[],
+  returns: string | undefined,
+  indent: string,
+): string[] {
+  const body = docBodyLines(description);
+  const tags: string[] = [];
+  for (const param of params) {
+    tags.push(`@param ${param.name} ${renderParameterDescription(param)}`);
+  }
+  if (returns) tags.push(`@return ${escapeBlockComment(returns)}`);
+  if (body.length === 0 && tags.length === 0) return [];
+
+  const out: string[] = [`${indent}/**`];
+  for (const line of body) out.push(line ? `${indent} * ${line}` : `${indent} *`);
+  if (body.length > 0 && tags.length > 0) out.push(`${indent} *`);
+  for (const tag of tags) out.push(`${indent} * ${tag}`);
+  out.push(`${indent} */`);
+  return out;
+}
+
+/** Normalize and escape a description into KDoc body lines. */
+function docBodyLines(description: string | undefined): string[] {
+  if (!description) return [];
+  const trimmed = description.trim();
+  if (!trimmed) return [];
+  return escapeBlockComment(trimmed)
+    .split('\n')
+    .map((line) => line.trim());
+}
+
+function renderParameterDescription(param: DocParameter): string {
+  const firstLine =
+    param.description
+      ?.trim()
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? '';
+  if (firstLine) {
+    const escaped = escapeBlockComment(firstLine);
+    if (/^deprecated\b/i.test(escaped)) return escaped;
+    return param.deprecated ? `Deprecated. ${escaped}` : escaped;
+  }
+
+  const fallback = param.name
+    .split('`')
+    .join('')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .toLowerCase();
+  return param.deprecated ? `Deprecated. The ${fallback} value.` : `The ${fallback} value.`;
+}

--- a/src/android/enums.ts
+++ b/src/android/enums.ts
@@ -1,0 +1,149 @@
+import type { Enum, EnumValue, EmitterContext, GeneratedFile } from '@workos/oagen';
+import { toPascalCase } from '@workos/oagen';
+import { isEnumInScope } from '../shared/resolved-ops.js';
+import { typeName, fileName, mainSourcePath, subPackage, ktStringLiteral } from './naming.js';
+import { renderImportBlock } from './imports.js';
+import { renderDocComment } from './doc-comments.js';
+
+/**
+ * Generate one forward-compatible sealed-class file per IR enum.
+ *
+ * A Kotlin `enum class` cannot carry an unrecognized wire value, so an unknown
+ * server value would have to re-serialize as the wrong token — breaking wire
+ * parity on round-trip. A sealed class preserves it in `Unknown(value)`, which
+ * matches the iOS emitter's `case unknown(String)` and still gives `when`
+ * exhaustiveness checking at the call site.
+ */
+export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
+  const files: GeneratedFile[] = [];
+  for (const e of enums) {
+    // Scoped (`--services`) runs leave out-of-scope enum files untouched on disk.
+    if (!isEnumInScope(e.name, ctx)) continue;
+    files.push({
+      path: mainSourcePath(ctx, 'enums', fileName(e.name)),
+      content: renderEnum(e, ctx),
+    });
+  }
+  return files;
+}
+
+interface RenderedCase {
+  id: string;
+  value: string | number;
+  description?: string;
+  deprecated?: boolean;
+}
+
+/**
+ * Derive a unique, valid Kotlin object name from an enum value. `Unknown`,
+ * `Serializer`, and `Companion` are reserved so a real wire value with one of
+ * those names is suffixed rather than colliding with generated members.
+ */
+function caseIdentifier(source: string, seen: Set<string>): string {
+  let base = toPascalCase(source);
+  if (base === '' || /^[0-9]/.test(base)) base = `Value${base}`;
+  let candidate = base;
+  let n = 2;
+  while (seen.has(candidate)) {
+    candidate = `${base}${n++}`;
+  }
+  seen.add(candidate);
+  return candidate;
+}
+
+function renderEnum(e: Enum, ctx: EmitterContext): string {
+  const name = typeName(e.name);
+  const pkg = subPackage(ctx, 'enums');
+  const isNumeric = e.values.length > 0 && e.values.every((v) => typeof v.value === 'number');
+  const rawType = isNumeric ? 'Int' : 'String';
+  const primitiveKind = isNumeric ? 'PrimitiveKind.INT' : 'PrimitiveKind.STRING';
+  const decodeCall = isNumeric ? 'decoder.decodeInt()' : 'decoder.decodeString()';
+  const encodeCall = isNumeric ? 'encoder.encodeInt(value.rawValue)' : 'encoder.encodeString(value.rawValue)';
+
+  const seen = new Set<string>(['Unknown', 'Serializer', 'Companion']);
+  const cases: RenderedCase[] = e.values.map((ev: EnumValue) => ({
+    id: caseIdentifier(String(ev.name ?? ev.value), seen),
+    value: ev.value,
+    description: ev.description,
+    deprecated: ev.deprecated,
+  }));
+
+  const literal = (v: string | number): string => (isNumeric ? String(v) : ktStringLiteral(String(v)));
+
+  const imports = [
+    'kotlinx.serialization.KSerializer',
+    'kotlinx.serialization.Serializable',
+    'kotlinx.serialization.descriptors.PrimitiveKind',
+    'kotlinx.serialization.descriptors.PrimitiveSerialDescriptor',
+    'kotlinx.serialization.descriptors.SerialDescriptor',
+    'kotlinx.serialization.encoding.Decoder',
+    'kotlinx.serialization.encoding.Encoder',
+  ];
+
+  const lines: string[] = [];
+  lines.push(`package ${pkg}`);
+  lines.push('');
+  lines.push(...renderImportBlock(imports, pkg));
+  lines.push('');
+  lines.push(...renderDocComment(`Enumeration of valid ${name} values.`, ''));
+  lines.push(`@Serializable(with = ${name}.Serializer::class)`);
+  lines.push(`public sealed class ${name}(public val rawValue: ${rawType}) {`);
+
+  for (const c of cases) {
+    lines.push(...renderDocComment(c.description, '    '));
+    if (c.deprecated) lines.push('    @Deprecated("This value is deprecated.")');
+    lines.push(`    public data object ${c.id} : ${name}(${literal(c.value)})`);
+  }
+
+  lines.push('');
+  lines.push('    /** A value not known at SDK generation time. */');
+  lines.push(`    public data class Unknown(public val value: ${rawType}) : ${name}(value)`);
+  lines.push('');
+
+  // Companion: the known-value list plus a total raw-value parser.
+  lines.push('    public companion object {');
+  if (cases.length === 0) {
+    lines.push(`        public val allKnownValues: List<${name}> = emptyList()`);
+  } else {
+    const known = cases.map((c) => c.id).join(', ');
+    const singleLine = `        public val allKnownValues: List<${name}> = listOf(${known})`;
+    if (singleLine.length <= 120) {
+      lines.push(singleLine);
+    } else {
+      lines.push(`        public val allKnownValues: List<${name}> =`);
+      lines.push('            listOf(');
+      for (const c of cases) lines.push(`                ${c.id},`);
+      lines.push('            )');
+    }
+  }
+  lines.push('');
+  lines.push(`        /** Parse a wire value, mapping anything unrecognized to [Unknown]. */`);
+  lines.push(`        public fun fromRawValue(rawValue: ${rawType}): ${name} =`);
+  if (cases.length === 0) {
+    lines.push('            Unknown(rawValue)');
+  } else {
+    lines.push('            when (rawValue) {');
+    for (const c of cases) {
+      lines.push(`                ${literal(c.value)} -> ${c.id}`);
+    }
+    lines.push('                else -> Unknown(rawValue)');
+    lines.push('            }');
+  }
+  lines.push('    }');
+  lines.push('');
+
+  // Generated serializer: emitted explicitly rather than relying on any implicit
+  // conformance, so encoding always round-trips `rawValue` verbatim.
+  lines.push(`    internal object Serializer : KSerializer<${name}> {`);
+  lines.push('        override val descriptor: SerialDescriptor =');
+  lines.push(`            PrimitiveSerialDescriptor(${ktStringLiteral(name)}, ${primitiveKind})`);
+  lines.push('');
+  lines.push(`        override fun deserialize(decoder: Decoder): ${name} = fromRawValue(${decodeCall})`);
+  lines.push('');
+  lines.push(`        override fun serialize(encoder: Encoder, value: ${name}) {`);
+  lines.push(`            ${encodeCall}`);
+  lines.push('        }');
+  lines.push('    }');
+  lines.push('}');
+  return lines.join('\n');
+}

--- a/src/android/fixtures.ts
+++ b/src/android/fixtures.ts
@@ -1,0 +1,139 @@
+import type { Model, TypeRef, Enum } from '@workos/oagen';
+import { propertyName } from './naming.js';
+
+/**
+ * JSON fixture generation for the generated Kotlin test suites. Fixtures are
+ * embedded as Kotlin string literals rather than `resources/` files, so no Gradle
+ * test-resource wiring is needed.
+ *
+ * Fixtures must decode into the emitted data classes, so callers pass the SAME
+ * model set the model generator used (enriched + union-flattened).
+ */
+
+/** Prefix mapping for generating realistic ID fixture values. */
+const ID_PREFIXES: Record<string, string> = {
+  Connection: 'conn_',
+  Organization: 'org_',
+  OrganizationMembership: 'om_',
+  User: 'user_',
+  Directory: 'directory_',
+  DirectoryGroup: 'dir_grp_',
+  DirectoryUser: 'dir_usr_',
+  Invitation: 'inv_',
+  Session: 'session_',
+  AuthenticationFactor: 'auth_factor_',
+  EmailVerification: 'email_verification_',
+  MagicAuth: 'magic_auth_',
+  PasswordReset: 'password_reset_',
+};
+
+export function generateModelFixture(
+  model: Model,
+  modelMap: Map<string, Model>,
+  enumMap: Map<string, Enum>,
+  depth = 0,
+): Record<string, unknown> {
+  const fixture: Record<string, unknown> = {};
+
+  // Dedup by the Kotlin property name to mirror the emitted data class
+  // (flattened discriminated unions can repeat fields).
+  const seenProps = new Set<string>();
+  for (const field of model.fields) {
+    const prop = propertyName(field.domainName ?? field.name);
+    if (seenProps.has(prop)) continue;
+    seenProps.add(prop);
+    fixture[field.name] =
+      field.example !== undefined
+        ? field.example
+        : generateFieldValue(field.type, field.name, model.name, modelMap, enumMap, depth);
+  }
+
+  if (model.discriminator) {
+    const first = Object.entries(model.discriminator.mapping)[0];
+    if (first) {
+      const [firstValue, variantName] = first;
+      fixture[model.discriminator.property] = firstValue;
+      const variantModel = modelMap.get(variantName);
+      if (variantModel) {
+        for (const field of variantModel.fields) {
+          if (!(field.name in fixture)) {
+            fixture[field.name] =
+              field.example !== undefined
+                ? field.example
+                : generateFieldValue(field.type, field.name, model.name, modelMap, enumMap, depth);
+          }
+        }
+      }
+    }
+  }
+
+  return fixture;
+}
+
+function generateFieldValue(
+  ref: TypeRef,
+  fName: string,
+  modelName: string,
+  modelMap: Map<string, Model>,
+  enumMap: Map<string, Enum>,
+  depth: number,
+): unknown {
+  switch (ref.kind) {
+    case 'primitive':
+      return generatePrimitiveValue(ref.type, ref.format, fName, modelName);
+    case 'literal':
+      return ref.value;
+    case 'enum': {
+      const e = enumMap.get(ref.name);
+      return e?.values[0]?.value ?? 'unknown';
+    }
+    case 'model': {
+      // Bound recursion so self-referential models terminate.
+      const nested = modelMap.get(ref.name);
+      if (nested && depth < 4) return generateModelFixture(nested, modelMap, enumMap, depth + 1);
+      return {};
+    }
+    case 'array': {
+      if (ref.items.kind === 'enum') {
+        const e = enumMap.get(ref.items.name);
+        if (e && e.values.length > 0) return e.values.map((v) => v.value);
+      }
+      return [generateFieldValue(ref.items, fName, modelName, modelMap, enumMap, depth)];
+    }
+    case 'nullable':
+      return generateFieldValue(ref.inner, fName, modelName, modelMap, enumMap, depth);
+    case 'union':
+      if (ref.variants.length > 0) {
+        return generateFieldValue(ref.variants[0], fName, modelName, modelMap, enumMap, depth);
+      }
+      return null;
+    case 'map':
+      return { key: generateFieldValue(ref.valueType, 'value', modelName, modelMap, enumMap, depth) };
+  }
+}
+
+function generatePrimitiveValue(type: string, format: string | undefined, name: string, modelName: string): unknown {
+  switch (type) {
+    case 'string':
+      if (format === 'date-time') return '2023-01-01T00:00:00.000Z';
+      if (format === 'date') return '2023-01-01';
+      if (format === 'uuid') return '00000000-0000-0000-0000-000000000000';
+      if (format === 'byte' || format === 'binary') return 'dGVzdA==';
+      if (name === 'id') return `${ID_PREFIXES[modelName] ?? ''}01234`;
+      if (name.includes('id')) return `${name}_01234`;
+      if (name.includes('email')) return 'test@example.com';
+      if (name.includes('url') || name.includes('uri')) return 'https://example.com';
+      if (name.includes('name')) return 'Test';
+      return `test_${name}`;
+    case 'integer':
+      return 1;
+    case 'number':
+      return 1.5;
+    case 'boolean':
+      return true;
+    case 'unknown':
+      return {};
+    default:
+      return null;
+  }
+}

--- a/src/android/imports.ts
+++ b/src/android/imports.ts
@@ -1,0 +1,88 @@
+import type { EmitterContext } from '@workos/oagen';
+import { subPackage, typeName } from './naming.js';
+
+/**
+ * Kotlin types that are always in scope (stdlib) or resolved by an explicit
+ * import the generator adds directly, so they must never be treated as a
+ * generated model/enum reference needing a package import.
+ */
+const BUILT_IN_TYPES = new Set([
+  'Any',
+  'Boolean',
+  'ByteArray',
+  'Double',
+  'Instant',
+  'Int',
+  'JsonElement',
+  'List',
+  'Long',
+  'Map',
+  'Nothing',
+  'Set',
+  'String',
+  'Unit',
+]);
+
+/**
+ * Runtime types that live in the SDK's root package (hand-maintained). A
+ * generated file in a sub-package must import them explicitly.
+ */
+const ROOT_PACKAGE_TYPES = new Set(['Configuration', 'ListMetadata', 'Page', 'RequestOptions']);
+
+/** Runtime types that live in the SDK's `internal` package (hand-maintained). */
+const INTERNAL_PACKAGE_TYPES = new Set(['JsonBody', 'PathEncoding', 'QueryParam', 'Transport']);
+
+/**
+ * Extract candidate Kotlin type identifiers from a type expression.
+ * `List<Organization>?` → `['List', 'Organization']`.
+ */
+export function extractTypeNames(expr: string): string[] {
+  return expr.match(/\b[A-Z][A-Za-z0-9_]*\b/g) ?? [];
+}
+
+/**
+ * Resolve the imports required by a set of Kotlin type expressions: generated
+ * models and enums resolve to their sub-package, hand-maintained runtime types
+ * to the root or `internal` package. Unknown identifiers are skipped rather than
+ * guessed, so a bad type never produces a dangling import.
+ */
+export function resolveTypeImports(ctx: EmitterContext, exprs: Iterable<string>): string[] {
+  const modelNames = new Set(ctx.spec.models.map((m) => typeName(m.name)));
+  const enumNames = new Set(ctx.spec.enums.map((e) => typeName(e.name)));
+
+  const imports = new Set<string>();
+  for (const expr of exprs) {
+    for (const name of extractTypeNames(expr)) {
+      if (BUILT_IN_TYPES.has(name)) continue;
+      if (modelNames.has(name)) {
+        imports.add(`${subPackage(ctx, 'models')}.${name}`);
+      } else if (enumNames.has(name)) {
+        imports.add(`${subPackage(ctx, 'enums')}.${name}`);
+      } else if (ROOT_PACKAGE_TYPES.has(name)) {
+        imports.add(`${subPackage(ctx, '')}.${name}`);
+      } else if (INTERNAL_PACKAGE_TYPES.has(name)) {
+        imports.add(`${subPackage(ctx, 'internal')}.${name}`);
+      }
+    }
+  }
+  return [...imports];
+}
+
+/**
+ * Render a deterministic, ktlint-compatible import block: lexicographically
+ * sorted, de-duplicated, no blank-line grouping. Self-imports (types already in
+ * `currentPackage`) are dropped — Kotlin rejects an import from the file's own
+ * package as redundant, and ktlint flags it.
+ */
+export function renderImportBlock(imports: Iterable<string>, currentPackage?: string): string[] {
+  const unique = new Set<string>();
+  for (const imp of imports) {
+    if (currentPackage && imp.startsWith(`${currentPackage}.`)) {
+      // Same-package import only if it is a direct child (no further dots).
+      const tail = imp.slice(currentPackage.length + 1);
+      if (!tail.includes('.')) continue;
+    }
+    unique.add(imp);
+  }
+  return [...unique].sort().map((imp) => `import ${imp}`);
+}

--- a/src/android/imports.ts
+++ b/src/android/imports.ts
@@ -1,5 +1,6 @@
 import type { EmitterContext } from '@workos/oagen';
 import { subPackage, typeName } from './naming.js';
+import { getSyntheticEnums } from '../shared/model-utils.js';
 
 /**
  * Kotlin types that are always in scope (stdlib) or resolved by an explicit
@@ -48,7 +49,12 @@ export function extractTypeNames(expr: string): string[] {
  */
 export function resolveTypeImports(ctx: EmitterContext, exprs: Iterable<string>): string[] {
   const modelNames = new Set(ctx.spec.models.map((m) => typeName(m.name)));
-  const enumNames = new Set(ctx.spec.enums.map((e) => typeName(e.name)));
+  // Synthetic enums (minted from inline oneOf sets during model enrichment) are
+  // emitted into the enums package but are absent from `ctx.spec.enums`. Without
+  // them here, a model field typed as one would generate no import and the file
+  // would not compile. The WorkOS spec currently mints none, so this changes no
+  // output today.
+  const enumNames = new Set([...ctx.spec.enums, ...getSyntheticEnums()].map((e) => typeName(e.name)));
 
   const imports = new Set<string>();
   for (const expr of exprs) {

--- a/src/android/index.ts
+++ b/src/android/index.ts
@@ -1,0 +1,129 @@
+import type {
+  Emitter,
+  EmitterContext,
+  FormatCommand,
+  GeneratedFile,
+  ApiSpec,
+  Model,
+  Enum,
+  Service,
+} from '@workos/oagen';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { AUTOGEN_NOTICE } from '../shared/file-header.js';
+import { enrichModelsFromSpec, getSyntheticEnums } from '../shared/model-utils.js';
+import { flattenDiscriminatedUnionFields } from '../shared/union-flatten.js';
+import { generateModels } from './models.js';
+import { generateEnums } from './enums.js';
+import { generateResources } from './resources.js';
+import { generateClient } from './client.js';
+import { generateTests } from './tests.js';
+import { buildOperationsMap } from './manifest.js';
+
+/**
+ * Normalize generated files: strip trailing whitespace from every line (ktlint's
+ * no-trailing-spaces rule), ensure a trailing newline, and mark every file
+ * generator-owned (`overwriteExisting`, the Go/iOS pattern) — this is a fresh,
+ * fully-generated SDK, so regeneration must replace stale content rather than
+ * merge with it.
+ */
+function normalize(files: GeneratedFile[]): GeneratedFile[] {
+  for (const f of files) {
+    // The smoke-plan sidecar manages its own flags; don't clobber them.
+    if (f.integrateTarget !== false) f.overwriteExisting = true;
+    if (!f.content) continue;
+    f.content = f.content.replace(/[ \t]+$/gm, '');
+    if (!f.content.endsWith('\n')) {
+      f.content += '\n';
+    }
+  }
+  return files;
+}
+
+/**
+ * Restore fields on discriminated base models that `enrichModelsFromSpec` clears
+ * for sum-type-capable languages, then flatten oneOf/allOf variant fields so the
+ * emitted flat data classes carry every variant's fields. Mirrors the Go/iOS/
+ * Kotlin base-model handling.
+ */
+function prepareModels(models: Model[], enums: Enum[]): Model[] {
+  const enriched = enrichModelsFromSpec(models, enums);
+  const originalByName = new Map(models.map((m) => [m.name, m]));
+  const restored = enriched.map((m) => {
+    if (m.discriminator && m.fields.length === 0) {
+      const original = originalByName.get(m.name);
+      if (original && original.fields.length > 0) return { ...m, fields: original.fields };
+    }
+    return m;
+  });
+  return flattenDiscriminatedUnionFields(restored);
+}
+
+/**
+ * The Android / Kotlin emitter. Generates the spec-driven surface of an Android
+ * library: kotlinx.serialization data classes, forward-compatible sealed-class
+ * enums, coroutine (`suspend`) resource methods over OkHttp, and per-mount JUnit 5
+ * suites. The HTTP runtime and Gradle files are hand-maintained in the SDK repo.
+ * See `docs/sdk-architecture/android.md`.
+ */
+export const androidEmitter: Emitter = {
+  language: 'android',
+
+  generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
+    return normalize(generateModels(prepareModels(models, ctx.spec.enums), ctx));
+  },
+
+  generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
+    // Include synthetic enums minted during model enrichment (inline oneOf sets).
+    const syntheticEnums = getSyntheticEnums();
+    return normalize(generateEnums([...enums, ...syntheticEnums], ctx));
+  },
+
+  generateResources(services: Service[], ctx: EmitterContext): GeneratedFile[] {
+    return normalize(generateResources(services, ctx));
+  },
+
+  generateClient(_spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
+    return normalize(generateClient(ctx));
+  },
+
+  generateErrors(): GeneratedFile[] {
+    // The exception hierarchy is hand-maintained in the SDK repo (@oagen-ignore-file).
+    return [];
+  },
+
+  generateTypeSignatures(): GeneratedFile[] {
+    // Kotlin uses inline type annotations -- no separate type-signature files.
+    return [];
+  },
+
+  generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
+    // Pass enriched models so fixtures and sample constructions see the same
+    // field set the model generator emitted.
+    const enrichedModels = prepareModels(spec.models, spec.enums);
+    const enrichedSpec: ApiSpec = { ...spec, models: enrichedModels };
+    return normalize(generateTests(enrichedSpec, { ...ctx, spec: enrichedSpec }));
+  },
+
+  buildOperationsMap(spec: ApiSpec, ctx: EmitterContext) {
+    return buildOperationsMap(spec, ctx);
+  },
+
+  fileHeader(): string {
+    return `// ${AUTOGEN_NOTICE}`;
+  },
+
+  formatCommand(targetDir: string): FormatCommand | null {
+    // `./gradlew ktlintFormat` fixes whitespace, import ordering, and most
+    // wrapping/line-length violations across the whole source set. The file list
+    // oagen appends is ignored — Gradle reformats every Kotlin file. oagen's
+    // writer already runs the spawned process with `cwd: targetDir`, so we must
+    // not `cd` again (a relative `targetDir` would re-resolve against itself).
+    if (!fs.existsSync(path.join(targetDir, 'gradlew'))) return null;
+    return {
+      cmd: 'bash',
+      args: ['-c', './gradlew ktlintFormat --quiet >/dev/null 2>&1; true'],
+    };
+  },
+};

--- a/src/android/index.ts
+++ b/src/android/index.ts
@@ -120,10 +120,29 @@ export const androidEmitter: Emitter = {
     // oagen appends is ignored — Gradle reformats every Kotlin file. oagen's
     // writer already runs the spawned process with `cwd: targetDir`, so we must
     // not `cd` again (a relative `targetDir` would re-resolve against itself).
+    // Must exit non-zero on failure, and must not swallow stderr.
+    //
+    // This used to end in `>/dev/null 2>&1; true`, which hid the most common
+    // failure completely: `gradlew` needs a JDK, and a shell running
+    // `oagen generate` frequently has no `JAVA_HOME`, so formatting never ran and
+    // every generation silently left its output unformatted. CI does not hit that
+    // — `setup-sdk-runtime` installs the JDK before the generate step.
+    //
+    // The exit code is what makes the failure visible at all: oagen's
+    // `formatTargetFiles` reports `[oagen] formatter batch failed: …` from its
+    // catch block and otherwise discards the child's output entirely. Exiting 0
+    // with a message on stderr therefore prints nothing — the message goes into a
+    // buffer nobody reads. The trailing marker below rides along in the reported
+    // error so the cause is greppable next to Gradle's own stderr.
+    //
+    // A non-zero exit does not fail generation; oagen catches it and continues.
     if (!fs.existsSync(path.join(targetDir, 'gradlew'))) return null;
+    const marker =
+      '[android] ktlintFormat failed, so generated files are unformatted. ' +
+      'Most often no JDK on PATH (JAVA_HOME unset). Run ./script/ci in the SDK repo to format.';
     return {
       cmd: 'bash',
-      args: ['-c', './gradlew ktlintFormat --quiet >/dev/null 2>&1; true'],
+      args: ['-c', `./gradlew ktlintFormat --quiet || { echo "${marker}" >&2; exit 1; }`],
     };
   },
 };

--- a/src/android/index.ts
+++ b/src/android/index.ts
@@ -135,7 +135,19 @@ export const androidEmitter: Emitter = {
     // buffer nobody reads. The trailing marker below rides along in the reported
     // error so the cause is greppable next to Gradle's own stderr.
     //
-    // A non-zero exit does not fail generation; oagen catches it and continues.
+    // A non-zero exit does not fail generation: oagen catches it and continues.
+    // That is intentional and not something this hook can change — `FormatCommand`
+    // is `{cmd, args, batchSize}` with no failure-policy field, and the catch in
+    // `formatTargetFiles` is unconditional. Making it fatal would also be the
+    // wrong trade: formatting is cosmetic, so a missing JDK would break
+    // `oagen generate` on machines where the emitted Kotlin is perfectly valid.
+    //
+    // Correctness is gated after generation instead, by the SDK's own `script/ci`
+    // (`set -euo pipefail`, then ktlintFormat → ktlintCheck → test). CI runs it
+    // immediately after the generate step and does not allow it to fail, so
+    // invalid Kotlin fails the build there rather than reaching a consumer.
+    // If generation should ever hard-fail on a formatter error, the knob belongs
+    // on `FormatCommand` in oagen, not here.
     if (!fs.existsSync(path.join(targetDir, 'gradlew'))) return null;
     const marker =
       '[android] ktlintFormat failed, so generated files are unformatted. ' +

--- a/src/android/manifest.ts
+++ b/src/android/manifest.ts
@@ -1,0 +1,43 @@
+import type { ApiSpec, EmitterContext, OperationsMap } from '@workos/oagen';
+import { groupByMount } from '../shared/resolved-ops.js';
+import { accessorName, resolveMethodName, methodName, withResolvedOps } from './naming.js';
+
+/**
+ * Build the `"METHOD /path" -> { sdkMethod, service }` map written into
+ * `.oagen-manifest.json`. Uses the same mount grouping and method-name resolution
+ * as `generateResources`, so the smoke runner resolves the exact methods the
+ * emitter produced. Split operations map to an array (one entry per wrapper).
+ * URL builders are skipped — there is no HTTP call to verify. Reserved-word
+ * back-ticks are stripped: the manifest records the logical selector, and the
+ * smoke generator re-escapes if needed.
+ */
+export function buildOperationsMap(_spec: ApiSpec, ctx: EmitterContext): OperationsMap {
+  const rctx = withResolvedOps(ctx);
+  const operations: OperationsMap = {};
+
+  for (const group of groupByMount(rctx).values()) {
+    const service = strip(accessorName(group.name));
+    for (const resolved of group.resolvedOps) {
+      if (resolved.urlBuilder) continue;
+      const op = resolved.operation;
+      const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
+      if (resolved.wrappers && resolved.wrappers.length > 0) {
+        operations[httpKey] = resolved.wrappers.map((w) => ({
+          sdkMethod: strip(methodName(w.name)),
+          service,
+        }));
+      } else {
+        operations[httpKey] = {
+          sdkMethod: strip(resolveMethodName(op, group.name, rctx)),
+          service,
+        };
+      }
+    }
+  }
+
+  return operations;
+}
+
+function strip(name: string): string {
+  return name.split('`').join('');
+}

--- a/src/android/models.ts
+++ b/src/android/models.ts
@@ -1,0 +1,112 @@
+import type { Model, Field, EmitterContext, GeneratedFile } from '@workos/oagen';
+import { toCamelCase } from '@workos/oagen';
+import { isModelInScope } from '../shared/resolved-ops.js';
+import { typeName, fileName, propertyName, mainSourcePath, subPackage, ktStringLiteral } from './naming.js';
+import { fieldKotlinType, implicitImportsFor } from './type-map.js';
+import { resolveTypeImports, renderImportBlock } from './imports.js';
+import { renderDocComment } from './doc-comments.js';
+
+/**
+ * Generate one `@Serializable data class` file per IR model.
+ *
+ * Each class gets: a KDoc block, primary-constructor `val` properties (camelCase,
+ * required first then nullable-with-`= null`), and an explicit `@SerialName` per
+ * property mapping it to its wire key.
+ */
+export function generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
+  const files: GeneratedFile[] = [];
+  for (const model of models) {
+    // Scoped (`--services`) runs leave out-of-scope model files untouched on disk.
+    if (!isModelInScope(model.name, ctx)) continue;
+    files.push({
+      path: mainSourcePath(ctx, 'models', fileName(model.name)),
+      content: renderModel(model, ctx),
+    });
+  }
+  return files;
+}
+
+interface RenderedField {
+  prop: string;
+  type: string;
+  optional: boolean;
+  field: Field;
+}
+
+function renderedField(field: Field): RenderedField {
+  const prop = propertyName(field.domainName ?? field.name);
+  const type = fieldKotlinType(field.type, field.required);
+  return { prop, type, optional: type.endsWith('?'), field };
+}
+
+function renderModel(model: Model, ctx: EmitterContext): string {
+  const name = typeName(model.name);
+  const pkg = subPackage(ctx, 'models');
+
+  // Deduplicate by Kotlin property name: flattening discriminated-union variants
+  // can repeat a field (same property from multiple variants), which would
+  // declare the same constructor parameter twice.
+  const seenProps = new Set<string>();
+  const fields = model.fields.map(renderedField).filter((f) => {
+    if (seenProps.has(f.prop)) return false;
+    seenProps.add(f.prop);
+    return true;
+  });
+
+  const imports = new Set<string>(['kotlinx.serialization.Serializable']);
+  if (fields.length > 0) imports.add('kotlinx.serialization.SerialName');
+  for (const f of fields) {
+    for (const imp of implicitImportsFor(f.type)) imports.add(imp);
+  }
+  for (const imp of resolveTypeImports(
+    ctx,
+    fields.map((f) => f.type),
+  )) {
+    imports.add(imp);
+  }
+
+  const lines: string[] = [];
+  lines.push(`package ${pkg}`);
+  lines.push('');
+  const importLines = renderImportBlock(imports, pkg);
+  if (importLines.length > 0) {
+    lines.push(...importLines);
+    lines.push('');
+  }
+
+  lines.push(...renderDocComment(model.description, ''));
+
+  // A Kotlin `data class` requires at least one constructor parameter, so a
+  // field-less model degrades to a plain class.
+  if (fields.length === 0) {
+    lines.push('@Serializable');
+    lines.push(`public class ${name}`);
+    return lines.join('\n');
+  }
+
+  // Required properties first, then nullable ones (which get `= null`), so
+  // callers can omit optionals and rely on named arguments.
+  const ordered = [...fields].sort((a, b) => Number(a.optional) - Number(b.optional));
+
+  lines.push('@Serializable');
+  lines.push(`public data class ${name}(`);
+  for (const f of ordered) {
+    lines.push(...renderDocComment(f.field.description, '    '));
+    if (f.field.deprecated) lines.push('    @Deprecated("This field is deprecated.")');
+    lines.push(`    @SerialName(${ktStringLiteral(f.field.name)})`);
+    const suffix = f.optional ? ' = null' : '';
+    lines.push(`    public val ${f.prop}: ${f.type}${suffix},`);
+  }
+  lines.push(')');
+  return lines.join('\n');
+}
+
+/** The Kotlin property name a model field is exposed under (used by tests.ts). */
+export function modelFieldPropertyName(field: Field): string {
+  return propertyName(field.domainName ?? field.name);
+}
+
+/** The plain (unescaped) camelCase form of a field's property name. */
+export function modelFieldPlainName(field: Field): string {
+  return toCamelCase(field.domainName ?? field.name);
+}

--- a/src/android/naming.ts
+++ b/src/android/naming.ts
@@ -1,0 +1,250 @@
+import type { EmitterContext, Operation } from '@workos/oagen';
+import { toPascalCase, toCamelCase, resolveOperations } from '@workos/oagen';
+import { buildResolvedLookup, lookupResolved } from '../shared/resolved-ops.js';
+import { stripUrnPrefix, trimMountedResourceFromMethod } from '../shared/naming-utils.js';
+
+/**
+ * Kotlin identifier naming, reserved-word escaping, package resolution, and
+ * operation method-name resolution for the Android/Kotlin emitter.
+ *
+ * IR names are PascalCase; Kotlin types stay PascalCase (with acronym casing via
+ * `toPascalCase`'s built-in ACRONYM_SET), methods/properties are camelCase.
+ */
+
+/** Source-set roots for an Android library module. */
+export const SRC_MAIN = 'src/main/kotlin';
+export const SRC_TEST = 'src/test/kotlin';
+
+/**
+ * Kotlin HARD keywords, which are never legal as bare identifiers and must be
+ * back-tick escaped.
+ *
+ * Soft/modifier keywords (`get`, `set`, `data`, `value`, `open`, `sealed`,
+ * `internal`, `public`, `expect`, `actual`, `where`, `by`, `field`, …) are legal
+ * identifiers and are intentionally omitted — `get` and `value` in particular are
+ * common method and field names.
+ *
+ * Unlike Swift, `object` IS reserved in Kotlin, and it is a frequent wire field
+ * name in this API ("object": "organization"), so escaping matters more here.
+ */
+const KOTLIN_RESERVED = new Set([
+  'as',
+  'break',
+  'class',
+  'continue',
+  'do',
+  'else',
+  'false',
+  'for',
+  'fun',
+  'if',
+  'in',
+  'interface',
+  'is',
+  'null',
+  'object',
+  'package',
+  'return',
+  'super',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typealias',
+  'typeof',
+  'val',
+  'var',
+  'when',
+  'while',
+]);
+
+/** Wrap an identifier in back-ticks when it collides with a Kotlin hard keyword. */
+export function escapeReserved(name: string): string {
+  return KOTLIN_RESERVED.has(name) ? `\`${name}\`` : name;
+}
+
+/** PascalCase type name for models, enums, and resources. */
+export function typeName(name: string): string {
+  return toPascalCase(stripUrnPrefix(name));
+}
+
+/** File base name (without extension) for a generated type. */
+export function fileName(name: string): string {
+  return typeName(name);
+}
+
+/** camelCase method name (reserved-word escaped). */
+export function methodName(name: string): string {
+  return escapeReserved(toCamelCase(name));
+}
+
+/** camelCase property / parameter name (reserved-word escaped). */
+export function propertyName(name: string): string {
+  return escapeReserved(toCamelCase(name));
+}
+
+/** camelCase resource accessor property on the client (e.g. `organizations`). */
+export function accessorName(mountName: string): string {
+  return escapeReserved(toCamelCase(mountName));
+}
+
+// --- packages ---------------------------------------------------------------
+
+/**
+ * The root package for the generated SDK. Defaults to `com.{namespace}.android`
+ * (the convention Stripe's Android SDK uses), which also keeps the Android
+ * artifact from colliding with the server-side Kotlin SDK's `com.{namespace}`
+ * classes if both ever land on one classpath. Overridable via
+ * `emitterOptions.packagePrefix`.
+ */
+export function basePackage(ctx: EmitterContext): string {
+  const configured = ctx.emitterOptions?.packagePrefix;
+  if (typeof configured === 'string' && configured.length > 0) return configured;
+  // A package segment must be a single lower-case alphanumeric token. `ctx.namespace`
+  // arrives snake_cased (`--namespace WorkOS` → `work_os`), so separators are
+  // stripped rather than preserved: `com.workos.android`, not `com.work_os.android`.
+  const segment = (ctx.namespace || 'api').replace(/[^a-zA-Z0-9]/g, '').toLowerCase() || 'api';
+  return `com.${segment}.android`;
+}
+
+/** A sub-package of the SDK root (e.g. `models` → `com.workos.android.models`). */
+export function subPackage(ctx: EmitterContext, segment: string): string {
+  return segment ? `${basePackage(ctx)}.${segment}` : basePackage(ctx);
+}
+
+/** Directory path form of a package (`com.workos.android` → `com/workos/android`). */
+export function packageDir(pkg: string): string {
+  return pkg.split('.').join('/');
+}
+
+/** Full source path for a generated main-source-set file. */
+export function mainSourcePath(ctx: EmitterContext, segment: string, base: string): string {
+  return `${SRC_MAIN}/${packageDir(subPackage(ctx, segment))}/${base}.kt`;
+}
+
+/** Full source path for a generated test-source-set file. */
+export function testSourcePath(ctx: EmitterContext, segment: string, base: string): string {
+  return `${SRC_TEST}/${packageDir(subPackage(ctx, segment))}/${base}.kt`;
+}
+
+// --- well-known type names --------------------------------------------------
+
+/**
+ * The namespace in Kotlin type-name form.
+ *
+ * `namespacePascal` is passed through verbatim from `--namespace`, and callers
+ * only supply the cased form (`WorkOS`) for languages whose namespace doubles as
+ * a type/module name. Kotlin class names must start with an upper-case letter, so
+ * a lower-case namespace is capitalized here rather than emitting an
+ * unconventional `workosClient`. Acronym casing beyond the first character cannot
+ * be recovered from a lower-case namespace (`workos` → `Workos`, not `WorkOS`), so
+ * pass `--namespace WorkOS` to get exact casing.
+ */
+export function namespaceType(ctx: EmitterContext): string {
+  const raw = ctx.namespacePascal || ctx.namespace;
+  if (!raw) return 'Api';
+  return raw.charAt(0).toUpperCase() + raw.slice(1);
+}
+
+/** The main client class name (e.g. `WorkOSClient`). */
+export function clientClassName(ctx: EmitterContext): string {
+  return `${namespaceType(ctx)}Client`;
+}
+
+/** The base exception type name (e.g. `WorkOSException`). */
+export function exceptionTypeName(ctx: EmitterContext): string {
+  return `${namespaceType(ctx)}Exception`;
+}
+
+// --- literals ---------------------------------------------------------------
+
+/**
+ * Escape a string for embedding as a Kotlin string literal.
+ *
+ * `$` MUST be escaped: Kotlin interpolates `$name` and `${expr}` inside string
+ * literals, so an unescaped `$` in spec-derived text (a description, an enum wire
+ * value) would become live code in the generated source.
+ */
+export function ktStringLiteral(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/\$/g, '\\$')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
+/**
+ * Escape a literal fragment for embedding inside a Kotlin **template** string
+ * (one containing `${...}` interpolations, as the generated path expressions do).
+ *
+ * `$` MUST be escaped or the fragment would start an interpolation of its own.
+ * Distinct from {@link ktStringLiteral}, which wraps and escapes a whole value;
+ * this escapes a fragment that is being concatenated into a larger literal.
+ */
+export function ktTemplatePart(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\$/g, '\\$').replace(/"/g, '\\"');
+}
+
+/** Escape any scalar as a Kotlin literal expression. */
+export function ktLiteral(value: string | number | boolean): string {
+  if (typeof value === 'string') return ktStringLiteral(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
+// --- resolved operations ----------------------------------------------------
+
+/**
+ * Return a context whose `resolvedOperations` is guaranteed populated. When the
+ * engine already populated it (`buildEmitterContext`), it is returned as-is;
+ * otherwise (unit tests, hint-less specs) it is resolved from the spec so the
+ * shared mount-group helpers work uniformly.
+ */
+export function withResolvedOps(ctx: EmitterContext): EmitterContext {
+  if (ctx.resolvedOperations && ctx.resolvedOperations.length > 0) return ctx;
+  return { ...ctx, resolvedOperations: resolveOperations(ctx.spec) };
+}
+
+/** The set of PascalCase type names declared by models and enums. */
+export function collectDeclaredTypeNames(ctx: EmitterContext): Set<string> {
+  const names = new Set<string>();
+  for (const model of ctx.spec.models) names.add(typeName(model.name));
+  for (const e of ctx.spec.enums) names.add(typeName(e.name));
+  return names;
+}
+
+/**
+ * Resource class name for a mount group. A resource whose name collides with a
+ * model or enum type gets a `Resource` suffix — Kotlin would technically allow
+ * the duplicate across packages, but the resulting imports are ambiguous to read
+ * and easy to mis-import. Mirrors the iOS emitter's rule so type names agree.
+ */
+export function resourceTypeName(mountName: string, ctx: EmitterContext): string {
+  const base = typeName(mountName);
+  return collectDeclaredTypeNames(ctx).has(base) ? `${base}Resource` : base;
+}
+
+/**
+ * Strip the mount-group resource noun when it directly follows the leading verb
+ * (family-wide convention, shared with the Go/Kotlin/iOS/.NET emitters), so
+ * method names match across languages.
+ */
+export function trimMountResource(method: string, mountName: string): string {
+  return trimMountedResourceFromMethod(method, typeName(mountName));
+}
+
+/**
+ * Resolve the Kotlin method name for an operation within a mount group. Prefers
+ * the hint-aware `ResolvedOperation.methodName`, falls back to `op.name`, then
+ * trims the mount resource noun and escapes reserved words.
+ */
+export function resolveMethodName(op: Operation, mountName: string, ctx: EmitterContext): string {
+  const lookup = buildResolvedLookup(withResolvedOps(ctx));
+  const resolved = lookupResolved(op, lookup);
+  const snake = resolved?.methodName ?? op.name;
+  const camel = toCamelCase(snake);
+  return escapeReserved(trimMountResource(camel, mountName));
+}

--- a/src/android/resources.ts
+++ b/src/android/resources.ts
@@ -625,6 +625,15 @@ function renderBody(
   defaults: Record<string, string | number | boolean>,
   infer: string[],
 ): string {
+  // Every body is built as a `JsonBody` regardless of `op.requestBodyEncoding`.
+  // The IR does carry that field (`'json' | 'form-data' | 'form-urlencoded' |
+  // 'binary' | 'text'`), and the `kotlin` and `node` emitters branch on it, but
+  // the hand-maintained Android transport only exposes `JsonBody` — there is no
+  // `FormBody` to dispatch to. Sending JSON is still correct for the two
+  // form-urlencoded operations in the spec (`POST /sso/token`, User Management
+  // authenticate): the API accepts JSON for those as well, the same fallback the
+  // `kotlin` emitter documents (wrappers.ts). If a genuine form-only endpoint is
+  // ever added, the runtime gains a `FormBody` and this branch appears here.
   const raw = params.find((p) => p.kind === 'bodyRaw');
   if (raw) {
     // The transport takes a `JsonBody`, so a whole-object body goes through the raw

--- a/src/android/resources.ts
+++ b/src/android/resources.ts
@@ -424,9 +424,28 @@ function renderAutoPagingMethod(
   const name = autoPagingMethodName(method);
 
   const passthrough = orderMethodParams(auto.params.filter((p) => p !== auto.cursorParam));
-  const callArgs = orderMethodParams(auto.params).map((p) =>
-    p === auto.cursorParam ? `${p.name} = cursor` : `${p.name} = ${p.name}`,
-  );
+
+  // The reverse cursor, sent on the first page only.
+  //
+  // WorkOS pagination pairs `after` (forward) with `before` (reverse). They are
+  // alternative windows, not filters, so re-sending `before` alongside an
+  // advancing `after` asks the server for a contradictory range — which can
+  // return the same page indefinitely. `autoPagingFlow` stops only when `after`
+  // is null, so that would be an infinite flow emitting duplicates, not a bad
+  // page. Passing it on the first request preserves "start from this reverse
+  // cursor" without corrupting the walk, and `cursor == null` is exactly the
+  // first page. The kotlin emitter solves the same problem inside its pagination
+  // engine; android has no engine to hook, so it is resolved at the call site.
+  const reverseCursor =
+    auto.cursorParam.wire === 'after'
+      ? auto.params.find((p) => p.kind === 'query' && p.wire === 'before' && p.type === 'String?')
+      : undefined;
+
+  const callArgs = orderMethodParams(auto.params).map((p) => {
+    if (p === auto.cursorParam) return `${p.name} = cursor`;
+    if (p === reverseCursor) return `${p.name} = if (cursor == null) ${p.name} else null`;
+    return `${p.name} = ${p.name}`;
+  });
   callArgs.push('requestOptions = requestOptions');
 
   const lines: string[] = [];

--- a/src/android/resources.ts
+++ b/src/android/resources.ts
@@ -570,6 +570,31 @@ function renderQueryAppend(q: RenderedParam): string[] {
     }
     return out;
   }
+  // A map-valued query param expands to one bracketed entry per key —
+  // `provider_query_params[hd]=example.com` — which is the encoding the API and
+  // every other WorkOS SDK use. Falling through to the scalar branch below would
+  // emit `it.toString()`, i.e. Kotlin's own map rendering
+  // (`{hd=example.com, access_type=offline}`) as a single opaque value, so the
+  // provider would receive one meaningless parameter instead of the pairs.
+  if (base.kind === 'map') {
+    const valueExpr = isStringPrimitive(base.valueType) ? 'value' : 'value.toString()';
+    const loop = (indent: string): void => {
+      out.push(`${indent}for ((key, value) in ${q.optional ? 'it' : q.name}) {`);
+      // `[$key]` is a Kotlin template referencing the loop variable; the wire name
+      // itself must be literal text, so it goes through ktTemplatePart (which
+      // escapes `$` and quotes) rather than being wrapped in an interpolation.
+      out.push(`${indent}    query.add(QueryParam("${ktTemplatePart(q.wire)}[$key]", ${valueExpr}))`);
+      out.push(`${indent}}`);
+    };
+    if (q.optional) {
+      out.push(`        ${q.name}?.let {`);
+      loop('            ');
+      out.push('        }');
+    } else {
+      loop('        ');
+    }
+    return out;
+  }
   if (q.optional) {
     out.push(
       `        ${q.name}?.let { query.add(QueryParam(${ktStringLiteral(q.wire)}, ${queryValueExpr('it', base)})) }`,

--- a/src/android/resources.ts
+++ b/src/android/resources.ts
@@ -9,7 +9,7 @@ import type {
 } from '@workos/oagen';
 import { planOperation } from '@workos/oagen';
 import { parsePathTemplate } from '../shared/path-template.js';
-import { unwrapListModel } from '../shared/model-utils.js';
+import { isEnumTypeRef, resolvePaginatedItemModelName, unwrapNullableRef } from '../shared/model-utils.js';
 import { scopedMountGroups, buildHiddenParams, getOpDefaults, getOpInferFromClient } from '../shared/resolved-ops.js';
 import {
   typeName,
@@ -43,14 +43,8 @@ export function generateResources(_services: Service[], ctx: EmitterContext): Ge
 
 // --- TypeRef helpers --------------------------------------------------------
 
-function unwrapNullable(ref: TypeRef): TypeRef {
-  return ref.kind === 'nullable' ? ref.inner : ref;
-}
-function isEnumRef(ref: TypeRef): boolean {
-  return unwrapNullable(ref).kind === 'enum';
-}
 function isStringPrimitive(ref: TypeRef): boolean {
-  const base = unwrapNullable(ref);
+  const base = unwrapNullableRef(ref);
   return base.kind === 'primitive' && base.type === 'string' && base.format !== 'date-time' && base.format !== 'date';
 }
 
@@ -519,10 +513,7 @@ function returnType(plan: ReturnType<typeof planOperation>, ctx: EmitterContext)
  * element must be the inner item (`Organization`), not the wrapper.
  */
 export function resolvePaginatedItemName(name: string, ctx: EmitterContext): string {
-  const model = ctx.spec.models.find((m) => m.name === name);
-  if (!model) return name;
-  const modelMap = new Map(ctx.spec.models.map((m) => [m.name, m]));
-  return unwrapListModel(model, modelMap)?.name ?? name;
+  return resolvePaginatedItemModelName(name, ctx.spec.models);
 }
 
 function renderPathExpr(op: Operation, params: RenderedParam[]): string {
@@ -536,7 +527,7 @@ function renderPathExpr(op: Operation, params: RenderedParam[]): string {
     } else {
       const p = byWire.get(seg.name);
       const name = p ? p.name : propertyName(seg.name);
-      const accessor = p && isEnumRef(p.ref) ? `${name}.rawValue` : name;
+      const accessor = p && isEnumTypeRef(p.ref) ? `${name}.rawValue` : name;
       expr += `\${PathEncoding.segment(${accessor})}`;
     }
   }
@@ -545,17 +536,17 @@ function renderPathExpr(op: Operation, params: RenderedParam[]): string {
 }
 
 function queryValueExpr(name: string, ref: TypeRef): string {
-  if (isEnumRef(ref)) return `${name}.rawValue`;
+  if (isEnumTypeRef(ref)) return `${name}.rawValue`;
   if (isStringPrimitive(ref)) return name;
   return `${name}.toString()`;
 }
 
 function renderQueryAppend(q: RenderedParam): string[] {
-  const base = unwrapNullable(q.ref);
+  const base = unwrapNullableRef(q.ref);
   const out: string[] = [];
   if (base.kind === 'array') {
     const elem = base.items;
-    const elemExpr = isEnumRef(elem) ? 'value.rawValue' : isStringPrimitive(elem) ? 'value' : 'value.toString()';
+    const elemExpr = isEnumTypeRef(elem) ? 'value.rawValue' : isStringPrimitive(elem) ? 'value' : 'value.toString()';
     const loop = (indent: string): void => {
       out.push(`${indent}for (value in ${q.optional ? 'it' : q.name}) {`);
       out.push(`${indent}    query.add(QueryParam(${ktStringLiteral(q.wire)}, ${elemExpr}))`);
@@ -607,7 +598,7 @@ function renderQueryAppend(q: RenderedParam): string[] {
 
 /** True when a raw request body is a model ref, whose serializer the emitter can name. */
 function rawBodyIsModel(ref: TypeRef): boolean {
-  return unwrapNullable(ref).kind === 'model';
+  return unwrapNullableRef(ref).kind === 'model';
 }
 
 /**
@@ -641,7 +632,7 @@ function renderBody(
     const local = uniqueLocalName('payload', params);
     lines.push(`        val ${local} = JsonBody()`);
     if (rawBodyIsModel(raw.ref)) {
-      const modelType = mapTypeRef(unwrapNullable(raw.ref));
+      const modelType = mapTypeRef(unwrapNullableRef(raw.ref));
       lines.push(`        ${local}.setRaw(${modelType}.serializer(), ${raw.name})`);
     } else {
       lines.push(`        ${local}.setRawJson(${raw.name})`);

--- a/src/android/resources.ts
+++ b/src/android/resources.ts
@@ -1,0 +1,633 @@
+import type {
+  Service,
+  EmitterContext,
+  GeneratedFile,
+  Operation,
+  Field,
+  TypeRef,
+  ResolvedOperation,
+} from '@workos/oagen';
+import { planOperation } from '@workos/oagen';
+import { parsePathTemplate } from '../shared/path-template.js';
+import { unwrapListModel } from '../shared/model-utils.js';
+import { scopedMountGroups, buildHiddenParams, getOpDefaults, getOpInferFromClient } from '../shared/resolved-ops.js';
+import {
+  typeName,
+  resourceTypeName,
+  propertyName,
+  resolveMethodName,
+  withResolvedOps,
+  mainSourcePath,
+  subPackage,
+  ktStringLiteral,
+  ktLiteral,
+  ktTemplatePart,
+} from './naming.js';
+import { fieldKotlinType, mapTypeRef, implicitImportsFor } from './type-map.js';
+import { resolveTypeImports, renderImportBlock } from './imports.js';
+import { generateWrapperMethods } from './wrappers.js';
+import { renderMethodDoc } from './doc-comments.js';
+
+/**
+ * Generate one Kotlin resource class per mount group. Each operation becomes a
+ * `suspend fun`; path/query/body params are flattened into the signature.
+ */
+export function generateResources(_services: Service[], ctx: EmitterContext): GeneratedFile[] {
+  const rctx = withResolvedOps(ctx);
+  const groups = [...scopedMountGroups(rctx).values()].sort((a, b) => a.name.localeCompare(b.name));
+  return groups.map((group) => ({
+    path: mainSourcePath(rctx, 'resources', resourceTypeName(group.name, rctx)),
+    content: renderResource(group.name, group.resolvedOps, rctx),
+  }));
+}
+
+// --- TypeRef helpers --------------------------------------------------------
+
+function unwrapNullable(ref: TypeRef): TypeRef {
+  return ref.kind === 'nullable' ? ref.inner : ref;
+}
+function isEnumRef(ref: TypeRef): boolean {
+  return unwrapNullable(ref).kind === 'enum';
+}
+function isStringPrimitive(ref: TypeRef): boolean {
+  const base = unwrapNullable(ref);
+  return base.kind === 'primitive' && base.type === 'string' && base.format !== 'date-time' && base.format !== 'date';
+}
+
+// --- rendering --------------------------------------------------------------
+
+/** A rendered method block plus the imports its body and signature require. */
+export interface RenderedMethod {
+  name: string;
+  lines: string[];
+  imports: string[];
+}
+
+function renderResource(mountName: string, resolvedOps: ResolvedOperation[], ctx: EmitterContext): string {
+  const resourceName = resourceTypeName(mountName, ctx);
+  const pkg = subPackage(ctx, 'resources');
+  const methods: RenderedMethod[] = [];
+  const seen = new Set<string>();
+
+  for (const resolved of resolvedOps) {
+    if (resolved.urlBuilder) {
+      const method = resolveMethodName(resolved.operation, mountName, ctx);
+      if (seen.has(method)) continue;
+      seen.add(method);
+      methods.push(renderUrlBuilderMethod(resolved, method, ctx));
+      continue;
+    }
+    if (resolved.wrappers && resolved.wrappers.length > 0) {
+      for (const block of generateWrapperMethods(resolved, ctx)) {
+        if (seen.has(block.name)) continue;
+        seen.add(block.name);
+        methods.push(block);
+      }
+      continue;
+    }
+    const method = resolveMethodName(resolved.operation, mountName, ctx);
+    if (seen.has(method)) continue;
+    seen.add(method);
+    methods.push(renderMethod(resolved, mountName, method, ctx));
+
+    // Cursor-paginated operations get an auto-paginating companion that walks
+    // every page through the same underlying method.
+    const auto = renderAutoPagingMethod(resolved, method, ctx);
+    if (auto && !seen.has(auto.name)) {
+      seen.add(auto.name);
+      methods.push(auto);
+    }
+  }
+
+  const imports = new Set<string>([`${subPackage(ctx, 'internal')}.Transport`]);
+  for (const m of methods) {
+    for (const imp of m.imports) imports.add(imp);
+  }
+
+  const lines: string[] = [];
+  lines.push(`package ${pkg}`);
+  lines.push('');
+  const importLines = renderImportBlock(imports, pkg);
+  if (importLines.length > 0) {
+    lines.push(...importLines);
+    lines.push('');
+  }
+  lines.push(`/** Operations for the ${resourceName} API. */`);
+  lines.push(`public class ${resourceName} internal constructor(`);
+  lines.push('    private val transport: Transport,');
+  lines.push(') {');
+  let first = true;
+  for (const m of methods) {
+    if (!first) lines.push('');
+    first = false;
+    lines.push(...m.lines);
+  }
+  lines.push('}');
+  return lines.join('\n');
+}
+
+export interface RenderedParam {
+  name: string;
+  wire: string;
+  type: string;
+  optional: boolean;
+  ref: TypeRef;
+  kind: 'path' | 'query' | 'body' | 'bodyRaw';
+  deprecated?: boolean;
+  description?: string;
+}
+
+/**
+ * Collect the flattened method parameters (path, body, query) for an operation
+ * in collection order, applying the same hidden-param filtering and name
+ * de-duplication the resource methods use. Exported so the smoke runner can
+ * reconstruct the exact call signature.
+ */
+export function collectMethodParams(resolved: ResolvedOperation, ctx: EmitterContext): RenderedParam[] {
+  const op = resolved.operation;
+  const hidden = buildHiddenParams(resolved);
+  const params: RenderedParam[] = [];
+  const usedNames = new Set<string>();
+  const dedupe = (name: string): string => {
+    let candidate = name;
+    let n = 2;
+    while (usedNames.has(candidate)) candidate = `${name}${n++}`;
+    usedNames.add(candidate);
+    return candidate;
+  };
+
+  // Path params in template order.
+  const pathParamOrder = parsePathTemplate(op.path)
+    .filter((s) => s.kind === 'param')
+    .map((s) => (s.kind === 'param' ? s.name : ''));
+  const pathByWire = new Map(op.pathParams.map((p) => [p.name, p]));
+  for (const wire of pathParamOrder) {
+    const p = pathByWire.get(wire);
+    if (!p || hidden.has(p.name)) continue;
+    params.push({
+      name: dedupe(propertyName(p.name)),
+      wire: p.name,
+      type: fieldKotlinType(p.type, true),
+      optional: false,
+      ref: p.type,
+      kind: 'path',
+      deprecated: p.deprecated,
+      description: p.description,
+    });
+  }
+
+  // Body params: expand a model body's fields, or a single raw body param.
+  const bodyFields = resolveBodyFields(op, ctx);
+  if (bodyFields === 'raw' && op.requestBody) {
+    params.push({
+      name: dedupe('body'),
+      wire: '',
+      // A raw body is serialized whole. A model ref keeps its generated type (the
+      // emitter can name its compile-time serializer); any other shape is exposed
+      // as raw JSON, since there is no named serializer to reference.
+      type: rawBodyIsModel(op.requestBody) ? mapTypeRef(op.requestBody) : 'JsonElement',
+      optional: false,
+      ref: op.requestBody,
+      kind: 'bodyRaw',
+    });
+  } else if (bodyFields !== 'raw' && bodyFields) {
+    for (const f of bodyFields) {
+      if (hidden.has(f.name)) continue;
+      const type = fieldKotlinType(f.type, f.required);
+      params.push({
+        name: dedupe(propertyName(f.domainName ?? f.name)),
+        wire: f.name,
+        type,
+        optional: type.endsWith('?'),
+        ref: f.type,
+        kind: 'body',
+        deprecated: f.deprecated,
+        description: f.description,
+      });
+    }
+  }
+
+  // Query params.
+  for (const q of op.queryParams) {
+    if (hidden.has(q.name)) continue;
+    const type = fieldKotlinType(q.type, q.required);
+    params.push({
+      name: dedupe(propertyName(q.name)),
+      wire: q.name,
+      type,
+      optional: type.endsWith('?'),
+      ref: q.type,
+      kind: 'query',
+      deprecated: q.deprecated,
+      description: q.description,
+    });
+  }
+
+  return params;
+}
+
+/** Signature order: required params first, optionals after. */
+export function orderMethodParams(params: RenderedParam[]): RenderedParam[] {
+  return [...params].sort((a, b) => Number(a.optional) - Number(b.optional));
+}
+
+/** Imports implied by a parameter list plus a return type. */
+function collectMethodImports(ctx: EmitterContext, typeExprs: string[]): string[] {
+  const imports = new Set<string>();
+  for (const expr of typeExprs) {
+    for (const imp of implicitImportsFor(expr)) imports.add(imp);
+  }
+  for (const imp of resolveTypeImports(ctx, typeExprs)) imports.add(imp);
+  return [...imports];
+}
+
+function renderMethod(
+  resolved: ResolvedOperation,
+  mountName: string,
+  method: string,
+  ctx: EmitterContext,
+): RenderedMethod {
+  const op = resolved.operation;
+  const plan = planOperation(op);
+  const defaults = getOpDefaults(resolved);
+  const infer = getOpInferFromClient(resolved);
+
+  const params = collectMethodParams(resolved, ctx);
+  const ordered = orderMethodParams(params);
+  const ret = returnType(plan, ctx);
+
+  const lines: string[] = [];
+  lines.push(
+    ...renderMethodDoc(
+      op.description,
+      [
+        ...ordered.map((param) => ({
+          name: param.name,
+          description: param.description,
+          deprecated: param.deprecated,
+        })),
+        {
+          name: 'requestOptions',
+          description: 'Per-request overrides: extra headers, timeout, retries, base URL, idempotency key.',
+        },
+      ],
+      ret ? `The \`${ret}\` returned by the API.` : undefined,
+      '    ',
+    ),
+  );
+  if (op.deprecated) lines.push('    @Deprecated("This operation is deprecated.")');
+
+  lines.push(`    public suspend fun ${method}(`);
+  for (const p of ordered) {
+    lines.push(`        ${p.name}: ${p.type}${p.optional ? ' = null' : ''},`);
+  }
+  lines.push('        requestOptions: RequestOptions? = null,');
+  lines.push(`    )${ret ? `: ${ret}` : ''} {`);
+
+  lines.push(`        val path = ${renderPathExpr(op, params)}`);
+
+  const queryParams = params.filter((p) => p.kind === 'query');
+  let queryArg = 'emptyList()';
+  if (queryParams.length > 0) {
+    lines.push('        val query = mutableListOf<QueryParam>()');
+    for (const q of queryParams) lines.push(...renderQueryAppend(q));
+    queryArg = 'query';
+  }
+
+  const bodyArg = renderBody(lines, params, defaults, infer);
+
+  const httpMethod = op.httpMethod.toUpperCase();
+  const call = ret ? `return transport.request<${ret}>(` : 'transport.requestVoid(';
+  lines.push(`        ${call}`);
+  lines.push(`            method = ${ktStringLiteral(httpMethod)},`);
+  lines.push('            path = path,');
+  lines.push(`            query = ${queryArg},`);
+  lines.push(`            body = ${bodyArg},`);
+  lines.push('            options = requestOptions,');
+  lines.push('        )');
+  lines.push('    }');
+
+  const imports = collectMethodImports(ctx, [...ordered.map((p) => p.type), ...(ret ? [ret] : [])]);
+  imports.push(`${subPackage(ctx, '')}.RequestOptions`);
+  if (queryParams.length > 0) imports.push(`${subPackage(ctx, 'internal')}.QueryParam`);
+  // Any body argument other than the literal `null` is a JsonBody local.
+  if (bodyArg !== 'null') imports.push(`${subPackage(ctx, 'internal')}.JsonBody`);
+  if (renderPathExpr(op, params).includes('PathEncoding')) {
+    imports.push(`${subPackage(ctx, 'internal')}.PathEncoding`);
+  }
+  return { name: method, lines, imports };
+}
+
+/**
+ * Render a URL-builder method for a browser-redirect operation (`urlBuilder`
+ * hint, e.g. `GET /sso/authorize`). The method never performs an HTTP request:
+ * it assembles and returns the URL the caller redirects the user to, so it is
+ * NOT `suspend`. Hidden defaults (`response_type=code`) and client-inferred
+ * values (`client_id`) are appended alongside the caller's parameters.
+ */
+function renderUrlBuilderMethod(resolved: ResolvedOperation, method: string, ctx: EmitterContext): RenderedMethod {
+  const op = resolved.operation;
+  const defaults = getOpDefaults(resolved);
+  const infer = getOpInferFromClient(resolved);
+  const params = collectMethodParams(resolved, ctx);
+  const ordered = orderMethodParams(params);
+
+  const lines: string[] = [];
+  lines.push(
+    ...renderMethodDoc(
+      op.description,
+      ordered.map((param) => ({
+        name: param.name,
+        description: param.description,
+        deprecated: param.deprecated,
+      })),
+      'The assembled URL to redirect the user to.',
+      '    ',
+    ),
+  );
+  if (op.deprecated) lines.push('    @Deprecated("This operation is deprecated.")');
+
+  if (ordered.length === 0) {
+    lines.push(`    public fun ${method}(): String {`);
+  } else {
+    lines.push(`    public fun ${method}(`);
+    for (const p of ordered) {
+      lines.push(`        ${p.name}: ${p.type}${p.optional ? ' = null' : ''},`);
+    }
+    lines.push('    ): String {');
+  }
+
+  lines.push(`        val path = ${renderPathExpr(op, params)}`);
+  lines.push('        val query = mutableListOf<QueryParam>()');
+  for (const key of Object.keys(defaults)) {
+    lines.push(`        query.add(QueryParam(${ktStringLiteral(key)}, ${ktLiteral(defaults[key])}))`);
+  }
+  for (const key of infer) {
+    // `clientId` is nullable on Configuration; only append when set.
+    if (key === 'client_id') {
+      lines.push(`        ${clientFieldExpr(key)}?.let { query.add(QueryParam(${ktStringLiteral(key)}, it)) }`);
+    } else {
+      lines.push(`        query.add(QueryParam(${ktStringLiteral(key)}, ${clientFieldExpr(key)}))`);
+    }
+  }
+  for (const q of params.filter((p) => p.kind === 'query')) {
+    lines.push(...renderQueryAppend(q));
+  }
+  lines.push('        return transport.buildUrl(path, query)');
+  lines.push('    }');
+
+  const imports = collectMethodImports(
+    ctx,
+    ordered.map((p) => p.type),
+  );
+  imports.push(`${subPackage(ctx, 'internal')}.QueryParam`);
+  if (renderPathExpr(op, params).includes('PathEncoding')) {
+    imports.push(`${subPackage(ctx, 'internal')}.PathEncoding`);
+  }
+  return { name: method, lines, imports };
+}
+
+/** The auto-paging companion method name for a paginated operation. */
+export function autoPagingMethodName(method: string): string {
+  return `${method}AutoPaging`;
+}
+
+/**
+ * Details of an operation's auto-paging companion, or null when the operation is
+ * not cursor-paginated (or its cursor param is not a plain nullable string query
+ * param the wrapper can drive).
+ */
+export function planAutoPaging(
+  resolved: ResolvedOperation,
+  ctx: EmitterContext,
+): { itemType: string; cursorWire: string; params: RenderedParam[]; cursorParam: RenderedParam } | null {
+  const op = resolved.operation;
+  const plan = planOperation(op);
+  if (!plan.isPaginated || !plan.paginatedItemModelName) return null;
+  if (op.pagination?.strategy !== 'cursor') return null;
+  const params = collectMethodParams(resolved, ctx);
+  // The flow drives the cursor with a String? (null on the first page), so the
+  // underlying method's cursor param must be an optional string.
+  const cursorParam = params.find((p) => p.kind === 'query' && p.wire === op.pagination?.param);
+  if (!cursorParam || cursorParam.type !== 'String?') return null;
+  const itemType = typeName(resolvePaginatedItemName(plan.paginatedItemModelName, ctx));
+  return { itemType, cursorWire: cursorParam.wire, params, cursorParam };
+}
+
+function renderAutoPagingMethod(
+  resolved: ResolvedOperation,
+  method: string,
+  ctx: EmitterContext,
+): RenderedMethod | null {
+  const auto = planAutoPaging(resolved, ctx);
+  if (!auto) return null;
+  const name = autoPagingMethodName(method);
+
+  const passthrough = orderMethodParams(auto.params.filter((p) => p !== auto.cursorParam));
+  const callArgs = orderMethodParams(auto.params).map((p) =>
+    p === auto.cursorParam ? `${p.name} = cursor` : `${p.name} = ${p.name}`,
+  );
+  callArgs.push('requestOptions = requestOptions');
+
+  const lines: string[] = [];
+  lines.push(
+    ...renderMethodDoc(
+      `Auto-paginating variant of [${method}]: emits every item across successive pages as the flow is collected.`,
+      [
+        ...passthrough.map((param) => ({
+          name: param.name,
+          description: param.description,
+          deprecated: param.deprecated,
+        })),
+        {
+          name: 'requestOptions',
+          description: 'Per-request overrides: extra headers, timeout, retries, base URL, idempotency key.',
+        },
+      ],
+      `A cold flow of \`${auto.itemType}\` values.`,
+      '    ',
+    ),
+  );
+  if (resolved.operation.deprecated) lines.push('    @Deprecated("This operation is deprecated.")');
+  lines.push(`    public fun ${name}(`);
+  for (const p of passthrough) {
+    lines.push(`        ${p.name}: ${p.type}${p.optional ? ' = null' : ''},`);
+  }
+  lines.push('        requestOptions: RequestOptions? = null,');
+  lines.push(`    ): Flow<${auto.itemType}> =`);
+  lines.push('        autoPagingFlow { cursor ->');
+  lines.push(`            ${method}(`);
+  for (const arg of callArgs) lines.push(`                ${arg},`);
+  lines.push('            )');
+  lines.push('        }');
+
+  const imports = collectMethodImports(ctx, [...passthrough.map((p) => p.type), auto.itemType]);
+  imports.push('kotlinx.coroutines.flow.Flow');
+  imports.push(`${subPackage(ctx, 'internal')}.autoPagingFlow`);
+  imports.push(`${subPackage(ctx, '')}.RequestOptions`);
+  return { name, lines, imports };
+}
+
+/** Determine whether the body is a model (return its fields), raw, or absent. */
+function resolveBodyFields(op: Operation, ctx: EmitterContext): Field[] | 'raw' | null {
+  const rb = op.requestBody;
+  if (!rb) return null;
+  if (rb.kind === 'model') {
+    const model = ctx.spec.models.find((m) => m.name === rb.name);
+    if (model && model.fields.length > 0) return model.fields;
+  }
+  return 'raw';
+}
+
+function returnType(plan: ReturnType<typeof planOperation>, ctx: EmitterContext): string | null {
+  if (plan.isPaginated && plan.paginatedItemModelName) {
+    const item = resolvePaginatedItemName(plan.paginatedItemModelName, ctx);
+    return `Page<${typeName(item)}>`;
+  }
+  if (plan.isArrayResponse && plan.responseModelName) {
+    return `List<${typeName(plan.responseModelName)}>`;
+  }
+  if (plan.responseModelName) {
+    return typeName(plan.responseModelName);
+  }
+  return null;
+}
+
+/**
+ * Unwrap a list-wrapper model to its element type. Pagination itemType often
+ * resolves to the wrapper (e.g. `OrganizationList { data: [Organization],
+ * list_metadata }`); the runtime `Page<T>` already models that envelope, so the
+ * element must be the inner item (`Organization`), not the wrapper.
+ */
+export function resolvePaginatedItemName(name: string, ctx: EmitterContext): string {
+  const model = ctx.spec.models.find((m) => m.name === name);
+  if (!model) return name;
+  const modelMap = new Map(ctx.spec.models.map((m) => [m.name, m]));
+  return unwrapListModel(model, modelMap)?.name ?? name;
+}
+
+function renderPathExpr(op: Operation, params: RenderedParam[]): string {
+  const segments = parsePathTemplate(op.path, { stripLeadingSlash: true });
+  if (segments.length === 0) return '""';
+  const byWire = new Map(params.filter((p) => p.kind === 'path').map((p) => [p.wire, p]));
+  let expr = '"';
+  for (const seg of segments) {
+    if (seg.kind === 'literal') {
+      expr += ktTemplatePart(seg.value);
+    } else {
+      const p = byWire.get(seg.name);
+      const name = p ? p.name : propertyName(seg.name);
+      const accessor = p && isEnumRef(p.ref) ? `${name}.rawValue` : name;
+      expr += `\${PathEncoding.segment(${accessor})}`;
+    }
+  }
+  expr += '"';
+  return expr;
+}
+
+function queryValueExpr(name: string, ref: TypeRef): string {
+  if (isEnumRef(ref)) return `${name}.rawValue`;
+  if (isStringPrimitive(ref)) return name;
+  return `${name}.toString()`;
+}
+
+function renderQueryAppend(q: RenderedParam): string[] {
+  const base = unwrapNullable(q.ref);
+  const out: string[] = [];
+  if (base.kind === 'array') {
+    const elem = base.items;
+    const elemExpr = isEnumRef(elem) ? 'value.rawValue' : isStringPrimitive(elem) ? 'value' : 'value.toString()';
+    const loop = (indent: string): void => {
+      out.push(`${indent}for (value in ${q.optional ? 'it' : q.name}) {`);
+      out.push(`${indent}    query.add(QueryParam(${ktStringLiteral(q.wire)}, ${elemExpr}))`);
+      out.push(`${indent}}`);
+    };
+    if (q.optional) {
+      out.push(`        ${q.name}?.let {`);
+      loop('            ');
+      out.push('        }');
+    } else {
+      loop('        ');
+    }
+    return out;
+  }
+  if (q.optional) {
+    out.push(
+      `        ${q.name}?.let { query.add(QueryParam(${ktStringLiteral(q.wire)}, ${queryValueExpr('it', base)})) }`,
+    );
+  } else {
+    out.push(`        query.add(QueryParam(${ktStringLiteral(q.wire)}, ${queryValueExpr(q.name, base)}))`);
+  }
+  return out;
+}
+
+/** True when a raw request body is a model ref, whose serializer the emitter can name. */
+function rawBodyIsModel(ref: TypeRef): boolean {
+  return unwrapNullable(ref).kind === 'model';
+}
+
+/**
+ * Pick a local variable name that cannot shadow a method parameter. A raw body is
+ * exposed as a parameter literally named `body`, and a model body field may also be
+ * named `body`, either of which would make `val body = JsonBody()` shadow the
+ * parameter the very next line reads.
+ */
+function uniqueLocalName(base: string, params: RenderedParam[]): string {
+  const taken = new Set(params.map((p) => p.name.replace(/`/g, '')));
+  taken.add('path');
+  taken.add('query');
+  taken.add('requestOptions');
+  if (!taken.has(base)) return base;
+  let n = 2;
+  while (taken.has(`${base}${n}`)) n++;
+  return `${base}${n}`;
+}
+
+/** Emit body-building statements and return the argument expression for `body =`. */
+function renderBody(
+  lines: string[],
+  params: RenderedParam[],
+  defaults: Record<string, string | number | boolean>,
+  infer: string[],
+): string {
+  const raw = params.find((p) => p.kind === 'bodyRaw');
+  if (raw) {
+    // The transport takes a `JsonBody`, so a whole-object body goes through the raw
+    // setters rather than being passed straight through (which would not typecheck).
+    const local = uniqueLocalName('payload', params);
+    lines.push(`        val ${local} = JsonBody()`);
+    if (rawBodyIsModel(raw.ref)) {
+      const modelType = mapTypeRef(unwrapNullable(raw.ref));
+      lines.push(`        ${local}.setRaw(${modelType}.serializer(), ${raw.name})`);
+    } else {
+      lines.push(`        ${local}.setRawJson(${raw.name})`);
+    }
+    return local;
+  }
+
+  const bodyParams = params.filter((p) => p.kind === 'body');
+  const defaultKeys = Object.keys(defaults);
+  if (bodyParams.length === 0 && defaultKeys.length === 0 && infer.length === 0) {
+    return 'null';
+  }
+
+  const local = uniqueLocalName('payload', params);
+  lines.push(`        val ${local} = JsonBody()`);
+  for (const p of bodyParams) {
+    lines.push(`        ${local}.set(${ktStringLiteral(p.wire)}, ${p.name})`);
+  }
+  for (const key of defaultKeys) {
+    lines.push(`        ${local}.set(${ktStringLiteral(key)}, ${ktLiteral(defaults[key])})`);
+  }
+  for (const key of infer) {
+    lines.push(`        ${local}.set(${ktStringLiteral(key)}, ${clientFieldExpr(key)})`);
+  }
+  return local;
+}
+
+/** Map an `inferFromClient` wire key to the client configuration property. */
+export function clientFieldExpr(key: string): string {
+  if (key === 'client_id') return 'transport.configuration.clientId';
+  if (key === 'client_secret') return 'transport.configuration.apiKey';
+  return `transport.configuration.${propertyName(key)}`;
+}

--- a/src/android/resources.ts
+++ b/src/android/resources.ts
@@ -43,9 +43,15 @@ export function generateResources(_services: Service[], ctx: EmitterContext): Ge
 
 // --- TypeRef helpers --------------------------------------------------------
 
-function isStringPrimitive(ref: TypeRef): boolean {
-  const base = unwrapNullableRef(ref);
-  return base.kind === 'primitive' && base.type === 'string' && base.format !== 'date-time' && base.format !== 'date';
+/**
+ * True when a `TypeRef` renders as Kotlin `String` — the case where `.toString()`
+ * would be redundant. Covers primitive strings AND string-valued literals
+ * (`{ kind: 'literal', value: 'login' }`), which `mapTypeRef` also renders as
+ * `String`. Date/date-time strings are excluded: `mapTypeRef` renders those as
+ * `Instant`/`LocalDate`, so they still need `.toString()` to produce wire text.
+ */
+function rendersAsString(ref: TypeRef): boolean {
+  return mapTypeRef(unwrapNullableRef(ref)) === 'String';
 }
 
 // --- rendering --------------------------------------------------------------
@@ -537,7 +543,7 @@ function renderPathExpr(op: Operation, params: RenderedParam[]): string {
 
 function queryValueExpr(name: string, ref: TypeRef): string {
   if (isEnumTypeRef(ref)) return `${name}.rawValue`;
-  if (isStringPrimitive(ref)) return name;
+  if (rendersAsString(ref)) return name;
   return `${name}.toString()`;
 }
 
@@ -546,7 +552,7 @@ function renderQueryAppend(q: RenderedParam): string[] {
   const out: string[] = [];
   if (base.kind === 'array') {
     const elem = base.items;
-    const elemExpr = isEnumTypeRef(elem) ? 'value.rawValue' : isStringPrimitive(elem) ? 'value' : 'value.toString()';
+    const elemExpr = isEnumTypeRef(elem) ? 'value.rawValue' : rendersAsString(elem) ? 'value' : 'value.toString()';
     const loop = (indent: string): void => {
       out.push(`${indent}for (value in ${q.optional ? 'it' : q.name}) {`);
       out.push(`${indent}    query.add(QueryParam(${ktStringLiteral(q.wire)}, ${elemExpr}))`);
@@ -568,7 +574,7 @@ function renderQueryAppend(q: RenderedParam): string[] {
   // (`{hd=example.com, access_type=offline}`) as a single opaque value, so the
   // provider would receive one meaningless parameter instead of the pairs.
   if (base.kind === 'map') {
-    const valueExpr = isStringPrimitive(base.valueType) ? 'value' : 'value.toString()';
+    const valueExpr = rendersAsString(base.valueType) ? 'value' : 'value.toString()';
     const loop = (indent: string): void => {
       out.push(`${indent}for ((key, value) in ${q.optional ? 'it' : q.name}) {`);
       // `[$key]` is a Kotlin template referencing the loop variable; the wire name

--- a/src/android/smoke-plan.ts
+++ b/src/android/smoke-plan.ts
@@ -1,0 +1,107 @@
+import type { EmitterContext, GeneratedFile, TypeRef } from '@workos/oagen';
+import { groupByMount } from '../shared/resolved-ops.js';
+import { accessorName, resolveMethodName, typeName, withResolvedOps } from './naming.js';
+import { collectMethodParams, orderMethodParams } from './resources.js';
+
+/**
+ * Emit `.oagen-android-smoke.json` — an authoritative, transform-aware call plan
+ * the Kotlin smoke runner consumes to build driver calls.
+ *
+ * The smoke runner parses the spec WITHOUT the consumer's schemaNameTransform /
+ * operationHints, so it cannot re-derive the generated method names, enum type
+ * names, or hidden params. This sidecar is produced with the full emitter
+ * context, so every method/service/param/enum-type it lists matches the generated
+ * SDK exactly. Split (wrapper) and URL-builder operations are omitted (the runner
+ * skips them). Not merged into a live SDK (`integrateTarget: false`).
+ */
+export function generateSmokePlan(ctx: EmitterContext): GeneratedFile {
+  const rctx = withResolvedOps(ctx);
+  const operations: Record<string, SmokePlanEntry> = {};
+
+  for (const group of groupByMount(rctx).values()) {
+    const service = accessorName(group.name);
+    for (const resolved of group.resolvedOps) {
+      if (resolved.urlBuilder) continue;
+      if (resolved.wrappers && resolved.wrappers.length > 0) continue;
+      const op = resolved.operation;
+      const httpKey = `${op.httpMethod.toUpperCase()} ${op.path}`;
+      const params = orderMethodParams(collectMethodParams(resolved, rctx)).map((p) => ({
+        label: stripBackticks(p.name),
+        wire: p.wire,
+        source: p.kind,
+        optional: p.optional,
+        serialize: serializeDescriptor(p.ref),
+      }));
+      operations[httpKey] = {
+        service: stripBackticks(service),
+        method: stripBackticks(resolveMethodName(op, group.name, rctx)),
+        params,
+      };
+    }
+  }
+
+  return {
+    path: '.oagen-android-smoke.json',
+    content: JSON.stringify({ version: 1, operations }, null, 2) + '\n',
+    integrateTarget: false,
+    overwriteExisting: true,
+    headerPlacement: 'skip',
+  };
+}
+
+/** The plan records logical selectors; the driver re-escapes if it needs to. */
+function stripBackticks(name: string): string {
+  return name.split('`').join('');
+}
+
+interface SmokePlanEntry {
+  service: string;
+  method: string;
+  params: Array<{
+    label: string;
+    wire: string;
+    source: 'path' | 'query' | 'body' | 'bodyRaw';
+    optional: boolean;
+    serialize: Serialize;
+  }>;
+}
+
+type Serialize =
+  | { kind: 'string' | 'int' | 'long' | 'double' | 'bool' | 'instant' | 'bytes' | 'json' | 'unsupported' }
+  | { kind: 'enum'; enumType: string }
+  | { kind: 'array'; element: Serialize }
+  | { kind: 'map'; value: Serialize };
+
+/**
+ * Describe how to serialize a runtime value to a Kotlin literal for a given IR
+ * type. Enum type names are resolved with the emitter's `typeName`, so they match
+ * the generated enums (which the smoke runner cannot otherwise compute).
+ */
+function serializeDescriptor(ref: TypeRef): Serialize {
+  const base = ref.kind === 'nullable' ? ref.inner : ref;
+  switch (base.kind) {
+    case 'enum':
+      return { kind: 'enum', enumType: typeName(base.name) };
+    case 'primitive':
+      if (base.type === 'unknown') return { kind: 'json' };
+      if (base.format === 'date-time' || base.format === 'date') return { kind: 'instant' };
+      if (base.format === 'binary' || base.format === 'byte') return { kind: 'bytes' };
+      if (base.type === 'string') return { kind: 'string' };
+      if (base.type === 'integer') return { kind: base.format === 'int32' ? 'int' : 'long' };
+      if (base.type === 'number') return { kind: 'double' };
+      if (base.type === 'boolean') return { kind: 'bool' };
+      return { kind: 'unsupported' };
+    case 'array':
+      return { kind: 'array', element: serializeDescriptor(base.items) };
+    case 'map':
+      return { kind: 'map', value: serializeDescriptor(base.valueType) };
+    case 'literal':
+      if (typeof base.value === 'string') return { kind: 'string' };
+      if (typeof base.value === 'number') return Number.isInteger(base.value) ? { kind: 'long' } : { kind: 'double' };
+      if (typeof base.value === 'boolean') return { kind: 'bool' };
+      return { kind: 'unsupported' };
+    default:
+      // model / union — cannot construct a value literal in the driver
+      return { kind: 'unsupported' };
+  }
+}

--- a/src/android/tests.ts
+++ b/src/android/tests.ts
@@ -866,7 +866,17 @@ class SuiteGenerator {
       case 'primitive':
         switch (ref.type) {
           case 'string': {
-            if (ref.format === 'date-time' || ref.format === 'date') {
+            // Keep the sample type in lockstep with `mapPrimitive` in type-map.ts:
+            // `date` maps to `LocalDate` (no time or offset), `date-time` to
+            // `Instant`. Emitting an `Instant` sample for a `date` field would not
+            // compile against a `LocalDate` parameter.
+            if (ref.format === 'date') {
+              return {
+                expr: 'LocalDate.parse("2023-01-01")',
+                imports: ['kotlinx.datetime.LocalDate'],
+              };
+            }
+            if (ref.format === 'date-time') {
               return {
                 expr: 'Instant.parse("2023-01-01T00:00:00Z")',
                 imports: ['kotlinx.datetime.Instant'],

--- a/src/android/tests.ts
+++ b/src/android/tests.ts
@@ -34,6 +34,7 @@ import {
   resolvePaginatedItemName,
 } from './resources.js';
 import type { RenderedParam } from './resources.js';
+import { fieldKotlinType } from './type-map.js';
 import { renderImportBlock } from './imports.js';
 import { generateModelFixture } from './fixtures.js';
 
@@ -572,7 +573,7 @@ class SuiteGenerator {
       lines.push(`            assertTrue(body.containsKey(${ktStringLiteral(firstBodyWire)}))`);
     }
     if (model && fixture) {
-      for (const assertion of this.idAssertion(model, fixture, 'result')) {
+      for (const assertion of this.fieldAssertion(model, fixture, 'result')) {
         lines.push(`            ${assertion}`);
       }
     }
@@ -967,7 +968,7 @@ class SuiteGenerator {
       const json = `{"data":[${JSON.stringify(item)}],"list_metadata":{"before":null,"after":null}}`;
       const assertions = [
         'assertEquals(1, result.data.size)',
-        ...this.idAssertion(itemModel, item, 'result.data.first()'),
+        ...this.fieldAssertion(itemModel, item, 'result.data.first()'),
       ];
       return { json, binding: true, assertions };
     }
@@ -988,23 +989,172 @@ class SuiteGenerator {
       return {
         json: JSON.stringify(fixture),
         binding: true,
-        assertions: this.idAssertion(model, fixture, 'result'),
+        assertions: this.fieldAssertion(model, fixture, 'result'),
       };
     }
     return { json: '{}', binding: false, assertions: [] };
   }
 
-  /** Assert the decoded `id` when the model has a plain required string id. */
-  private idAssertion(model: Model, fixture: Record<string, unknown>, target: string): string[] {
-    const idField = model.fields.find(
-      (f) => f.name === 'id' && f.required && f.type.kind === 'primitive' && f.type.type === 'string' && !f.type.format,
-    );
-    const value = fixture['id'];
-    if (!idField || typeof value !== 'string') {
-      this.imports.add('kotlin.test.assertNotNull');
-      return [`assertNotNull(${target})`];
+  /**
+   * Assert one real decoded field value on the response, which
+   * `docs/lang-gen/sdk-runtime-contract.md` §6 requires of every per-service test
+   * ("at least one meaningful field value"; existence-only assertions are listed
+   * as an anti-pattern).
+   *
+   * `id` is preferred so the common case reads consistently across suites, but any
+   * required scalar will do — otherwise every response model without a string `id`
+   * (`AuthenticateResponse`, `AuthorizationCheck`, …) degrades to `assertNotNull`
+   * even though its fixture carries a perfectly assertable `access_token` or
+   * `authorized`.
+   *
+   * Envelope responses (`{"user":{…}}`, `{"object":"list","data":[…]}`) hold no
+   * scalar of their own, so the search descends through required model and
+   * model-array fields to reach one. Descending only through REQUIRED fields is what
+   * keeps the emitted chain non-null, so no `?.` or `!!` is ever needed.
+   */
+  private fieldAssertion(model: Model, fixture: Record<string, unknown>, target: string): string[] {
+    const found = this.scalarAssertion(model, fixture, target, 0, new Set());
+    if (found) return found;
+    this.imports.add('kotlin.test.assertNotNull');
+    return [`assertNotNull(${target})`];
+  }
+
+  /**
+   * Depth-first search for an assertable scalar, `null` when the model has none.
+   *
+   * `nullableChain` tracks whether any hop so far was optional. Once one is, EVERY
+   * later hop must be a safe call: `a?.b.c` does not compile ("only safe calls are
+   * allowed on a nullable receiver"), so the separator is chosen from this flag
+   * rather than from the current field alone.
+   */
+  private scalarAssertion(
+    model: Model,
+    fixture: Record<string, unknown>,
+    target: string,
+    depth: number,
+    visited: Set<string>,
+    nullableChain = false,
+  ): string[] | null {
+    // Self-referential models (Role -> Role, Event -> Event) would otherwise
+    // recurse forever; the fixture generator caps itself at depth 4 the same way.
+    if (visited.has(model.name) || depth > 3) return null;
+    visited.add(model.name);
+    const sep = nullableChain ? '?.' : '.';
+
+    // Mirror the fixture generator's dedup so a flattened-union duplicate never
+    // points at a property the data class did not declare.
+    const seenProps = new Set<string>();
+    const all: { field: Model['fields'][number]; prop: string }[] = [];
+    for (const field of [...model.fields].sort((a, b) => Number(b.name === 'id') - Number(a.name === 'id'))) {
+      const prop = propertyName(field.domainName ?? field.name);
+      if (seenProps.has(prop)) continue;
+      seenProps.add(prop);
+      all.push({ field, prop });
     }
-    return [`assertEquals(${ktStringLiteral(value)}, ${target}.id)`];
+    const candidates = all.filter((c) => c.field.required);
+
+    // Tier 1 — a required scalar on this level. The shallowest assertion is the
+    // clearest, so this is preferred over anything reached by descending.
+    for (const { field, prop } of candidates) {
+      if (field.type.kind !== 'primitive') continue;
+      const literal = ktScalarLiteral(fieldKotlinType(field.type, true), fixture[field.name]);
+      if (literal) return [`assertEquals(${literal}, ${target}${sep}${prop})`];
+    }
+
+    // Tier 2 — descend through required models and model arrays.
+    for (const { field, prop } of candidates) {
+      const found = this.descend(field.type, fixture[field.name], `${target}${sep}${prop}`, depth, visited, false);
+      if (found) return found;
+    }
+
+    // Tier 3 — any scalar on this level, including optional and explicitly
+    // `nullable` ones. The fixture generator populates optionals and unwraps
+    // `nullable`, so the value is on the wire and decodes non-null; the Kotlin
+    // property is `T?`, which `assertEquals` accepts by inferring `T?`.
+    for (const { field, prop } of all) {
+      const scalar = field.type.kind === 'nullable' ? field.type.inner : field.type;
+      if (scalar.kind !== 'primitive') continue;
+      const literal = ktScalarLiteral(fieldKotlinType(scalar, true), fixture[field.name]);
+      if (literal) return [`assertEquals(${literal}, ${target}${sep}${prop})`];
+    }
+
+    // Tier 4 — descend through an OPTIONAL model with a safe call. Reached only by
+    // responses whose every field is optional and whose payload is nested
+    // (`DataIntegrationAccessTokenResponse`: `active` is a discriminator literal and
+    // the real value sits in the optional `access_token`). Without this they fall
+    // back to `assertNotNull`, which §6 lists as an anti-pattern.
+    for (const { field, prop } of all) {
+      if (field.required) continue;
+      const inner = field.type.kind === 'nullable' ? field.type.inner : field.type;
+      const found = this.descend(inner, fixture[field.name], `${target}${sep}${prop}`, depth, visited, true);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  /** Recurse into a model or model-array `TypeRef`, or return `null` if it is neither. */
+  private descend(
+    ref: TypeRef,
+    value: unknown,
+    target: string,
+    depth: number,
+    visited: Set<string>,
+    nullableChain: boolean,
+  ): string[] | null {
+    const sep = nullableChain ? '?.' : '.';
+    if (ref.kind === 'model') {
+      const nested = this.modelMap.get(ref.name);
+      if (!nested || typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+      return this.scalarAssertion(nested, value as Record<string, unknown>, target, depth + 1, visited, nullableChain);
+    }
+    // A non-paginated list envelope: the decoded element count is itself a real
+    // field value, and the first element usually carries an id worth asserting.
+    if (ref.kind === 'array' && ref.items.kind === 'model' && Array.isArray(value) && value.length > 0) {
+      const nested = this.modelMap.get(ref.items.name);
+      const size = `assertEquals(${value.length}, ${target}${sep}size)`;
+      const first = value[0];
+      if (!nested || typeof first !== 'object' || first === null) return [size];
+      const inner = this.scalarAssertion(
+        nested,
+        first as Record<string, unknown>,
+        `${target}${sep}first()`,
+        depth + 1,
+        visited,
+        nullableChain,
+      );
+      return inner ? [size, ...inner] : [size];
+    }
+    return null;
+  }
+}
+
+/**
+ * Render a fixture value as a Kotlin literal of exactly `kotlinType`, or `null`
+ * when it cannot be. The type is the one the model generator declared for the
+ * property, so the literal can never drift from it — which matters for the
+ * numerics: `assertEquals(1, aLong)` compiles (both widen to `Any`) and then
+ * fails at runtime, so `Long` must get `1L` and `Double` must get `1.0`.
+ */
+function ktScalarLiteral(kotlinType: string, value: unknown): string | null {
+  switch (kotlinType) {
+    case 'String':
+      return typeof value === 'string' ? ktStringLiteral(value) : null;
+    case 'Boolean':
+      return typeof value === 'boolean' ? String(value) : null;
+    case 'Int':
+      return typeof value === 'number' && Number.isInteger(value) ? String(value) : null;
+    case 'Long':
+      return typeof value === 'number' && Number.isInteger(value) ? `${value}L` : null;
+    case 'Double':
+      return typeof value === 'number' && Number.isFinite(value)
+        ? Number.isInteger(value)
+          ? `${value}.0`
+          : String(value)
+        : null;
+    default:
+      // Instant, LocalDate, ByteArray, JsonElement: no literal form that compares
+      // equal to a JSON string, so those fields are not assertion candidates.
+      return null;
   }
 }
 

--- a/src/android/tests.ts
+++ b/src/android/tests.ts
@@ -1,0 +1,999 @@
+import type {
+  ApiSpec,
+  EmitterContext,
+  GeneratedFile,
+  Model,
+  Enum,
+  TypeRef,
+  ResolvedOperation,
+  ResolvedWrapper,
+} from '@workos/oagen';
+import { planOperation } from '@workos/oagen';
+import { scopedMountGroups, getOpDefaults, isModelInScope, isEnumInScope } from '../shared/resolved-ops.js';
+import { resolveWrapperParams } from '../shared/wrapper-utils.js';
+import { enrichModelsFromSpec, getSyntheticEnums } from '../shared/model-utils.js';
+import { flattenDiscriminatedUnionFields } from '../shared/union-flatten.js';
+import { parsePathTemplate } from '../shared/path-template.js';
+import {
+  typeName,
+  accessorName,
+  resourceTypeName,
+  resolveMethodName,
+  methodName,
+  propertyName,
+  subPackage,
+  testSourcePath,
+  ktStringLiteral,
+  withResolvedOps,
+} from './naming.js';
+import {
+  collectMethodParams,
+  orderMethodParams,
+  planAutoPaging,
+  autoPagingMethodName,
+  resolvePaginatedItemName,
+} from './resources.js';
+import type { RenderedParam } from './resources.js';
+import { renderImportBlock } from './imports.js';
+import { generateModelFixture } from './fixtures.js';
+
+/**
+ * Generate the spec-driven test suites:
+ *
+ * - One suite per mount group with one wire-level test per operation: each test
+ *   calls the real generated method against a fixture response and asserts the
+ *   HTTP method, the rendered path, the encoded body/query, and that the response
+ *   decodes into the expected type.
+ * - One multi-page auto-pagination test driving the generated `Flow` through two
+ *   stubbed pages.
+ *
+ * The static test support (`testClient`, the `RecordedRequest` helpers) and the
+ * transport behavior suite are hand-maintained in the SDK repo with
+ * `@oagen-ignore-file`. Keeping the MockWebServer-specific details behind those
+ * helpers means a MockWebServer API change is a one-file edit rather than a
+ * regeneration of every suite. Live wire parity is covered separately by the
+ * oagen smoke runner (`smoke/sdk-android.ts`).
+ */
+export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
+  const rctx = withResolvedOps(ctx);
+  const groups = [...scopedMountGroups(rctx).values()].sort((a, b) => a.name.localeCompare(b.name));
+
+  // Fixtures must decode into the emitted data classes, so mirror the exact model
+  // pipeline the model generator runs (enrich + union-flatten).
+  const enriched = enrichModelsFromSpec(spec.models, spec.enums);
+  const originalByName = new Map(spec.models.map((m) => [m.name, m]));
+  const flatModels = flattenDiscriminatedUnionFields(
+    enriched.map((m) => {
+      if (m.discriminator && m.fields.length === 0) {
+        const original = originalByName.get(m.name);
+        if (original && original.fields.length > 0) return { ...m, fields: original.fields };
+      }
+      return m;
+    }),
+  );
+  const modelMap = new Map(flatModels.map((m) => [m.name, m]));
+  const enumMap = new Map([...spec.enums, ...getSyntheticEnums()].map((e) => [e.name, e]));
+
+  const files: GeneratedFile[] = [];
+
+  // Generate the multi-page auto-pagination test exactly once, on the first
+  // paginated operation (deterministic: groups and ops are sorted).
+  let autoPagingEmitted = false;
+
+  for (const group of groups) {
+    const gen = new SuiteGenerator(rctx, modelMap, enumMap);
+    const suite = typeName(group.name);
+    const accessor = accessorName(group.name);
+    const resource = resourceTypeName(group.name, rctx);
+
+    // No existence-only "resource is reachable" test: the runtime contract's §6
+    // anti-patterns forbid asserting that a symbol exists. Reachability is proven
+    // by the per-operation tests, which call through the accessor for real.
+    const tests: string[] = [];
+
+    const seen = new Set<string>();
+    for (const resolved of [...group.resolvedOps].sort((a, b) => a.operation.path.localeCompare(b.operation.path))) {
+      if (resolved.urlBuilder) {
+        const method = resolveMethodName(resolved.operation, group.name, rctx);
+        if (seen.has(method)) continue;
+        seen.add(method);
+        const test = gen.urlBuilderTest(resolved, accessor, method);
+        if (test) tests.push('', test);
+        continue;
+      }
+      if (resolved.wrappers && resolved.wrappers.length > 0) {
+        for (const wrapper of resolved.wrappers) {
+          const method = methodName(wrapper.name);
+          if (seen.has(method)) continue;
+          seen.add(method);
+          const test = gen.wrapperTest(resolved, wrapper, accessor, method);
+          if (test) tests.push('', test);
+        }
+        continue;
+      }
+      const method = resolveMethodName(resolved.operation, group.name, rctx);
+      if (seen.has(method)) continue;
+      seen.add(method);
+      const test = gen.operationTest(resolved, accessor, method);
+      if (test) tests.push('', test);
+      if (!autoPagingEmitted) {
+        const autoTest = gen.autoPagingTest(resolved, accessor, method);
+        if (autoTest) {
+          tests.push('', autoTest);
+          autoPagingEmitted = true;
+        }
+      }
+    }
+
+    // §6 suite-level coverage: error paths, per-request options, query encoding,
+    // and the empty-page case. Ordered ops so the chosen subject is deterministic.
+    const sortedOps = [...group.resolvedOps].sort((a, b) => a.operation.path.localeCompare(b.operation.path));
+    const emptyPage = gen.emptyPageTest(sortedOps, accessor, group.name);
+    if (emptyPage) tests.push('', emptyPage);
+    const queryEncoding = gen.queryEncodingTest(sortedOps, accessor, group.name);
+    if (queryEncoding) tests.push('', queryEncoding);
+    const requestOptions = gen.requestOptionsTest(sortedOps, accessor, group.name);
+    if (requestOptions) tests.push('', requestOptions);
+    for (const errTest of gen.errorPathTests(sortedOps, accessor, group.name)) {
+      tests.push('', errTest);
+    }
+
+    // A mount group whose every operation is unsampleable would otherwise emit an
+    // empty test class — noise that also reads as coverage. Skip the file instead.
+    if (tests.length === 0) continue;
+
+    const pkg = subPackage(rctx, '');
+    const imports = new Set<string>([
+      'kotlinx.coroutines.test.runTest',
+      'org.junit.jupiter.api.Test',
+      `${subPackage(rctx, 'support')}.testClient`,
+      ...gen.imports,
+    ]);
+
+    const lines: string[] = [];
+    lines.push(`package ${pkg}`);
+    lines.push('');
+    lines.push(...renderImportBlock(imports, pkg));
+    lines.push('');
+    lines.push(`/**`);
+    lines.push(` * Wire-level tests for the ${resource} resource: each test performs a real call`);
+    lines.push(' * through the mocked transport and asserts the request that went out and the');
+    lines.push(' * decoded response that came back.');
+    lines.push(' */');
+    lines.push(`class ${suite}Test {`);
+    lines.push(tests.join('\n'));
+    lines.push('}');
+    files.push({ path: testSourcePath(rctx, '', `${suite}Test`), content: lines.join('\n') });
+  }
+
+  const roundTrip = generateModelRoundTripTests(flatModels, enumMap, rctx);
+  if (roundTrip) files.push(roundTrip);
+
+  const enumForwardCompat = generateEnumForwardCompatTests([...enumMap.values()], rctx);
+  if (enumForwardCompat) files.push(enumForwardCompat);
+
+  return files;
+}
+
+/**
+ * Forward-compatible enum tests (§5: "unknown enum values should be preserved").
+ *
+ * The sealed-class-plus-`Unknown(value)` shape is this emitter's distinguishing
+ * choice over `enum class`, and its whole point is that a value the API adds after
+ * this SDK shipped survives a decode/encode cycle byte-for-byte instead of throwing
+ * or collapsing to a sentinel. Nothing else in the suite exercises that: the
+ * per-operation and model round-trip tests only ever feed values the spec already
+ * knows, so a serializer that silently dropped the carrier would pass all of them.
+ *
+ * Each test asserts both directions, because either alone is insufficient:
+ * decoding proves the unknown value is captured, re-encoding proves it is not lost.
+ * A known value is checked in the same test so that an over-eager serializer
+ * mapping *everything* to `Unknown` fails too.
+ */
+function generateEnumForwardCompatTests(enums: Enum[], ctx: EmitterContext): GeneratedFile | null {
+  const cases: Array<{ type: string; known: string; isNumeric: boolean }> = [];
+  for (const e of [...enums].sort((a, b) => a.name.localeCompare(b.name))) {
+    if (e.values.length === 0) continue;
+    if (!isEnumInScope(e.name, ctx)) continue;
+    // A numeric enum has no unrepresentable string, so the unknown carrier is
+    // exercised with an out-of-range number instead.
+    const isNumeric = e.values.every((v) => typeof v.value === 'number');
+    cases.push({ type: typeName(e.name), known: String(e.values[0].value), isNumeric });
+    // Proportionate: the shape is identical across all of them, so a sample proves
+    // the generator, and the per-enum serializers are generated from one template.
+    if (cases.length >= 30) break;
+  }
+  if (cases.length === 0) return null;
+
+  const pkg = subPackage(ctx, '');
+  const imports = new Set<string>([
+    'kotlin.test.assertEquals',
+    'kotlin.test.assertTrue',
+    'kotlinx.serialization.json.Json',
+    'org.junit.jupiter.api.Test',
+  ]);
+  // Explicit per-enum imports, not a wildcard: ktlint's no-wildcard-imports rule
+  // rejects `enums.*` and cannot auto-correct it.
+  for (const c of cases) imports.add(`${subPackage(ctx, 'enums')}.${c.type}`);
+
+  const lines: string[] = [];
+  lines.push(`package ${pkg}`);
+  lines.push('');
+  lines.push(...renderImportBlock(imports, pkg));
+  lines.push('');
+  lines.push('/**');
+  lines.push(' * Forward-compatibility coverage for the generated enum serializers: a wire value');
+  lines.push(' * this SDK does not know must decode into `Unknown` and re-encode unchanged, and a');
+  lines.push(' * known value must still resolve to its own case.');
+  lines.push(' */');
+  lines.push('class EnumForwardCompatTest {');
+  lines.push('    private val json = Json { ignoreUnknownKeys = true }');
+  for (const c of cases) {
+    const unknownWire = c.isNumeric ? '987654' : 'totally-new-value-from-the-api';
+    const unknownJson = c.isNumeric ? '987654' : '"totally-new-value-from-the-api"';
+    const unknownArg = c.isNumeric ? unknownWire : ktStringLiteral(unknownWire);
+    const knownJson = c.isNumeric ? c.known : JSON.stringify(c.known);
+    lines.push('');
+    lines.push('    @Test');
+    lines.push(`    fun \`${c.type} preserves an unknown wire value\`() {`);
+    lines.push(`        val decoded = json.decodeFromString(${c.type}.serializer(), ${ktStringLiteral(unknownJson)})`);
+    lines.push('');
+    lines.push(`        assertEquals(${c.type}.Unknown(${unknownArg}), decoded)`);
+    lines.push(
+      `        assertEquals(${ktStringLiteral(unknownJson)}, json.encodeToString(${c.type}.serializer(), decoded))`,
+    );
+    lines.push('');
+    lines.push('        // A known value must still resolve to its own case, not Unknown.');
+    lines.push(`        val known = json.decodeFromString(${c.type}.serializer(), ${ktStringLiteral(knownJson)})`);
+    lines.push(`        assertTrue(known !is ${c.type}.Unknown)`);
+    lines.push(`        assertEquals(${ktLiteralForRaw(c.known, c.isNumeric)}, known.rawValue)`);
+    lines.push('    }');
+  }
+  lines.push('}');
+  return { path: testSourcePath(ctx, '', 'EnumForwardCompatTest'), content: lines.join('\n') };
+}
+
+/** Render an enum's raw value as the Kotlin literal its `rawValue` property returns. */
+function ktLiteralForRaw(value: string, isNumeric: boolean): string {
+  return isNumeric ? value : ktStringLiteral(value);
+}
+
+/**
+ * Model round-trip tests (§6): encode a constructed model to JSON, decode it
+ * back, and assert equality. This is what actually proves `@SerialName` wire
+ * mappings and the forward-compatible enum serializers survive a round trip —
+ * the per-operation tests only exercise the decode direction.
+ *
+ * Only models whose required fields are all sample-constructible are covered;
+ * a model needing a heterogeneous union is skipped rather than faked.
+ */
+function generateModelRoundTripTests(
+  models: Model[],
+  enumMap: Map<string, Enum>,
+  ctx: EmitterContext,
+): GeneratedFile | null {
+  const modelMap = new Map(models.map((m) => [m.name, m]));
+  const gen = new SuiteGenerator(ctx, modelMap, enumMap);
+  const pkg = subPackage(ctx, '');
+
+  const cases: Array<{ type: string; expr: string }> = [];
+  for (const model of [...models].sort((a, b) => a.name.localeCompare(b.name))) {
+    if (model.fields.length === 0) continue;
+    if (!isModelInScope(model.name, ctx)) continue;
+    const built = gen.sampleModelExpression(model.name);
+    if (!built) continue;
+    cases.push({ type: typeName(model.name), expr: built.expr });
+    // Keep the suite proportionate; the shapes repeat heavily across 500+ models.
+    if (cases.length >= 40) break;
+  }
+  if (cases.length === 0) return null;
+
+  const imports = new Set<string>([
+    'kotlin.test.assertEquals',
+    'kotlinx.serialization.json.Json',
+    'org.junit.jupiter.api.Test',
+    ...gen.imports,
+  ]);
+
+  const lines: string[] = [];
+  lines.push(`package ${pkg}`);
+  lines.push('');
+  lines.push(...renderImportBlock(imports, pkg));
+  lines.push('');
+  lines.push('/**');
+  lines.push(' * Serialization round-trip coverage: every model here is encoded, decoded, and');
+  lines.push(' * compared for equality, so a wrong `@SerialName` or a lossy enum serializer');
+  lines.push(' * fails here rather than silently corrupting a request body.');
+  lines.push(' */');
+  lines.push('class ModelRoundTripTest {');
+  lines.push('    private val json = Json { ignoreUnknownKeys = true; explicitNulls = false }');
+  for (const c of cases) {
+    lines.push('');
+    lines.push('    @Test');
+    lines.push(`    fun \`${c.type} round-trips through JSON\`() {`);
+    lines.push(`        val original = ${c.expr}`);
+    lines.push('');
+    lines.push(`        val encoded = json.encodeToString(${c.type}.serializer(), original)`);
+    lines.push(`        val decoded = json.decodeFromString(${c.type}.serializer(), encoded)`);
+    lines.push('');
+    lines.push('        assertEquals(original, decoded)');
+    lines.push('    }');
+  }
+  lines.push('}');
+  return { path: testSourcePath(ctx, '', 'ModelRoundTripTest'), content: lines.join('\n') };
+}
+
+// --- per-operation test generation -------------------------------------------
+
+interface SampleArg {
+  /** Kotlin argument expression. */
+  expr: string;
+  /** For path params: the literal value interpolated into the URL path. */
+  pathValue?: string;
+  /** For query params: the expected serialized query value. */
+  queryValue?: string;
+  /** Imports the expression requires. */
+  imports?: string[];
+}
+
+class SuiteGenerator {
+  /** Imports accumulated across every test rendered by this generator. */
+  readonly imports = new Set<string>();
+
+  constructor(
+    private ctx: EmitterContext,
+    private modelMap: Map<string, Model>,
+    private enumMap: Map<string, Enum>,
+  ) {}
+
+  /**
+   * Import a hand-maintained test-support helper. `pathOnly`/`bodyJson`/`queryParam`
+   * are EXTENSION functions on `RecordedRequest`, and Kotlin only resolves an
+   * extension that is explicitly imported (or declared in the same package) — a
+   * missing import here is a compile error in every generated suite, not a warning.
+   */
+  private supportImport(name: string): void {
+    this.imports.add(`${subPackage(this.ctx, 'support')}.${name}`);
+  }
+
+  /**
+   * Build a wire-level test for one operation, or null when a required parameter
+   * cannot be sample-constructed (heterogeneous-union bodies etc.).
+   */
+  operationTest(resolved: ResolvedOperation, accessor: string, method: string): string | null {
+    const op = resolved.operation;
+    const params = collectMethodParams(resolved, this.ctx);
+    const ordered = orderMethodParams(params);
+
+    const args: string[] = [];
+    const pathValues = new Map<string, string>();
+    let firstBodyWire: string | null = null;
+    let firstQuery: { wire: string; value: string } | null = null;
+    for (const p of ordered) {
+      if (p.optional) continue;
+      const sample = this.sampleArg(p);
+      if (!sample) return null;
+      args.push(`${p.name} = ${sample.expr}`);
+      if (p.kind === 'path' && sample.pathValue) pathValues.set(p.wire, sample.pathValue);
+      if (p.kind === 'body' && firstBodyWire === null) firstBodyWire = p.wire;
+      if (p.kind === 'query' && firstQuery === null && sample.queryValue) {
+        firstQuery = { wire: p.wire, value: sample.queryValue };
+      }
+    }
+
+    const expectedPath = this.expectedPath(op.path, pathValues);
+    if (expectedPath === null) return null;
+    const fixture = this.responseFixture(resolved);
+    if (fixture === null) return null;
+
+    this.imports.add('kotlin.test.assertEquals');
+
+    const lines: string[] = [];
+    lines.push('    @Test');
+    if (op.deprecated) lines.push('    @Suppress("DEPRECATION")');
+    lines.push(`    fun \`${testLabel(method)} sends expected request\`() =`);
+    lines.push('        runTest {');
+    lines.push(`            val (client, server) = testClient(responding = ${ktStringLiteral(fixture.json)})`);
+    const call = `client.${accessor}.${method}(${args.join(', ')})`;
+    if (fixture.binding) {
+      lines.push(`            val result = ${call}`);
+    } else {
+      lines.push(`            ${call}`);
+    }
+    lines.push('');
+    lines.push('            val request = server.takeRequest()');
+    lines.push(`            assertEquals(${ktStringLiteral(op.httpMethod.toUpperCase())}, request.method)`);
+    this.supportImport('pathOnly');
+    lines.push(`            assertEquals(${ktStringLiteral(expectedPath)}, request.pathOnly())`);
+    if (firstBodyWire) {
+      this.imports.add('kotlin.test.assertTrue');
+      this.supportImport('bodyJson');
+      lines.push(`            assertTrue(request.bodyJson().containsKey(${ktStringLiteral(firstBodyWire)}))`);
+    }
+    if (firstQuery) {
+      this.supportImport('queryParam');
+      lines.push(
+        `            assertEquals(${ktStringLiteral(firstQuery.value)}, request.queryParam(${ktStringLiteral(firstQuery.wire)}))`,
+      );
+    }
+    for (const assertion of fixture.assertions) {
+      lines.push(`            ${assertion}`);
+    }
+    lines.push('        }');
+    return lines.join('\n');
+  }
+
+  /**
+   * Build a test for a URL-builder operation: call the non-suspend method and
+   * assert the assembled URL's path and query (defaults, inferred, caller params).
+   */
+  urlBuilderTest(resolved: ResolvedOperation, accessor: string, method: string): string | null {
+    const op = resolved.operation;
+    const defaults = getOpDefaults(resolved);
+    const params = collectMethodParams(resolved, this.ctx);
+    const ordered = orderMethodParams(params);
+
+    const args: string[] = [];
+    const pathValues = new Map<string, string>();
+    let queryAssert: { wire: string; value: string } | null = null;
+    for (const p of ordered) {
+      if (p.optional) continue;
+      const sample = this.sampleArg(p);
+      if (!sample) return null;
+      args.push(`${p.name} = ${sample.expr}`);
+      if (p.kind === 'path' && sample.pathValue) pathValues.set(p.wire, sample.pathValue);
+      if (p.kind === 'query' && queryAssert === null && sample.queryValue) {
+        queryAssert = { wire: p.wire, value: sample.queryValue };
+      }
+    }
+    const expectedPath = this.expectedPath(op.path, pathValues);
+    if (expectedPath === null) return null;
+
+    this.imports.add('kotlin.test.assertEquals');
+    this.imports.add('kotlin.test.assertTrue');
+
+    const lines: string[] = [];
+    lines.push('    @Test');
+    if (op.deprecated) lines.push('    @Suppress("DEPRECATION")');
+    lines.push(`    fun \`${testLabel(method)} builds expected url\`() {`);
+    lines.push('        val (client, _) = testClient()');
+    lines.push('');
+    lines.push(`        val url = client.${accessor}.${method}(${args.join(', ')})`);
+    lines.push('');
+    lines.push(`        assertTrue(url.substringBefore('?').endsWith(${ktStringLiteral(expectedPath)}))`);
+    for (const [key, value] of Object.entries(defaults)) {
+      lines.push(`        assertTrue(url.contains(${ktStringLiteral(`${key}=${String(value)}`)}))`);
+    }
+    if (queryAssert) {
+      lines.push(`        assertTrue(url.contains(${ktStringLiteral(`${queryAssert.wire}=`)}))`);
+    }
+    lines.push('    }');
+    return lines.join('\n');
+  }
+
+  /**
+   * Build a wire-level test for one union-split wrapper method: call it with
+   * sample variant params and assert the request (including the discriminating
+   * default, e.g. `grant_type`) and the decoded response.
+   */
+  wrapperTest(resolved: ResolvedOperation, wrapper: ResolvedWrapper, accessor: string, method: string): string | null {
+    const op = resolved.operation;
+    const wparams = resolveWrapperParams(wrapper, this.ctx);
+
+    // Path params (rare for split ops) lead the signature, mirroring wrappers.ts.
+    const args: string[] = [];
+    const pathValues = new Map<string, string>();
+    for (const p of op.pathParams) {
+      const sample = this.sampleForRef(p.type, p.name, 'path');
+      if (!sample?.pathValue) return null;
+      args.push(`${propertyName(p.name)} = ${sample.expr}`);
+      pathValues.set(p.name, sample.pathValue);
+    }
+    let firstBodyWire: string | null = null;
+    for (const wp of wparams) {
+      if (wp.isOptional) continue;
+      const sample = wp.field
+        ? this.sampleForRef(wp.field.type, wp.paramName, 'body')
+        : { expr: ktStringLiteral(`test_${wp.paramName}`) };
+      if (!sample) return null;
+      args.push(`${propertyName(wp.paramName)} = ${sample.expr}`);
+      if (firstBodyWire === null) firstBodyWire = wp.paramName;
+    }
+    const expectedPath = this.expectedPath(op.path, pathValues);
+    if (expectedPath === null) return null;
+
+    const model = wrapper.responseModelName ? this.modelMap.get(wrapper.responseModelName) : undefined;
+    // A declared response type we cannot fixture would leave the result unused;
+    // skip rather than emit a test that asserts nothing about the response.
+    if (wrapper.responseModelName && !model) return null;
+    const fixture = model ? generateModelFixture(model, this.modelMap, this.enumMap) : null;
+    const json = fixture ? JSON.stringify(fixture) : '{}';
+
+    this.imports.add('kotlin.test.assertEquals');
+
+    const lines: string[] = [];
+    lines.push('    @Test');
+    lines.push(`    fun \`${testLabel(method)} sends expected request\`() =`);
+    lines.push('        runTest {');
+    lines.push(`            val (client, server) = testClient(responding = ${ktStringLiteral(json)})`);
+    const call = `client.${accessor}.${method}(${args.join(', ')})`;
+    if (model) {
+      lines.push(`            val result = ${call}`);
+    } else {
+      lines.push(`            ${call}`);
+    }
+    lines.push('');
+    lines.push('            val request = server.takeRequest()');
+    lines.push(`            assertEquals(${ktStringLiteral(op.httpMethod.toUpperCase())}, request.method)`);
+    this.supportImport('pathOnly');
+    lines.push(`            assertEquals(${ktStringLiteral(expectedPath)}, request.pathOnly())`);
+
+    const defaultEntries = Object.entries(wrapper.defaults ?? {});
+    if (defaultEntries.length > 0 || firstBodyWire !== null) {
+      this.supportImport('bodyJson');
+      lines.push('            val body = request.bodyJson()');
+    }
+    for (const [key, value] of defaultEntries) {
+      if (typeof value === 'string') {
+        this.imports.add('kotlinx.serialization.json.jsonPrimitive');
+        lines.push(
+          `            assertEquals(${ktStringLiteral(value)}, body[${ktStringLiteral(key)}]?.jsonPrimitive?.content)`,
+        );
+      } else {
+        this.imports.add('kotlin.test.assertTrue');
+        lines.push(`            assertTrue(body.containsKey(${ktStringLiteral(key)}))`);
+      }
+    }
+    if (firstBodyWire) {
+      this.imports.add('kotlin.test.assertTrue');
+      lines.push(`            assertTrue(body.containsKey(${ktStringLiteral(firstBodyWire)}))`);
+    }
+    if (model && fixture) {
+      for (const assertion of this.idAssertion(model, fixture, 'result')) {
+        lines.push(`            ${assertion}`);
+      }
+    }
+    lines.push('        }');
+    return lines.join('\n');
+  }
+
+  /** A two-page auto-pagination test for the first eligible paginated op. */
+  autoPagingTest(resolved: ResolvedOperation, accessor: string, method: string): string | null {
+    const auto = planAutoPaging(resolved, this.ctx);
+    if (!auto) return null;
+    // Only all-optional signatures keep this test simple and deterministic.
+    if (auto.params.some((p) => !p.optional)) return null;
+    const itemName = planOperation(resolved.operation).paginatedItemModelName;
+    if (!itemName) return null;
+    const itemModel = this.modelMap.get(resolvePaginatedItemName(itemName, this.ctx));
+    if (!itemModel || itemModel.fields.length === 0) return null;
+    const item = generateModelFixture(itemModel, this.modelMap, this.enumMap);
+    const itemJson = JSON.stringify(item);
+    const page1 = `{"data":[${itemJson}],"list_metadata":{"before":null,"after":"cursor_2"}}`;
+    const page2 = `{"data":[${itemJson}],"list_metadata":{"before":null,"after":null}}`;
+
+    this.imports.add('kotlin.test.assertEquals');
+    this.imports.add('kotlinx.coroutines.flow.toList');
+    this.supportImport('testClientWithStubs');
+    this.supportImport('queryParam');
+
+    const autoName = autoPagingMethodName(method);
+    const lines: string[] = [];
+    lines.push('    @Test');
+    lines.push(`    fun \`${testLabel(autoName)} fetches all pages\`() =`);
+    lines.push('        runTest {');
+    lines.push('            val (client, server) =');
+    lines.push('                testClientWithStubs(');
+    lines.push('                    listOf(');
+    lines.push(`                        ${ktStringLiteral(page1)},`);
+    lines.push(`                        ${ktStringLiteral(page2)},`);
+    lines.push('                    ),');
+    lines.push('                )');
+    lines.push('');
+    lines.push(`            val items = client.${accessor}.${autoName}().toList()`);
+    lines.push('');
+    lines.push('            assertEquals(2, items.size)');
+    lines.push('            server.takeRequest()');
+    lines.push('            val second = server.takeRequest()');
+    lines.push(`            assertEquals("cursor_2", second.queryParam(${ktStringLiteral(auto.cursorWire)}))`);
+    lines.push('        }');
+    return lines.join('\n');
+  }
+
+  // --- §6 suite-level coverage ---------------------------------------------
+
+  /**
+   * The first operation in the suite that can be called with sample arguments —
+   * used as the subject for the suite-level error-path, request-options, and
+   * query-encoding tests. Deterministic: callers pass path-sorted ops.
+   * URL builders are excluded (they issue no HTTP request).
+   */
+  private firstCallable(
+    resolvedOps: ResolvedOperation[],
+    mountName: string,
+  ): { resolved: ResolvedOperation; method: string; args: string[] } | null {
+    for (const resolved of resolvedOps) {
+      if (resolved.urlBuilder) continue;
+      if (resolved.wrappers && resolved.wrappers.length > 0) continue;
+      const method = resolveMethodName(resolved.operation, mountName, this.ctx);
+      const params = orderMethodParams(collectMethodParams(resolved, this.ctx));
+      const args: string[] = [];
+      let ok = true;
+      for (const p of params) {
+        if (p.optional) continue;
+        const sample = this.sampleArg(p);
+        if (!sample) {
+          ok = false;
+          break;
+        }
+        args.push(`${p.name} = ${sample.expr}`);
+      }
+      if (ok) return { resolved, method, args };
+    }
+    return null;
+  }
+
+  /**
+   * Error-path tests (§6): one per status code in the spec's own
+   * `ErrorPolicy.statusCodeMap`, plus the 5xx catch-all. Exception names are
+   * derived from that map rather than hardcoded, so a policy change moves the
+   * generated tests with it.
+   */
+  errorPathTests(resolvedOps: ResolvedOperation[], accessor: string, mountName: string): string[] {
+    const target = this.firstCallable(resolvedOps, mountName);
+    if (!target) return [];
+    const policy = this.ctx.spec.sdk.errors;
+
+    // 401/404/429/400/422 come from the map; 500 uses the server catch-all.
+    const wanted: Array<{ status: number; kind: string; headers?: string }> = [];
+    for (const status of [401, 404, 429, 400, 422]) {
+      const kind = policy.statusCodeMap[status];
+      if (!kind) continue;
+      // A 429 must carry Retry-After so the runtime's backoff path is exercised.
+      wanted.push({ status, kind, headers: status === 429 ? 'mapOf("Retry-After" to "0")' : undefined });
+    }
+    wanted.push({ status: 500, kind: policy.serverErrorKind });
+
+    this.imports.add('kotlin.test.assertFailsWith');
+    this.supportImport('testClientWithStatus');
+
+    const out: string[] = [];
+    for (const { status, kind, headers } of wanted) {
+      const exc = `${kind}Exception`;
+      const stub = headers
+        ? `testClientWithStatus(${status}, ${ktStringLiteral(`{"message":"error"}`)}, ${headers})`
+        : `testClientWithStatus(${status}, ${ktStringLiteral(`{"message":"error"}`)})`;
+      const lines: string[] = [];
+      lines.push('    @Test');
+      lines.push(`    fun \`${testLabel(target.method)} throws ${exc} on ${status}\`() =`);
+      lines.push('        runTest {');
+      lines.push(`            val (client, _) = ${stub}`);
+      lines.push('');
+      lines.push(`            val error =`);
+      lines.push(`                assertFailsWith<${exc}> {`);
+      lines.push(`                    client.${accessor}.${target.method}(${target.args.join(', ')})`);
+      lines.push('                }');
+      lines.push('');
+      lines.push(`            assertEquals(${status}, error.statusCode)`);
+      lines.push('        }');
+      out.push(lines.join('\n'));
+    }
+    this.imports.add('kotlin.test.assertEquals');
+    return out;
+  }
+
+  /**
+   * Per-request-options test (§6 / §7): proves the runtime actually HONORS an
+   * option rather than merely accepting the type — asserts the extra header
+   * reached the wire.
+   */
+  requestOptionsTest(resolvedOps: ResolvedOperation[], accessor: string, mountName: string): string | null {
+    const target = this.firstCallable(resolvedOps, mountName);
+    if (!target) return null;
+    const fixture = this.responseFixture(target.resolved);
+    if (fixture === null) return null;
+
+    this.imports.add('kotlin.test.assertEquals');
+    this.supportImport('headerValue');
+
+    const args = [...target.args, 'requestOptions = RequestOptions(headers = mapOf("X-Custom" to "value"))'];
+    const lines: string[] = [];
+    lines.push('    @Test');
+    lines.push('    fun `request options are honored on the wire`() =');
+    lines.push('        runTest {');
+    lines.push(`            val (client, server) = testClient(responding = ${ktStringLiteral(fixture.json)})`);
+    lines.push('');
+    lines.push(`            client.${accessor}.${target.method}(${args.join(', ')})`);
+    lines.push('');
+    lines.push('            val request = server.takeRequest()');
+    lines.push('            assertEquals("value", request.headerValue("X-Custom"))');
+    lines.push('        }');
+    return lines.join('\n');
+  }
+
+  /**
+   * Query-encoding test (§6): drives an optional string query param with a value
+   * containing a space and a slash, then asserts it survives encoding intact.
+   */
+  queryEncodingTest(resolvedOps: ResolvedOperation[], accessor: string, mountName: string): string | null {
+    for (const resolved of resolvedOps) {
+      if (resolved.urlBuilder) continue;
+      if (resolved.wrappers && resolved.wrappers.length > 0) continue;
+      const params = collectMethodParams(resolved, this.ctx);
+      const target = params.find((p) => p.kind === 'query' && p.optional && p.type === 'String?');
+      if (!target) continue;
+      // Every non-target required param must still be constructible.
+      const required = orderMethodParams(params).filter((p) => !p.optional);
+      const args: string[] = [];
+      let ok = true;
+      for (const p of required) {
+        const sample = this.sampleArg(p);
+        if (!sample) {
+          ok = false;
+          break;
+        }
+        args.push(`${p.name} = ${sample.expr}`);
+      }
+      if (!ok) continue;
+
+      const method = resolveMethodName(resolved.operation, mountName, this.ctx);
+      const fixture = this.responseFixture(resolved);
+      if (fixture === null) continue;
+      const raw = 'a b/c&d=e';
+      args.push(`${target.name} = ${ktStringLiteral(raw)}`);
+
+      this.imports.add('kotlin.test.assertEquals');
+      this.supportImport('queryParam');
+
+      const lines: string[] = [];
+      lines.push('    @Test');
+      lines.push(`    fun \`${testLabel(method)} percent-encodes special characters in query params\`() =`);
+      lines.push('        runTest {');
+      lines.push(`            val (client, server) = testClient(responding = ${ktStringLiteral(fixture.json)})`);
+      lines.push('');
+      lines.push(`            client.${accessor}.${method}(${args.join(', ')})`);
+      lines.push('');
+      lines.push('            val request = server.takeRequest()');
+      lines.push(
+        `            assertEquals(${ktStringLiteral(raw)}, request.queryParam(${ktStringLiteral(target.wire)}))`,
+      );
+      lines.push('        }');
+      return lines.join('\n');
+    }
+    return null;
+  }
+
+  /** Empty-page test (§6): a paginated call against `{"data":[]}` must yield an empty page. */
+  emptyPageTest(resolvedOps: ResolvedOperation[], accessor: string, mountName: string): string | null {
+    for (const resolved of resolvedOps) {
+      if (resolved.urlBuilder) continue;
+      if (resolved.wrappers && resolved.wrappers.length > 0) continue;
+      if (!planOperation(resolved.operation).isPaginated) continue;
+      const params = orderMethodParams(collectMethodParams(resolved, this.ctx));
+      const args: string[] = [];
+      let ok = true;
+      for (const p of params) {
+        if (p.optional) continue;
+        const sample = this.sampleArg(p);
+        if (!sample) {
+          ok = false;
+          break;
+        }
+        args.push(`${p.name} = ${sample.expr}`);
+      }
+      if (!ok) continue;
+
+      const method = resolveMethodName(resolved.operation, mountName, this.ctx);
+      this.imports.add('kotlin.test.assertTrue');
+      const empty = '{"data":[],"list_metadata":{"before":null,"after":null}}';
+      const lines: string[] = [];
+      lines.push('    @Test');
+      lines.push(`    fun \`${testLabel(method)} returns an empty page\`() =`);
+      lines.push('        runTest {');
+      lines.push(`            val (client, _) = testClient(responding = ${ktStringLiteral(empty)})`);
+      lines.push('');
+      lines.push(`            val result = client.${accessor}.${method}(${args.join(', ')})`);
+      lines.push('');
+      lines.push('            assertTrue(result.data.isEmpty())');
+      lines.push('        }');
+      return lines.join('\n');
+    }
+    return null;
+  }
+
+  /** Render the expected URL path for a template with sample path values. */
+  private expectedPath(template: string, pathValues: Map<string, string>): string | null {
+    const segments = parsePathTemplate(template, { stripLeadingSlash: true });
+    let path = '';
+    for (const seg of segments) {
+      if (seg.kind === 'literal') {
+        path += seg.value;
+      } else {
+        const value = pathValues.get(seg.name);
+        if (!value) return null; // hidden/unsampled path param
+        path += value;
+      }
+    }
+    return `/${path}`;
+  }
+
+  /**
+   * Sample constructor expression for a model, or null when a required field
+   * cannot be built. Accumulates the imports the expression needs.
+   */
+  sampleModelExpression(modelName: string): SampleArg | null {
+    const sample = this.sampleForRef({ kind: 'model', name: modelName }, modelName, 'body');
+    if (sample?.imports) for (const imp of sample.imports) this.imports.add(imp);
+    return sample;
+  }
+
+  /** Sample Kotlin expression for a required parameter, or null if unsupported. */
+  private sampleArg(p: RenderedParam): SampleArg | null {
+    const sample = this.sampleForRef(p.ref, p.kind === 'bodyRaw' ? p.wire || 'body' : p.wire, p.kind);
+    if (sample?.imports) for (const imp of sample.imports) this.imports.add(imp);
+    return sample;
+  }
+
+  private sampleForRef(ref: TypeRef, wire: string, kind: RenderedParam['kind'], depth = 0): SampleArg | null {
+    if (depth > 4) return null; // guard against recursive model graphs
+    switch (ref.kind) {
+      case 'nullable':
+        return this.sampleForRef(ref.inner, wire, kind, depth);
+      case 'primitive':
+        switch (ref.type) {
+          case 'string': {
+            if (ref.format === 'date-time' || ref.format === 'date') {
+              return {
+                expr: 'Instant.parse("2023-01-01T00:00:00Z")',
+                imports: ['kotlinx.datetime.Instant'],
+              };
+            }
+            if (ref.format === 'byte' || ref.format === 'binary') {
+              return { expr: '"test".toByteArray()' };
+            }
+            const value = kind === 'path' ? `sample-${wire.replace(/[^a-zA-Z0-9]+/g, '-')}` : `test_${wire}`;
+            return { expr: ktStringLiteral(value), pathValue: value, queryValue: value };
+          }
+          case 'integer':
+            return ref.format === 'int32'
+              ? { expr: '1', pathValue: '1', queryValue: '1' }
+              : { expr: '1L', pathValue: '1', queryValue: '1' };
+          case 'number':
+            return { expr: '1.5', queryValue: '1.5' };
+          case 'boolean':
+            return { expr: 'true', queryValue: 'true' };
+          case 'unknown':
+            return {
+              expr: 'JsonPrimitive("test")',
+              imports: ['kotlinx.serialization.json.JsonPrimitive'],
+            };
+          default:
+            return null;
+        }
+      case 'literal':
+        if (typeof ref.value === 'string') {
+          return { expr: ktStringLiteral(ref.value), queryValue: ref.value };
+        }
+        if (typeof ref.value === 'number') {
+          return Number.isInteger(ref.value)
+            ? { expr: `${ref.value}L`, queryValue: String(ref.value) }
+            : { expr: String(ref.value), queryValue: String(ref.value) };
+        }
+        if (typeof ref.value === 'boolean') {
+          return { expr: String(ref.value), queryValue: String(ref.value) };
+        }
+        return null;
+      case 'enum': {
+        const e = this.enumMap.get(ref.name);
+        const first = e?.values[0]?.value;
+        if (first === undefined) return null;
+        const literal = typeof first === 'string' ? ktStringLiteral(first) : String(first);
+        const enumType = typeName(ref.name);
+        return {
+          expr: `${enumType}.fromRawValue(${literal})`,
+          pathValue: String(first),
+          queryValue: String(first),
+          imports: [`${subPackage(this.ctx, 'enums')}.${enumType}`],
+        };
+      }
+      case 'array': {
+        const inner = this.sampleForRef(ref.items, wire, 'body', depth + 1);
+        if (!inner) return null;
+        return { expr: `listOf(${inner.expr})`, imports: inner.imports };
+      }
+      case 'map': {
+        const inner = this.sampleForRef(ref.valueType, wire, 'body', depth + 1);
+        if (!inner) return null;
+        return { expr: `mapOf("key" to ${inner.expr})`, imports: inner.imports };
+      }
+      case 'model': {
+        // Construct the generated data class via its primary constructor:
+        // required fields only, using named arguments so the emitted
+        // required-first ordering cannot break the call.
+        const model = this.modelMap.get(ref.name);
+        if (!model) return null;
+        const modelType = typeName(model.name);
+        const imports = [`${subPackage(this.ctx, 'models')}.${modelType}`];
+        if (model.fields.length === 0) return { expr: `${modelType}()`, imports };
+        const args: string[] = [];
+        for (const f of model.fields) {
+          if (!f.required) continue;
+          const inner = this.sampleForRef(f.type, f.name, 'body', depth + 1);
+          if (!inner) return null;
+          if (inner.imports) imports.push(...inner.imports);
+          args.push(`${propertyName(f.domainName ?? f.name)} = ${inner.expr}`);
+        }
+        return { expr: `${modelType}(${args.join(', ')})`, imports };
+      }
+      default:
+        // union bodies need variant selection — skip those operations.
+        return null;
+    }
+  }
+
+  /** Fixture JSON + decode assertions for the operation's response. */
+  private responseFixture(
+    resolved: ResolvedOperation,
+  ): { json: string; binding: boolean; assertions: string[] } | null {
+    const op = resolved.operation;
+    const plan = planOperation(op);
+    if (plan.isPaginated && plan.paginatedItemModelName) {
+      const itemModel = this.modelMap.get(resolvePaginatedItemName(plan.paginatedItemModelName, this.ctx));
+      if (!itemModel || itemModel.fields.length === 0) return null;
+      const item = generateModelFixture(itemModel, this.modelMap, this.enumMap);
+      const json = `{"data":[${JSON.stringify(item)}],"list_metadata":{"before":null,"after":null}}`;
+      const assertions = [
+        'assertEquals(1, result.data.size)',
+        ...this.idAssertion(itemModel, item, 'result.data.first()'),
+      ];
+      return { json, binding: true, assertions };
+    }
+    if (plan.isArrayResponse && plan.responseModelName) {
+      const model = this.modelMap.get(plan.responseModelName);
+      if (!model || model.fields.length === 0) return null;
+      const item = generateModelFixture(model, this.modelMap, this.enumMap);
+      return { json: `[${JSON.stringify(item)}]`, binding: true, assertions: ['assertEquals(1, result.size)'] };
+    }
+    if (plan.responseModelName) {
+      const model = this.modelMap.get(plan.responseModelName);
+      if (!model) return null;
+      const fixture = generateModelFixture(model, this.modelMap, this.enumMap);
+      if (model.fields.length === 0) {
+        this.imports.add('kotlin.test.assertNotNull');
+        return { json: JSON.stringify(fixture), binding: true, assertions: ['assertNotNull(result)'] };
+      }
+      return {
+        json: JSON.stringify(fixture),
+        binding: true,
+        assertions: this.idAssertion(model, fixture, 'result'),
+      };
+    }
+    return { json: '{}', binding: false, assertions: [] };
+  }
+
+  /** Assert the decoded `id` when the model has a plain required string id. */
+  private idAssertion(model: Model, fixture: Record<string, unknown>, target: string): string[] {
+    const idField = model.fields.find(
+      (f) => f.name === 'id' && f.required && f.type.kind === 'primitive' && f.type.type === 'string' && !f.type.format,
+    );
+    const value = fixture['id'];
+    if (!idField || typeof value !== 'string') {
+      this.imports.add('kotlin.test.assertNotNull');
+      return [`assertNotNull(${target})`];
+    }
+    return [`assertEquals(${ktStringLiteral(value)}, ${target}.id)`];
+  }
+}
+
+/**
+ * Convert a Kotlin method identifier into a human-readable, backtick-safe test
+ * label. Back-ticks are stripped (a reserved-word method name would otherwise
+ * close the test function's own back-tick literal) and camelCase is split.
+ */
+function testLabel(method: string): string {
+  return method
+    .split('`')
+    .join('')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase();
+}

--- a/src/android/tests.ts
+++ b/src/android/tests.ts
@@ -147,6 +147,9 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
       'kotlinx.coroutines.test.runTest',
       'org.junit.jupiter.api.Test',
       `${subPackage(rctx, 'support')}.testClient`,
+      // Bounded request retrieval: an unbounded takeRequest() hangs until the CI
+      // job times out when the SDK issues no request, instead of failing legibly.
+      `${subPackage(rctx, 'support')}.awaitRequest`,
       ...gen.imports,
     ]);
 
@@ -401,7 +404,7 @@ class SuiteGenerator {
       lines.push(`            ${call}`);
     }
     lines.push('');
-    lines.push('            val request = server.takeRequest()');
+    lines.push('            val request = server.awaitRequest()');
     lines.push(`            assertEquals(${ktStringLiteral(op.httpMethod.toUpperCase())}, request.method)`);
     this.supportImport('pathOnly');
     lines.push(`            assertEquals(${ktStringLiteral(expectedPath)}, request.pathOnly())`);
@@ -467,6 +470,26 @@ class SuiteGenerator {
     if (queryAssert) {
       lines.push(`        assertTrue(url.contains(${ktStringLiteral(`${queryAssert.wire}=`)}))`);
     }
+
+    // A map-valued query param is the one shape whose encoding is easy to get
+    // silently wrong: stringifying the map yields Kotlin's own `{k=v}` rendering
+    // as a single opaque value, which the provider cannot read. Assert the
+    // bracketed form explicitly, and assert the un-bracketed name is absent so a
+    // regression to `toString()` fails rather than merely looking different.
+    const mapQuery = params.find(
+      (p) => p.kind === 'query' && (p.ref.kind === 'nullable' ? p.ref.inner : p.ref).kind === 'map',
+    );
+    if (mapQuery) {
+      const call = [...args, `${mapQuery.name} = mapOf("k1" to "v1")`].join(', ');
+      lines.push('');
+      lines.push(`        val withMap = client.${accessor}.${method}(${call})`);
+      // Query names go through URLEncoder, so the brackets arrive percent-encoded —
+      // `name%5Bk1%5D=v1`. Assert those literal bytes, matching what workos-kotlin
+      // puts on the wire. The negative assertion is the un-bracketed `name=`, which
+      // is exactly what a regression to `toString()` would produce.
+      lines.push(`        assertTrue(withMap.contains(${ktStringLiteral(`${mapQuery.wire}%5Bk1%5D=v1`)}))`);
+      lines.push(`        assertTrue(!withMap.contains(${ktStringLiteral(`${mapQuery.wire}=`)}))`);
+    }
     lines.push('    }');
     return lines.join('\n');
   }
@@ -523,7 +546,7 @@ class SuiteGenerator {
       lines.push(`            ${call}`);
     }
     lines.push('');
-    lines.push('            val request = server.takeRequest()');
+    lines.push('            val request = server.awaitRequest()');
     lines.push(`            assertEquals(${ktStringLiteral(op.httpMethod.toUpperCase())}, request.method)`);
     this.supportImport('pathOnly');
     lines.push(`            assertEquals(${ktStringLiteral(expectedPath)}, request.pathOnly())`);
@@ -593,8 +616,8 @@ class SuiteGenerator {
     lines.push(`            val items = client.${accessor}.${autoName}().toList()`);
     lines.push('');
     lines.push('            assertEquals(2, items.size)');
-    lines.push('            server.takeRequest()');
-    lines.push('            val second = server.takeRequest()');
+    lines.push('            server.awaitRequest()');
+    lines.push('            val second = server.awaitRequest()');
     lines.push(`            assertEquals("cursor_2", second.queryParam(${ktStringLiteral(auto.cursorWire)}))`);
     lines.push('        }');
     return lines.join('\n');
@@ -705,7 +728,7 @@ class SuiteGenerator {
     lines.push('');
     lines.push(`            client.${accessor}.${target.method}(${args.join(', ')})`);
     lines.push('');
-    lines.push('            val request = server.takeRequest()');
+    lines.push('            val request = server.awaitRequest()');
     lines.push('            assertEquals("value", request.headerValue("X-Custom"))');
     lines.push('        }');
     return lines.join('\n');
@@ -753,7 +776,7 @@ class SuiteGenerator {
       lines.push('');
       lines.push(`            client.${accessor}.${method}(${args.join(', ')})`);
       lines.push('');
-      lines.push('            val request = server.takeRequest()');
+      lines.push('            val request = server.awaitRequest()');
       lines.push(
         `            assertEquals(${ktStringLiteral(raw)}, request.queryParam(${ktStringLiteral(target.wire)}))`,
       );

--- a/src/android/type-map.ts
+++ b/src/android/type-map.ts
@@ -34,7 +34,13 @@ function mapPrimitive(ref: PrimitiveType): string {
   if (ref.format === 'int64') return 'Long';
   switch (ref.type) {
     case 'string':
-      if (ref.format === 'date-time' || ref.format === 'date') return 'Instant';
+      // `date` is a calendar date with no time or offset, so it cannot be parsed
+      // as an Instant — mapping both to Instant would throw at decode time on the
+      // first date-only field the spec introduces. The WorkOS spec currently has
+      // none (413 `date-time`, 0 `date`), so this changes no output today; it is
+      // here so that adding one is a type change rather than a runtime failure.
+      if (ref.format === 'date') return 'LocalDate';
+      if (ref.format === 'date-time') return 'Instant';
       return 'String';
     case 'integer':
       return 'Long';
@@ -85,6 +91,7 @@ export function fieldKotlinType(ref: TypeRef, required: boolean): string {
 export function implicitImportsFor(kotlinType: string): string[] {
   const imports: string[] = [];
   if (/\bInstant\b/.test(kotlinType)) imports.push('kotlinx.datetime.Instant');
+  if (/\bLocalDate\b/.test(kotlinType)) imports.push('kotlinx.datetime.LocalDate');
   if (/\bJsonElement\b/.test(kotlinType)) imports.push('kotlinx.serialization.json.JsonElement');
   return imports;
 }

--- a/src/android/type-map.ts
+++ b/src/android/type-map.ts
@@ -1,0 +1,90 @@
+import type { TypeRef, PrimitiveType, UnionType } from '@workos/oagen';
+import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
+import { typeName } from './naming.js';
+
+/**
+ * Map an IR `TypeRef` to a Kotlin type expression string.
+ *
+ * Kotlin marks nullability at use sites (`T?`). `nullable` variants become `T?`
+ * here; the caller (models/resources) additionally appends `?` for non-required,
+ * non-nullable fields via {@link fieldKotlinType} so we never double the marker.
+ */
+export function mapTypeRef(ref: TypeRef): string {
+  return irMapTypeRef<string>(ref, {
+    primitive: mapPrimitive,
+    array: (_ref, items) => `List<${items}>`,
+    model: (r) => typeName(r.name),
+    enum: (r) => typeName(r.name),
+    union: (r, variants) => joinUnionVariants(r, variants),
+    nullable: (_ref, inner) => (inner.endsWith('?') ? inner : `${inner}?`),
+    literal: (r) => {
+      if (r.value === null) return 'JsonElement';
+      if (typeof r.value === 'string') return 'String';
+      if (typeof r.value === 'number') return Number.isInteger(r.value) ? 'Long' : 'Double';
+      if (typeof r.value === 'boolean') return 'Boolean';
+      return 'JsonElement';
+    },
+    map: (_ref, value) => `Map<String, ${value}>`,
+  });
+}
+
+function mapPrimitive(ref: PrimitiveType): string {
+  if (ref.format === 'binary' || ref.format === 'byte') return 'ByteArray';
+  if (ref.format === 'int32') return 'Int';
+  if (ref.format === 'int64') return 'Long';
+  switch (ref.type) {
+    case 'string':
+      if (ref.format === 'date-time' || ref.format === 'date') return 'Instant';
+      return 'String';
+    case 'integer':
+      return 'Long';
+    case 'number':
+      return 'Double';
+    case 'boolean':
+      return 'Boolean';
+    case 'unknown':
+      // `JsonElement` rather than `Any`: it is @Serializable out of the box, so
+      // it needs no custom serializer at each use site.
+      return 'JsonElement';
+  }
+}
+
+function joinUnionVariants(ref: UnionType, variants: string[]): string {
+  // allOf merges collapse to the (already-merged) first variant shape.
+  if (ref.compositionKind === 'allOf') {
+    return variants[0] ?? 'JsonElement';
+  }
+  const unique = [...new Set(variants)];
+  if (unique.length === 1) return unique[0];
+  // v1: heterogeneous / discriminated unions widen to JsonElement (see the
+  // design doc's "Future Enhancements" for native sealed-interface modeling).
+  return 'JsonElement';
+}
+
+/** True when a `TypeRef` is a `nullable` wrapper (its Kotlin form already ends `?`). */
+export function isNullableRef(ref: TypeRef): boolean {
+  return ref.kind === 'nullable';
+}
+
+/**
+ * Kotlin type for a data-class property / method parameter, accounting for
+ * optionality. A field is nullable when it is not required OR its type is
+ * nullable; we append a single `?` and never double it.
+ */
+export function fieldKotlinType(ref: TypeRef, required: boolean): string {
+  const base = mapTypeRef(ref);
+  const optional = !required || isNullableRef(ref);
+  if (optional && !base.endsWith('?')) return `${base}?`;
+  return base;
+}
+
+/**
+ * Imports implied by a Kotlin type expression. Callers collect these into the
+ * file's import set so generated files compile standalone.
+ */
+export function implicitImportsFor(kotlinType: string): string[] {
+  const imports: string[] = [];
+  if (/\bInstant\b/.test(kotlinType)) imports.push('kotlinx.datetime.Instant');
+  if (/\bJsonElement\b/.test(kotlinType)) imports.push('kotlinx.serialization.json.JsonElement');
+  return imports;
+}

--- a/src/android/wrappers.ts
+++ b/src/android/wrappers.ts
@@ -1,0 +1,219 @@
+import type { EmitterContext, Operation, ResolvedOperation, ResolvedWrapper, TypeRef } from '@workos/oagen';
+import { resolveWrapperParams, formatWrapperDescription } from '../shared/wrapper-utils.js';
+import { parsePathTemplate } from '../shared/path-template.js';
+import {
+  methodName,
+  propertyName,
+  typeName,
+  subPackage,
+  ktStringLiteral,
+  ktLiteral,
+  ktTemplatePart,
+} from './naming.js';
+import { mapTypeRef, implicitImportsFor } from './type-map.js';
+import { resolveTypeImports } from './imports.js';
+import { renderMethodDoc } from './doc-comments.js';
+import type { RenderedMethod } from './resources.js';
+import { clientFieldExpr } from './resources.js';
+
+/**
+ * Render one `suspend fun` per wrapper of a union-split operation (e.g.
+ * `authenticate` → `authenticateWithPassword`, `authenticateWithCode`). Each
+ * exposes only its variant's fields plus any client-inferred / default values.
+ */
+export function generateWrapperMethods(resolved: ResolvedOperation, ctx: EmitterContext): RenderedMethod[] {
+  const op = resolved.operation;
+  return (resolved.wrappers ?? []).map((wrapper) => renderWrapper(op, wrapper, ctx));
+}
+
+interface WParam {
+  name: string;
+  wire: string;
+  type: string;
+  optional: boolean;
+  description?: string;
+  deprecated?: boolean;
+}
+
+interface WPathParam {
+  name: string;
+  wire: string;
+  ref: TypeRef;
+  description?: string;
+  deprecated?: boolean;
+}
+
+/**
+ * Doc text for a union-split wrapper.
+ *
+ * The variant name alone ("Create oauth application") only restates the method
+ * name — it drops everything the spec says about what the endpoint does. So the
+ * parent operation's description is carried through underneath it.
+ *
+ * Spec descriptions are conventionally "Short Title\n\nFull explanation.", and the
+ * short title duplicates the variant line, so when a body is present only the body
+ * is appended. With no body the whole description is used.
+ */
+function wrapperDoc(wrapperName: string, operationDescription: string | undefined): string {
+  const title = formatWrapperDescription(wrapperName);
+  const desc = operationDescription?.trim();
+  if (!desc) return title;
+  const blank = desc.indexOf('\n\n');
+  const body = blank === -1 ? desc : desc.slice(blank + 2).trim();
+  return body ? `${title}\n\n${body}` : title;
+}
+
+function unwrapNullable(ref: TypeRef): TypeRef {
+  return ref.kind === 'nullable' ? ref.inner : ref;
+}
+function isEnumRef(ref: TypeRef): boolean {
+  return unwrapNullable(ref).kind === 'enum';
+}
+
+function renderWrapper(op: Operation, wrapper: ResolvedWrapper, ctx: EmitterContext): RenderedMethod {
+  const method = methodName(wrapper.name);
+  const wparams = resolveWrapperParams(wrapper, ctx);
+  const used = new Set<string>();
+  const dedupe = (n: string): string => {
+    let c = n;
+    let i = 2;
+    while (used.has(c)) c = `${n}${i++}`;
+    used.add(c);
+    return c;
+  };
+
+  // Path params (rare for split ops) come first and are always required.
+  const pathParamOrder = parsePathTemplate(op.path)
+    .filter((s) => s.kind === 'param')
+    .map((s) => (s.kind === 'param' ? s.name : ''));
+  const pathByWire = new Map(op.pathParams.map((p) => [p.name, p]));
+  const pathParams: WPathParam[] = [];
+  for (const wire of pathParamOrder) {
+    const p = pathByWire.get(wire);
+    if (!p) continue;
+    pathParams.push({
+      name: dedupe(propertyName(p.name)),
+      wire: p.name,
+      ref: p.type,
+      description: p.description,
+      deprecated: p.deprecated,
+    });
+  }
+
+  const bodyParams: WParam[] = wparams.map((wp) => {
+    const base = wp.field ? mapTypeRef(wp.field.type) : 'String';
+    const type = wp.isOptional && !base.endsWith('?') ? `${base}?` : base;
+    return {
+      name: dedupe(propertyName(wp.paramName)),
+      wire: wp.paramName,
+      type,
+      optional: type.endsWith('?'),
+      description: wp.field?.description,
+      deprecated: wp.field?.deprecated,
+    };
+  });
+
+  const ret = wrapper.responseModelName ? typeName(wrapper.responseModelName) : null;
+
+  const required = bodyParams.filter((p) => !p.optional);
+  const optional = bodyParams.filter((p) => p.optional);
+
+  const lines: string[] = [];
+  lines.push(
+    ...renderMethodDoc(
+      wrapperDoc(wrapper.name, op.description),
+      [
+        ...pathParams.map((param) => ({
+          name: param.name,
+          description: param.description,
+          deprecated: param.deprecated,
+        })),
+        ...bodyParams.map((param) => ({
+          name: param.name,
+          description: param.description,
+          deprecated: param.deprecated,
+        })),
+        {
+          name: 'requestOptions',
+          description: 'Per-request overrides: extra headers, timeout, retries, base URL, idempotency key.',
+        },
+      ],
+      ret ? `The \`${ret}\` returned by the API.` : undefined,
+      '    ',
+    ),
+  );
+
+  lines.push(`    public suspend fun ${method}(`);
+  for (const p of pathParams) lines.push(`        ${p.name}: ${mapTypeRef(p.ref)},`);
+  for (const p of required) lines.push(`        ${p.name}: ${p.type},`);
+  for (const p of optional) lines.push(`        ${p.name}: ${p.type} = null,`);
+  lines.push('        requestOptions: RequestOptions? = null,');
+  lines.push(`    )${ret ? `: ${ret}` : ''} {`);
+
+  const pathExpr = renderPathExpr(op, pathParams);
+  lines.push(`        val path = ${pathExpr}`);
+  // Avoid shadowing a wrapper parameter that happens to be named `payload`/`body`.
+  const taken = new Set<string>([
+    ...pathParams.map((p) => p.name.replace(/`/g, '')),
+    ...bodyParams.map((p) => p.name.replace(/`/g, '')),
+    'path',
+    'requestOptions',
+  ]);
+  let local = 'payload';
+  for (let n = 2; taken.has(local); n++) local = `payload${n}`;
+
+  lines.push(`        val ${local} = JsonBody()`);
+  for (const p of bodyParams) {
+    lines.push(`        ${local}.set(${ktStringLiteral(p.wire)}, ${p.name})`);
+  }
+  for (const [key, value] of Object.entries(wrapper.defaults ?? {})) {
+    lines.push(`        ${local}.set(${ktStringLiteral(key)}, ${ktLiteral(value)})`);
+  }
+  for (const key of wrapper.inferFromClient ?? []) {
+    lines.push(`        ${local}.set(${ktStringLiteral(key)}, ${clientFieldExpr(key)})`);
+  }
+
+  const httpMethod = op.httpMethod.toUpperCase();
+  const call = ret ? `return transport.request<${ret}>(` : 'transport.requestVoid(';
+  lines.push(`        ${call}`);
+  lines.push(`            method = ${ktStringLiteral(httpMethod)},`);
+  lines.push('            path = path,');
+  lines.push('            query = emptyList(),');
+  lines.push(`            body = ${local},`);
+  lines.push('            options = requestOptions,');
+  lines.push('        )');
+  lines.push('    }');
+
+  const typeExprs = [
+    ...pathParams.map((p) => mapTypeRef(p.ref)),
+    ...bodyParams.map((p) => p.type),
+    ...(ret ? [ret] : []),
+  ];
+  const imports = new Set<string>([`${subPackage(ctx, '')}.RequestOptions`, `${subPackage(ctx, 'internal')}.JsonBody`]);
+  for (const expr of typeExprs) {
+    for (const imp of implicitImportsFor(expr)) imports.add(imp);
+  }
+  for (const imp of resolveTypeImports(ctx, typeExprs)) imports.add(imp);
+  if (pathExpr.includes('PathEncoding')) imports.add(`${subPackage(ctx, 'internal')}.PathEncoding`);
+
+  return { name: method, lines, imports: [...imports] };
+}
+
+function renderPathExpr(op: Operation, pathParams: WPathParam[]): string {
+  const segments = parsePathTemplate(op.path, { stripLeadingSlash: true });
+  if (segments.length === 0) return '""';
+  const byWire = new Map(pathParams.map((p) => [p.wire, p]));
+  let expr = '"';
+  for (const seg of segments) {
+    if (seg.kind === 'literal') {
+      expr += ktTemplatePart(seg.value);
+    } else {
+      const p = byWire.get(seg.name);
+      const name = p ? p.name : propertyName(seg.name);
+      const accessor = p && isEnumRef(p.ref) ? `${name}.rawValue` : name;
+      expr += `\${PathEncoding.segment(${accessor})}`;
+    }
+  }
+  expr += '"';
+  return expr;
+}

--- a/src/android/wrappers.ts
+++ b/src/android/wrappers.ts
@@ -1,5 +1,6 @@
 import type { EmitterContext, Operation, ResolvedOperation, ResolvedWrapper, TypeRef } from '@workos/oagen';
 import { resolveWrapperParams, formatWrapperDescription } from '../shared/wrapper-utils.js';
+import { isEnumTypeRef } from '../shared/model-utils.js';
 import { parsePathTemplate } from '../shared/path-template.js';
 import {
   methodName,
@@ -61,13 +62,6 @@ function wrapperDoc(wrapperName: string, operationDescription: string | undefine
   const blank = desc.indexOf('\n\n');
   const body = blank === -1 ? desc : desc.slice(blank + 2).trim();
   return body ? `${title}\n\n${body}` : title;
-}
-
-function unwrapNullable(ref: TypeRef): TypeRef {
-  return ref.kind === 'nullable' ? ref.inner : ref;
-}
-function isEnumRef(ref: TypeRef): boolean {
-  return unwrapNullable(ref).kind === 'enum';
 }
 
 function renderWrapper(op: Operation, wrapper: ResolvedWrapper, ctx: EmitterContext): RenderedMethod {
@@ -210,7 +204,7 @@ function renderPathExpr(op: Operation, pathParams: WPathParam[]): string {
     } else {
       const p = byWire.get(seg.name);
       const name = p ? p.name : propertyName(seg.name);
-      const accessor = p && isEnumRef(p.ref) ? `${name}.rawValue` : name;
+      const accessor = p && isEnumTypeRef(p.ref) ? `${name}.rawValue` : name;
       expr += `\${PathEncoding.segment(${accessor})}`;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { kotlinEmitter } from './kotlin/index.js';
 export { rubyEmitter } from './ruby/index.js';
 export { rustEmitter } from './rust/index.js';
 export { iosEmitter } from './ios/index.js';
+export { androidEmitter } from './android/index.js';
 export { elixirEmitter } from './elixir/index.js';
 
 export { nodeExtractor } from './compat/extractors/node.js';

--- a/src/ios/resources.ts
+++ b/src/ios/resources.ts
@@ -9,7 +9,7 @@ import type {
 } from '@workos/oagen';
 import { planOperation } from '@workos/oagen';
 import { parsePathTemplate } from '../shared/path-template.js';
-import { unwrapListModel } from '../shared/model-utils.js';
+import { isEnumTypeRef, resolvePaginatedItemModelName, unwrapNullableRef } from '../shared/model-utils.js';
 import { scopedMountGroups, buildHiddenParams, getOpDefaults, getOpInferFromClient } from '../shared/resolved-ops.js';
 import {
   moduleName,
@@ -40,14 +40,8 @@ export function generateResources(_services: Service[], ctx: EmitterContext): Ge
 
 // --- TypeRef helpers --------------------------------------------------------
 
-function unwrapNullable(ref: TypeRef): TypeRef {
-  return ref.kind === 'nullable' ? ref.inner : ref;
-}
-function isEnumRef(ref: TypeRef): boolean {
-  return unwrapNullable(ref).kind === 'enum';
-}
 function isStringPrimitive(ref: TypeRef): boolean {
-  const base = unwrapNullable(ref);
+  const base = unwrapNullableRef(ref);
   return base.kind === 'primitive' && base.type === 'string' && base.format !== 'date-time' && base.format !== 'date';
 }
 
@@ -472,10 +466,7 @@ function returnType(plan: ReturnType<typeof planOperation>, ctx: EmitterContext)
  * no `list_metadata` is not mistaken for a pagination envelope.
  */
 export function resolvePaginatedItemName(name: string, ctx: EmitterContext): string {
-  const model = ctx.spec.models.find((m) => m.name === name);
-  if (!model) return name;
-  const modelMap = new Map(ctx.spec.models.map((m) => [m.name, m]));
-  return unwrapListModel(model, modelMap)?.name ?? name;
+  return resolvePaginatedItemModelName(name, ctx.spec.models);
 }
 
 function renderPathExpr(op: Operation, params: RenderedParam[]): string {
@@ -489,7 +480,7 @@ function renderPathExpr(op: Operation, params: RenderedParam[]): string {
     } else {
       const p = byWire.get(seg.name);
       const name = p ? p.name : propertyName(seg.name);
-      const accessor = p && isEnumRef(p.ref) ? `${name}.rawValue` : name;
+      const accessor = p && isEnumTypeRef(p.ref) ? `${name}.rawValue` : name;
       expr += `\\(PathEncoding.segment(${accessor}))`;
     }
   }
@@ -498,17 +489,17 @@ function renderPathExpr(op: Operation, params: RenderedParam[]): string {
 }
 
 function queryValueExpr(name: string, ref: TypeRef): string {
-  if (isEnumRef(ref)) return `${name}.rawValue`;
+  if (isEnumTypeRef(ref)) return `${name}.rawValue`;
   if (isStringPrimitive(ref)) return name;
   return `"\\(${name})"`;
 }
 
 function renderQueryAppend(q: RenderedParam): string[] {
-  const base = unwrapNullable(q.ref);
+  const base = unwrapNullableRef(q.ref);
   const out: string[] = [];
   if (base.kind === 'array') {
     const elem = base.items;
-    const elemExpr = isEnumRef(elem) ? 'value.rawValue' : isStringPrimitive(elem) ? 'value' : '"\\(value)"';
+    const elemExpr = isEnumTypeRef(elem) ? 'value.rawValue' : isStringPrimitive(elem) ? 'value' : '"\\(value)"';
     if (q.optional) {
       out.push(`        if let ${q.name} {`);
       out.push(`            for value in ${q.name} {`);

--- a/src/ios/resources.ts
+++ b/src/ios/resources.ts
@@ -40,9 +40,16 @@ export function generateResources(_services: Service[], ctx: EmitterContext): Ge
 
 // --- TypeRef helpers --------------------------------------------------------
 
-function isStringPrimitive(ref: TypeRef): boolean {
-  const base = unwrapNullableRef(ref);
-  return base.kind === 'primitive' && base.type === 'string' && base.format !== 'date-time' && base.format !== 'date';
+/**
+ * True when a `TypeRef` renders as Swift `String` — the case where wrapping it
+ * in `"\(value)"` interpolation would be redundant. Covers primitive strings
+ * AND string-valued literals (`{ kind: 'literal', value: 'login' }`), which
+ * `mapTypeRef` also renders as `String`. Date/date-time strings are excluded:
+ * `mapTypeRef` renders those as `Date`, so they still need interpolation to
+ * produce wire text.
+ */
+function rendersAsString(ref: TypeRef): boolean {
+  return mapTypeRef(unwrapNullableRef(ref)) === 'String';
 }
 
 // --- rendering --------------------------------------------------------------
@@ -490,7 +497,7 @@ function renderPathExpr(op: Operation, params: RenderedParam[]): string {
 
 function queryValueExpr(name: string, ref: TypeRef): string {
   if (isEnumTypeRef(ref)) return `${name}.rawValue`;
-  if (isStringPrimitive(ref)) return name;
+  if (rendersAsString(ref)) return name;
   return `"\\(${name})"`;
 }
 
@@ -499,7 +506,7 @@ function renderQueryAppend(q: RenderedParam): string[] {
   const out: string[] = [];
   if (base.kind === 'array') {
     const elem = base.items;
-    const elemExpr = isEnumTypeRef(elem) ? 'value.rawValue' : isStringPrimitive(elem) ? 'value' : '"\\(value)"';
+    const elemExpr = isEnumTypeRef(elem) ? 'value.rawValue' : rendersAsString(elem) ? 'value' : '"\\(value)"';
     if (q.optional) {
       out.push(`        if let ${q.name} {`);
       out.push(`            for value in ${q.name} {`);

--- a/src/ios/wrappers.ts
+++ b/src/ios/wrappers.ts
@@ -1,5 +1,6 @@
 import type { EmitterContext, Operation, ResolvedOperation, ResolvedWrapper, TypeRef } from '@workos/oagen';
 import { resolveWrapperParams, formatWrapperDescription } from '../shared/wrapper-utils.js';
+import { isEnumTypeRef } from '../shared/model-utils.js';
 import { parsePathTemplate } from '../shared/path-template.js';
 import { methodName, propertyName, typeName, swiftStringLiteral } from './naming.js';
 import { mapTypeRef } from './type-map.js';
@@ -22,13 +23,6 @@ interface WParam {
   optional: boolean;
   description?: string;
   deprecated?: boolean;
-}
-
-function unwrapNullable(ref: TypeRef): TypeRef {
-  return ref.kind === 'nullable' ? ref.inner : ref;
-}
-function isEnumRef(ref: TypeRef): boolean {
-  return unwrapNullable(ref).kind === 'enum';
 }
 
 function renderWrapper(op: Operation, wrapper: ResolvedWrapper, ctx: EmitterContext): string {
@@ -159,7 +153,7 @@ function renderPathExpr(op: Operation, pathParams: { name: string; wire: string;
     } else {
       const p = byWire.get(seg.name);
       const name = p ? p.name : propertyName(seg.name);
-      const accessor = p && isEnumRef(p.ref) ? `${name}.rawValue` : name;
+      const accessor = p && isEnumTypeRef(p.ref) ? `${name}.rawValue` : name;
       expr += `\\(PathEncoding.segment(${accessor}))`;
     }
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,6 +10,7 @@ import { kotlinEmitter } from './kotlin/index.js';
 import { rubyEmitter } from './ruby/index.js';
 import { rustEmitter } from './rust/index.js';
 import { iosEmitter } from './ios/index.js';
+import { androidEmitter } from './android/index.js';
 import { elixirEmitter } from './elixir/index.js';
 import { nodeExtractor } from './compat/extractors/node.js';
 import { rubyExtractor } from './compat/extractors/ruby.js';
@@ -38,6 +39,7 @@ export const workosEmittersPlugin: Pick<OagenConfig, 'emitters' | 'extractors' |
     rubyEmitter,
     rustEmitter,
     iosEmitter,
+    androidEmitter,
     elixirEmitter,
   ],
   extractors: [
@@ -63,5 +65,6 @@ export const workosEmittersPlugin: Pick<OagenConfig, 'emitters' | 'extractors' |
     kotlin: path.join(smokeDir, 'sdk-kotlin.ts'),
     dotnet: path.join(smokeDir, 'sdk-dotnet.ts'),
     ios: path.join(smokeDir, 'sdk-ios.ts'),
+    android: path.join(smokeDir, 'sdk-android.ts'),
   },
 };

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -77,6 +77,32 @@ export function unwrapListModel(model: Model, modelMap: Map<string, Model>): Mod
 }
 
 /**
+ * The name of the item model a paginated response actually yields.
+ *
+ * A spec's pagination `itemType` frequently resolves to the list *wrapper*
+ * (`OrganizationList { data: [Organization], list_metadata }`) rather than the
+ * item, which would make a generated signature read `Page<OrganizationList>` and
+ * fail to decode. Unwraps one level when the wrapper convention matches, and
+ * returns `name` unchanged otherwise.
+ */
+export function resolvePaginatedItemModelName(name: string, models: readonly Model[]): string {
+  const model = models.find((m) => m.name === name);
+  if (!model) return name;
+  const modelMap = new Map(models.map((m) => [m.name, m]));
+  return unwrapListModel(model, modelMap)?.name ?? name;
+}
+
+/** Strip one `nullable` layer off a type reference. */
+export function unwrapNullableRef(ref: TypeRef): TypeRef {
+  return ref.kind === 'nullable' ? ref.inner : ref;
+}
+
+/** Whether a type reference is an enum, ignoring nullability. */
+export function isEnumTypeRef(ref: TypeRef): boolean {
+  return unwrapNullableRef(ref).kind === 'enum';
+}
+
+/**
  * Detect whether a model is a list metadata model (e.g., ListMetadata).
  * These models typically have exactly `before` and `after` nullable string fields.
  */

--- a/src/shared/non-spec-services.ts
+++ b/src/shared/non-spec-services.ts
@@ -45,7 +45,8 @@ export interface NonSpecService {
  * 2. Pinned-by-test — emitters whose non-spec surface is hand-maintained in the
  *    target SDK, because a generated accessor would reference a hand-maintained
  *    type that does not exist in staging. Each pins its coverage in a unit test:
- *      - ios, kotlin (same-module extensions): `test/{ios,kotlin}/non-spec.test.ts`
+ *      - ios, kotlin, android (same-module extensions):
+ *                                              `test/{ios,kotlin,android}/non-spec.test.ts`
  *      - elixir (standalone modules):          `test/elixir/non-spec.test.ts`
  *      - node (Scenario A, `src/workos.ts` preserved via --api-surface):
  *                                              `test/node/non-spec.test.ts`

--- a/src/shared/wrapper-utils.ts
+++ b/src/shared/wrapper-utils.ts
@@ -1,5 +1,5 @@
 import type { EmitterContext, Field, ResolvedWrapper } from '@workos/oagen';
-import { toSnakeCase } from '@workos/oagen';
+import { toPascalCase, toSnakeCase } from '@workos/oagen';
 import { enrichModelsFromSpec } from './model-utils.js';
 
 /**
@@ -61,10 +61,30 @@ export function resolveWrapperParams(wrapper: ResolvedWrapper, ctx: EmitterConte
 /**
  * Format a snake_case wrapper name into a human-readable description.
  * "authenticate_with_password" → "Authenticate with password"
+ *
+ * Each `_`-separated segment is recased through `toPascalCase`, so acronyms
+ * inherit oagen's `ACRONYM_SET` — the same source of truth the emitted method
+ * name uses. Lower-casing the raw segments instead produced a doc line that
+ * contradicted the symbol directly below it ("Create oauth application" over
+ * `createOAuthApplication`).
+ *
+ * Segments are kept at their original boundaries rather than re-split out of the
+ * camelCased whole: `splitPascalWords` mis-splits digit-adjacent acronyms
+ * (`M2M` → `2` + `MApplication`), and it also drives public method naming, so it
+ * is not the place to absorb a doc-formatting concern.
+ *
+ * A recased segment is preserved when `toPascalCase` marked it as an acronym
+ * (interior capitals, or a capital adjacent to a digit); otherwise it is
+ * lower-cased. The first word is capitalized to open the sentence.
  */
 export function formatWrapperDescription(name: string): string {
   return name
     .split('_')
-    .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .map((segment, i) => {
+      const cased = toPascalCase(segment);
+      const isAcronym = /[A-Z].*[A-Z]|[A-Z][0-9]|[0-9][A-Z]/.test(cased);
+      const word = isAcronym ? cased : segment.toLowerCase();
+      return i === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word;
+    })
     .join(' ');
 }

--- a/test/android/client.test.ts
+++ b/test/android/client.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import type { EmitterContext, ApiSpec, Service } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { generateClient } from '../../src/android/client.js';
+import { buildOperationsMap } from '../../src/android/manifest.js';
+
+const service: Service = {
+  name: 'Organizations',
+  operations: [
+    {
+      name: 'get_organization',
+      httpMethod: 'get',
+      path: '/organizations/{id}',
+      pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+  ],
+};
+
+const ssoService: Service = {
+  name: 'SSO',
+  operations: [
+    {
+      name: 'list_connections',
+      httpMethod: 'get',
+      path: '/connections',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model', name: 'Connection' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+  ],
+};
+
+function makeCtx(services: Service[]): EmitterContext {
+  const spec: ApiSpec = {
+    name: 'Test',
+    version: '1.0.0',
+    baseUrl: 'https://api.example.com',
+    services,
+    models: [
+      { name: 'Organization', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      { name: 'Connection', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ],
+    enums: [],
+    sdk: defaultSdkBehavior(),
+  };
+  return { namespace: 'workos', namespacePascal: 'WorkOS', spec };
+}
+
+describe('android/client', () => {
+  it('emits extension-property accessors plus the smoke-plan sidecar', () => {
+    const ctx = makeCtx([service, ssoService]);
+    const files = generateClient(ctx);
+    expect(files).toHaveLength(2);
+
+    const accessors = files[0];
+    expect(accessors.path).toBe('src/main/kotlin/com/workos/android/WorkOSClientResources.kt');
+    expect(accessors.overwriteExisting).toBe(true);
+    expect(accessors.content).toContain('package com.workos.android');
+    expect(accessors.content).toContain('public val WorkOSClient.organizations: Organizations');
+    expect(accessors.content).toContain('get() = Organizations(transport)');
+    expect(accessors.content).toContain('public val WorkOSClient.sso: SSO');
+    expect(accessors.content).toContain('import com.workos.android.resources.Organizations');
+  });
+
+  it('marks the smoke plan as staging-only so it is never merged into a live SDK', () => {
+    const plan = generateClient(makeCtx([service]))[1];
+    expect(plan.path).toBe('.oagen-android-smoke.json');
+    // `integrateTarget: false` only suppresses it during `--target` integration.
+    // A `--output` run still writes it next to the SDK, so the SDK repo must
+    // gitignore it (workos-ios does the same with .oagen-ios-smoke.json).
+    expect(plan.integrateTarget).toBe(false);
+    expect(plan.headerPlacement).toBe('skip');
+    const parsed: unknown = JSON.parse(plan.content ?? '{}');
+    expect(parsed).toMatchObject({
+      version: 1,
+      operations: { 'GET /organizations/{id}': { service: 'organizations', method: 'get' } },
+    });
+  });
+
+  it('sorts accessors so regeneration is byte-stable', () => {
+    const a = generateClient(makeCtx([service, ssoService]))[0].content;
+    const b = generateClient(makeCtx([ssoService, service]))[0].content;
+    expect(a).toBe(b);
+  });
+
+  it('capitalizes a lower-case namespace rather than emitting workosClient', () => {
+    const ctx = makeCtx([service]);
+    // Callers only pass the cased namespace for languages whose namespace also
+    // names a type; a lower-case one must still yield a valid Kotlin class name.
+    const content = generateClient({ ...ctx, namespacePascal: 'workos' })[0].content;
+    expect(content).toContain('public val WorkosClient.organizations: Organizations');
+    expect(content).not.toContain('workosClient');
+  });
+
+  it('builds an operations manifest keyed by METHOD /path', () => {
+    const ctx = makeCtx([service, ssoService]);
+    expect(buildOperationsMap(ctx.spec, ctx)).toEqual({
+      'GET /organizations/{id}': { sdkMethod: 'get', service: 'organizations' },
+      'GET /connections': { sdkMethod: 'listConnections', service: 'sso' },
+    });
+  });
+});

--- a/test/android/enums.test.ts
+++ b/test/android/enums.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import type { EmitterContext, ApiSpec, Enum } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { generateEnums } from '../../src/android/enums.js';
+
+const emptySpec: ApiSpec = {
+  name: 'Test',
+  version: '1.0.0',
+  baseUrl: '',
+  services: [],
+  models: [],
+  enums: [],
+  sdk: defaultSdkBehavior(),
+};
+
+const ctx: EmitterContext = {
+  namespace: 'workos',
+  namespacePascal: 'WorkOS',
+  spec: emptySpec,
+};
+
+describe('android/enums', () => {
+  it('returns empty for no enums', () => {
+    expect(generateEnums([], ctx)).toEqual([]);
+  });
+
+  it('generates a forward-compatible sealed class with a generated serializer', () => {
+    const enums: Enum[] = [
+      {
+        name: 'ConnectionState',
+        values: [
+          { name: 'active', value: 'active' },
+          { name: 'inactive', value: 'inactive' },
+        ],
+      },
+    ];
+    const files = generateEnums(enums, ctx);
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe('src/main/kotlin/com/workos/android/enums/ConnectionState.kt');
+    const content = files[0].content;
+    expect(content).toContain('@Serializable(with = ConnectionState.Serializer::class)');
+    expect(content).toContain('public sealed class ConnectionState(public val rawValue: String) {');
+    expect(content).toContain('public data object Active : ConnectionState("active")');
+    expect(content).toContain('public data object Inactive : ConnectionState("inactive")');
+    // the unknown carrier preserves the raw wire value so round-trips are lossless
+    expect(content).toContain('public data class Unknown(public val value: String) : ConnectionState(value)');
+    expect(content).toContain('public fun fromRawValue(rawValue: String): ConnectionState =');
+    expect(content).toContain('else -> Unknown(rawValue)');
+    expect(content).toContain('public val allKnownValues: List<ConnectionState> = listOf(Active, Inactive)');
+    // an explicit serializer, not implicit conformance
+    expect(content).toContain('internal object Serializer : KSerializer<ConnectionState> {');
+    expect(content).toContain('PrimitiveSerialDescriptor("ConnectionState", PrimitiveKind.STRING)');
+    expect(content).toContain('encoder.encodeString(value.rawValue)');
+  });
+
+  it('uses Int raw values for numeric enums', () => {
+    const enums: Enum[] = [
+      {
+        name: 'Level',
+        values: [
+          { name: 'one', value: 1 },
+          { name: 'two', value: 2 },
+        ],
+      },
+    ];
+    const content = generateEnums(enums, ctx)[0].content;
+    expect(content).toContain('public sealed class Level(public val rawValue: Int) {');
+    expect(content).toContain('public data object One : Level(1)');
+    expect(content).toContain('PrimitiveKind.INT');
+    expect(content).toContain('decoder.decodeInt()');
+    expect(content).toContain('encoder.encodeInt(value.rawValue)');
+  });
+
+  it('suffixes a wire value that collides with the reserved Unknown sentinel', () => {
+    const enums: Enum[] = [
+      {
+        name: 'Status',
+        values: [
+          { name: 'unknown', value: 'unknown' },
+          { name: 'active', value: 'active' },
+        ],
+      },
+    ];
+    const content = generateEnums(enums, ctx)[0].content;
+    // the real `unknown` wire value becomes Unknown2; the sentinel keeps `Unknown`
+    expect(content).toContain('public data object Unknown2 : Status("unknown")');
+    expect(content).toContain('public data class Unknown(public val value: String) : Status(value)');
+  });
+
+  it('prefixes numeric-leading values so the object name is a valid identifier', () => {
+    const enums: Enum[] = [{ name: 'Version', values: [{ name: '2fa', value: '2fa' }] }];
+    const content = generateEnums(enums, ctx)[0].content;
+    expect(content).toMatch(/public data object Value\w* : Version\("2fa"\)/);
+  });
+
+  it('escapes `$` in wire values so they cannot become Kotlin string templates', () => {
+    const enums: Enum[] = [
+      {
+        name: 'Status',
+        values: [
+          { name: 'active', value: 'active' },
+          { name: 'evil', value: '${System.getenv()}' },
+        ],
+      },
+    ];
+    const content = generateEnums(enums, ctx)[0].content;
+    expect(content).toContain('\\${System.getenv()}');
+    expect(content).not.toMatch(/[^\\]\$\{System\.getenv\(\)\}/);
+  });
+
+  it('handles a value-less enum without emitting an empty `when`', () => {
+    const content = generateEnums([{ name: 'Empty', values: [] }], ctx)[0].content;
+    expect(content).toContain('public val allKnownValues: List<Empty> = emptyList()');
+    expect(content).toContain('Unknown(rawValue)');
+    expect(content).not.toContain('when (rawValue) {');
+  });
+
+  it('marks deprecated values with @Deprecated', () => {
+    const enums: Enum[] = [{ name: 'Status', values: [{ name: 'old', value: 'old', deprecated: true }] }];
+    expect(generateEnums(enums, ctx)[0].content).toContain('@Deprecated(');
+  });
+});

--- a/test/android/models.test.ts
+++ b/test/android/models.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import type { EmitterContext, ApiSpec, Model } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { generateModels } from '../../src/android/models.js';
+
+const emptySpec: ApiSpec = {
+  name: 'Test',
+  version: '1.0.0',
+  baseUrl: '',
+  services: [],
+  models: [],
+  enums: [],
+  sdk: defaultSdkBehavior(),
+};
+
+const ctx: EmitterContext = {
+  namespace: 'workos',
+  namespacePascal: 'WorkOS',
+  spec: emptySpec,
+};
+
+describe('android/models', () => {
+  it('returns empty for no models', () => {
+    expect(generateModels([], ctx)).toEqual([]);
+  });
+
+  it('generates a @Serializable data class with required and nullable fields', () => {
+    const models: Model[] = [
+      {
+        name: 'Organization',
+        description: 'An organization.',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'created_at', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: false },
+        ],
+      },
+    ];
+    const files = generateModels(models, ctx);
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe('src/main/kotlin/com/workos/android/models/Organization.kt');
+    const content = files[0].content;
+    expect(content).toContain('package com.workos.android.models');
+    expect(content).toContain('@Serializable');
+    expect(content).toContain('public data class Organization(');
+    expect(content).toContain('public val id: String,');
+    expect(content).toContain('public val name: String,');
+    // nullable field gets `= null` so callers can omit it
+    expect(content).toContain('public val createdAt: Instant? = null,');
+    // explicit wire-key mapping
+    expect(content).toContain('@SerialName("created_at")');
+    // Instant import is pulled in for date-time
+    expect(content).toContain('import kotlinx.datetime.Instant');
+  });
+
+  it('orders required properties before nullable ones', () => {
+    const models: Model[] = [
+      {
+        name: 'Thing',
+        fields: [
+          { name: 'optional_first', type: { kind: 'primitive', type: 'string' }, required: false },
+          { name: 'required_second', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+    ];
+    const content = generateModels(models, ctx)[0].content;
+    expect(content.indexOf('requiredSecond')).toBeLessThan(content.indexOf('optionalFirst'));
+  });
+
+  it('maps arrays, maps, model refs and enum refs', () => {
+    const models: Model[] = [
+      {
+        name: 'User',
+        fields: [
+          { name: 'roles', type: { kind: 'array', items: { kind: 'primitive', type: 'string' } }, required: true },
+          {
+            name: 'metadata',
+            type: { kind: 'map', valueType: { kind: 'primitive', type: 'string' } },
+            required: false,
+          },
+          { name: 'profile', type: { kind: 'model', name: 'Profile' }, required: true },
+          { name: 'state', type: { kind: 'enum', name: 'UserState' }, required: true },
+        ],
+      },
+    ];
+    const specWithRefs: ApiSpec = {
+      ...emptySpec,
+      models: [...models, { name: 'Profile', fields: [] }],
+      enums: [{ name: 'UserState', values: [{ name: 'active', value: 'active' }] }],
+    };
+    const content = generateModels(models, { ...ctx, spec: specWithRefs })[0].content;
+    expect(content).toContain('public val roles: List<String>,');
+    expect(content).toContain('public val profile: Profile,');
+    expect(content).toContain('public val state: UserState,');
+    expect(content).toContain('public val metadata: Map<String, String>? = null,');
+    // A referenced enum lives in a sibling package, so it needs an import.
+    expect(content).toContain('import com.workos.android.enums.UserState');
+    // A referenced model is in this file's own package — Kotlin resolves it
+    // without an import, and ktlint flags a redundant same-package import.
+    expect(content).not.toContain('import com.workos.android.models.Profile');
+  });
+
+  it('escapes Kotlin reserved words used as field names', () => {
+    const models: Model[] = [
+      {
+        name: 'Event',
+        fields: [
+          { name: 'object', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'in', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+    ];
+    const content = generateModels(models, ctx)[0].content;
+    expect(content).toContain('public val `object`: String,');
+    expect(content).toContain('public val `in`: String,');
+    // the wire key stays unescaped
+    expect(content).toContain('@SerialName("object")');
+  });
+
+  it('degrades a field-less model to a plain class (data class needs a parameter)', () => {
+    const content = generateModels([{ name: 'Empty', fields: [] }], ctx)[0].content;
+    expect(content).toContain('public class Empty');
+    expect(content).not.toContain('data class');
+  });
+
+  it('marks deprecated fields with @Deprecated', () => {
+    const models: Model[] = [
+      {
+        name: 'Thing',
+        fields: [{ name: 'old', type: { kind: 'primitive', type: 'string' }, required: true, deprecated: true }],
+      },
+    ];
+    expect(generateModels(models, ctx)[0].content).toContain('@Deprecated(');
+  });
+
+  it('honors domainName for the property while keeping the wire key', () => {
+    const models: Model[] = [
+      {
+        name: 'Connection',
+        fields: [
+          {
+            name: 'connection_type',
+            domainName: 'type',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
+    ];
+    const content = generateModels(models, ctx)[0].content;
+    expect(content).toContain('public val type: String,');
+    expect(content).toContain('@SerialName("connection_type")');
+  });
+
+  it('de-duplicates repeated property names from flattened union variants', () => {
+    const models: Model[] = [
+      {
+        name: 'Owner',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+      },
+    ];
+    const content = generateModels(models, ctx)[0].content;
+    expect(content.match(/public val id: String/g)).toHaveLength(1);
+  });
+
+  it('renders a full model deterministically', () => {
+    const models: Model[] = [
+      {
+        name: 'Organization',
+        description: 'An organization.',
+        fields: [
+          { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true, description: 'The id.' },
+          { name: 'external_id', type: { kind: 'primitive', type: 'string' }, required: false },
+        ],
+      },
+    ];
+    expect(generateModels(models, ctx)[0].content).toMatchInlineSnapshot(`
+      "package com.workos.android.models
+
+      import kotlinx.serialization.SerialName
+      import kotlinx.serialization.Serializable
+
+      /** An organization. */
+      @Serializable
+      public data class Organization(
+          /** The id. */
+          @SerialName("id")
+          public val id: String,
+          @SerialName("external_id")
+          public val externalId: String? = null,
+      )"
+    `);
+  });
+});

--- a/test/android/non-spec.test.ts
+++ b/test/android/non-spec.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { NON_SPEC_SERVICES } from '../../src/shared/non-spec-services.js';
+import { generateClient } from '../../src/android/client.js';
+import type { ApiSpec, EmitterContext, Service } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+
+/**
+ * The Android emitter does NOT generate client accessors from NON_SPEC_SERVICES,
+ * for the same reason the iOS and Kotlin emitters don't: its staging output has to
+ * compile standalone (the smoke runner builds it via Gradle), so a generated
+ * accessor referencing a hand-maintained type that only exists in the SDK repo
+ * would break the build.
+ *
+ * Instead every non-spec service is mounted from a hand-maintained Kotlin file in
+ * `helpers/` — same module, so a `val {Namespace}Client.passwordless` extension
+ * property there is indistinguishable from a generated one at the call site.
+ *
+ * This test pins the set that hand-maintained layer is expected to cover. Adding an
+ * entry to NON_SPEC_SERVICES fails this test until the matching Kotlin helper (and
+ * this list) land in the same change.
+ */
+const ANDROID_HAND_MAINTAINED_COVERAGE = new Set([
+  'passwordless', // helpers/Passwordless.kt (extension on the client)
+  'webhook_verification', // helpers/WebhookVerification.kt (H01, H02) -- IMPLEMENTED
+  'actions', // helpers/Actions.kt (H03) -- IMPLEMENTED
+  'session_manager', // helpers/Iron.kt (H06) + helpers/Session.kt (H04, H05, H07) -- IMPLEMENTED
+  'pkce', // helpers/Pkce.kt + AuthKit.kt + SSOAuthKit.kt + PublicClient.kt (H08, H10, H15, H19).
+  // H16 is not implemented and will not be: POST /sso/token requires client_secret,
+  // so a secret-less PKCE exchange is impossible from an app. See helpers/SSOAuthKit.kt.
+]);
+
+const emptySpec: ApiSpec = {
+  name: 'Test',
+  version: '1.0.0',
+  baseUrl: '',
+  services: [],
+  models: [],
+  enums: [],
+  sdk: defaultSdkBehavior(),
+};
+
+const service: Service = {
+  name: 'Organizations',
+  operations: [
+    {
+      name: 'list_organizations',
+      httpMethod: 'get',
+      path: '/organizations',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+  ],
+};
+
+const ctx: EmitterContext = {
+  namespace: 'workos',
+  namespacePascal: 'WorkOS',
+  spec: { ...emptySpec, services: [service] },
+};
+
+describe('android non-spec service coverage', () => {
+  it('covers every NON_SPEC_SERVICES entry with a hand-maintained Kotlin helper', () => {
+    const uncovered = NON_SPEC_SERVICES.map((s) => s.id).filter((id) => !ANDROID_HAND_MAINTAINED_COVERAGE.has(id));
+    expect(
+      uncovered,
+      'New non-spec service(s) without an Android hand-maintained helper. Add the ' +
+        'client extension in workos-android/src/main/kotlin/com/workos/android/helpers/ ' +
+        'and update ANDROID_HAND_MAINTAINED_COVERAGE.',
+    ).toEqual([]);
+  });
+
+  it('does not generate an accessor for any non-spec service', () => {
+    // A generated accessor would reference a type that exists only in the SDK repo,
+    // breaking the standalone staging build the smoke runner compiles.
+    const accessors = generateClient(ctx)[0].content ?? '';
+    for (const svc of NON_SPEC_SERVICES) {
+      expect(accessors, `non-spec service '${svc.id}' must not get a generated accessor`).not.toMatch(
+        new RegExp(`WorkOSClient\\.${svc.id.replace(/_(.)/g, (_, c: string) => c.toUpperCase())}\\b`, 'i'),
+      );
+    }
+  });
+});

--- a/test/android/resources.test.ts
+++ b/test/android/resources.test.ts
@@ -150,6 +150,38 @@ describe('android/resources', () => {
     expect(content).toContain('limit?.let { query.add(QueryParam("limit", it.toString())) }');
   });
 
+  it('emits a string-valued literal query param without a redundant .toString()', () => {
+    // A `literal` TypeRef (e.g. the spec's `prompt: "login"` or
+    // `code_challenge_method: "S256"`) renders as Kotlin `String`, so
+    // `it.toString()` is redundant and Kotlin 2.4 flags it as a warning.
+    // Regression for the SSO/UserManagement authorize warnings.
+    const service: Service = {
+      name: 'Sso',
+      operations: [
+        {
+          name: 'get_authorization_url',
+          httpMethod: 'get',
+          path: '/sso/authorize',
+          pathParams: [],
+          queryParams: [
+            { name: 'prompt', type: { kind: 'literal', value: 'login' }, required: false },
+            { name: 'code_challenge_method', type: { kind: 'literal', value: 'S256' }, required: false },
+          ],
+          headerParams: [],
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([service]);
+    const content = generateResources([service], ctx)[0].content;
+    expect(content).toContain('prompt?.let { query.add(QueryParam("prompt", it)) }');
+    expect(content).toContain('codeChallengeMethod?.let { query.add(QueryParam("code_challenge_method", it)) }');
+    expect(content).not.toContain('QueryParam("prompt", it.toString())');
+    expect(content).not.toContain('QueryParam("code_challenge_method", it.toString())');
+  });
+
   it('emits an auto-paging Flow companion for a cursor-paginated operation', () => {
     const listService: Service = {
       name: 'Organizations',

--- a/test/android/resources.test.ts
+++ b/test/android/resources.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect } from 'vitest';
+import type { EmitterContext, ApiSpec, Service, Model } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { generateResources } from '../../src/android/resources.js';
+
+const organizationModel: Model = {
+  name: 'Organization',
+  fields: [
+    { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+    { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+  ],
+};
+
+const createBody: Model = {
+  name: 'CreateOrganizationOptions',
+  fields: [
+    { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+    { name: 'domains', type: { kind: 'array', items: { kind: 'primitive', type: 'string' } }, required: false },
+  ],
+};
+
+function makeCtx(services: Service[], models: Model[] = [organizationModel, createBody]): EmitterContext {
+  const spec: ApiSpec = {
+    name: 'Test',
+    version: '1.0.0',
+    baseUrl: 'https://api.example.com',
+    services,
+    models,
+    enums: [],
+    sdk: defaultSdkBehavior(),
+  };
+  return { namespace: 'workos', namespacePascal: 'WorkOS', spec };
+}
+
+const organizationsService: Service = {
+  name: 'Organizations',
+  operations: [
+    {
+      name: 'create_organization',
+      description: 'Creates a new organization.',
+      httpMethod: 'post',
+      path: '/organizations',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      requestBody: { kind: 'model', name: 'CreateOrganizationOptions' },
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+    {
+      name: 'get_organization',
+      httpMethod: 'get',
+      path: '/organizations/{id}',
+      pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+    {
+      name: 'delete_organization',
+      httpMethod: 'delete',
+      path: '/organizations/{id}',
+      pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'primitive', type: 'unknown' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+  ],
+};
+
+describe('android/resources', () => {
+  it('generates one resource class per mount group at the Android source path', () => {
+    const ctx = makeCtx([organizationsService]);
+    const files = generateResources([organizationsService], ctx);
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe('src/main/kotlin/com/workos/android/resources/Organizations.kt');
+    const content = files[0].content;
+    expect(content).toContain('package com.workos.android.resources');
+    expect(content).toContain('public class Organizations internal constructor(');
+    expect(content).toContain('private val transport: Transport,');
+  });
+
+  it('emits suspend functions with flattened body params and a trailing requestOptions', () => {
+    const ctx = makeCtx([organizationsService]);
+    const content = generateResources([organizationsService], ctx)[0].content;
+    expect(content).toContain('public suspend fun create(');
+    expect(content).toContain('name: String,');
+    // optional body field is nullable with a default so callers can omit it
+    expect(content).toContain('domains: List<String>? = null,');
+    expect(content).toContain('requestOptions: RequestOptions? = null,');
+    expect(content).toContain('val payload = JsonBody()');
+    expect(content).toContain('payload.set("name", name)');
+    expect(content).toContain('payload.set("domains", domains)');
+    expect(content).toContain('method = "POST",');
+  });
+
+  it('wraps path params in PathEncoding to prevent path traversal', () => {
+    const ctx = makeCtx([organizationsService]);
+    const content = generateResources([organizationsService], ctx)[0].content;
+    expect(content).toContain('val path = "organizations/${PathEncoding.segment(id)}"');
+    expect(content).toContain('import com.workos.android.internal.PathEncoding');
+  });
+
+  it('returns Unit (no return type) and calls requestVoid for a bodyless delete', () => {
+    const ctx = makeCtx([organizationsService]);
+    const content = generateResources([organizationsService], ctx)[0].content;
+    expect(content).toContain('transport.requestVoid(');
+    expect(content).toContain('method = "DELETE",');
+  });
+
+  it('builds a query list and a Page return type for a paginated list operation', () => {
+    const listService: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'list_organizations',
+          httpMethod: 'get',
+          path: '/organizations',
+          pathParams: [],
+          queryParams: [
+            { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+            { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+          ],
+          headerParams: [],
+          response: { kind: 'model', name: 'OrganizationList' },
+          errors: [],
+          injectIdempotencyKey: false,
+          pagination: { strategy: 'cursor', param: 'after', itemType: { kind: 'model', name: 'Organization' } },
+        },
+      ],
+    };
+    const listModel: Model = {
+      name: 'OrganizationList',
+      fields: [
+        { name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Organization' } }, required: true },
+        { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+      ],
+    };
+    const ctx = makeCtx([listService], [organizationModel, listModel]);
+    const content = generateResources([listService], ctx)[0].content;
+    expect(content).toContain('): Page<Organization> {');
+    expect(content).toContain('val query = mutableListOf<QueryParam>()');
+    expect(content).toContain('after?.let { query.add(QueryParam("after", it)) }');
+    // a non-string query value is stringified
+    expect(content).toContain('limit?.let { query.add(QueryParam("limit", it.toString())) }');
+  });
+
+  it('emits an auto-paging Flow companion for a cursor-paginated operation', () => {
+    const listService: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'list_organizations',
+          httpMethod: 'get',
+          path: '/organizations',
+          pathParams: [],
+          queryParams: [{ name: 'after', type: { kind: 'primitive', type: 'string' }, required: false }],
+          headerParams: [],
+          response: { kind: 'model', name: 'OrganizationList' },
+          errors: [],
+          injectIdempotencyKey: false,
+          pagination: { strategy: 'cursor', param: 'after', itemType: { kind: 'model', name: 'Organization' } },
+        },
+      ],
+    };
+    const listModel: Model = {
+      name: 'OrganizationList',
+      fields: [
+        { name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Organization' } }, required: true },
+        { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+      ],
+    };
+    const ctx = makeCtx([listService], [organizationModel, listModel]);
+    const content = generateResources([listService], ctx)[0].content;
+    expect(content).toContain('public fun listAutoPaging(');
+    expect(content).toContain('): Flow<Organization> =');
+    expect(content).toContain('autoPagingFlow { cursor ->');
+    expect(content).toContain('after = cursor,');
+    expect(content).toContain('import kotlinx.coroutines.flow.Flow');
+    // the auto-pager drives the cursor itself, so it is not a caller parameter
+    expect(content).not.toMatch(/public fun listAutoPaging\([^)]*after:/s);
+  });
+
+  it('suffixes a resource whose name collides with a model type', () => {
+    const service: Service = {
+      name: 'Organization',
+      operations: [
+        {
+          name: 'get_organization',
+          httpMethod: 'get',
+          path: '/organizations/{id}',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([service], [organizationModel]);
+    const files = generateResources([service], ctx);
+    expect(files[0].path).toBe('src/main/kotlin/com/workos/android/resources/OrganizationResource.kt');
+    expect(files[0].content).toContain('public class OrganizationResource internal constructor(');
+  });
+
+  it('routes a raw model body through setRaw with a named serializer', () => {
+    // A field-less model body cannot be flattened, so it is passed whole. The
+    // transport takes a JsonBody, so handing the model straight to `body =` would
+    // not typecheck — it must go through `setRaw`.
+    const rawModel: Model = { name: 'CreateApplicationSecret', fields: [] };
+    const rawService: Service = {
+      name: 'Connect',
+      operations: [
+        {
+          name: 'create_application_client_secret',
+          httpMethod: 'post',
+          path: '/connect/applications/{id}/client_secrets',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          requestBody: { kind: 'model', name: 'CreateApplicationSecret' },
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([rawService], [organizationModel, rawModel]);
+    const content = generateResources([rawService], ctx)[0].content;
+    expect(content).toContain('body: CreateApplicationSecret,');
+    expect(content).toContain('val payload = JsonBody()');
+    expect(content).toContain('payload.setRaw(CreateApplicationSecret.serializer(), body)');
+    expect(content).toContain('body = payload,');
+    // the local must not shadow the `body` parameter it reads on the next line
+    expect(content).not.toContain('val body = JsonBody()');
+  });
+
+  it('exposes a non-model raw body as JsonElement, which has no named serializer', () => {
+    const rawService: Service = {
+      name: 'Connect',
+      operations: [
+        {
+          name: 'push_raw',
+          httpMethod: 'post',
+          path: '/raw',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          requestBody: { kind: 'map', valueType: { kind: 'primitive', type: 'unknown' } },
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([rawService], [organizationModel]);
+    const content = generateResources([rawService], ctx)[0].content;
+    expect(content).toContain('body: JsonElement,');
+    expect(content).toContain('payload.setRawJson(body)');
+    expect(content).toContain('import kotlinx.serialization.json.JsonElement');
+  });
+
+  it('does not let a body field named `body` shadow the JsonBody local', () => {
+    const collidingBody: Model = {
+      name: 'SendOptions',
+      fields: [{ name: 'body', type: { kind: 'primitive', type: 'string' }, required: true }],
+    };
+    const svc: Service = {
+      name: 'Messages',
+      operations: [
+        {
+          name: 'send_message',
+          httpMethod: 'post',
+          path: '/messages',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          requestBody: { kind: 'model', name: 'SendOptions' },
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([svc], [organizationModel, collidingBody]);
+    const content = generateResources([svc], ctx)[0].content;
+    expect(content).toContain('body: String,');
+    expect(content).toContain('val payload = JsonBody()');
+    expect(content).toContain('payload.set("body", body)');
+  });
+
+  it('carries the parent operation description into split-wrapper docs', () => {
+    // The variant name alone only restates the method name; dropping the spec
+    // description leaves the KDoc saying nothing a reader could not already see.
+    const splitService: Service = {
+      name: 'Connect',
+      operations: [
+        {
+          name: 'create_application',
+          description: 'Create a Connect Application\n\nSupports both OAuth and M2M application types.',
+          httpMethod: 'post',
+          path: '/connect/applications',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          requestBody: { kind: 'model', name: 'CreateOrganizationOptions' },
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([splitService], [organizationModel, createBody]);
+    const resolved = {
+      operation: splitService.operations[0],
+      service: splitService,
+      methodName: 'create_application',
+      mountOn: 'Connect',
+      defaults: {},
+      inferFromClient: [],
+      urlBuilder: false,
+      wrappers: [
+        {
+          name: 'create_oauth_application',
+          targetVariant: 'CreateOrganizationOptions',
+          defaults: {},
+          inferFromClient: [],
+          exposedParams: ['name'],
+          optionalParams: [],
+          responseModelName: 'Organization',
+        },
+      ],
+    };
+    const content = generateResources([splitService], { ...ctx, resolvedOperations: [resolved] })[0].content ?? '';
+    expect(content).toContain('public suspend fun createOAuthApplication(');
+    // the variant line...
+    expect(content).toContain('Create oauth application');
+    // ...and the spec body beneath it. The spec's own short title is dropped as a
+    // duplicate of the variant line.
+    expect(content).toContain('Supports both OAuth and M2M application types.');
+  });
+
+  it('renders an array query param as a repeated key', () => {
+    const service: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'list_organizations',
+          httpMethod: 'get',
+          path: '/organizations',
+          pathParams: [],
+          queryParams: [
+            {
+              name: 'domains',
+              type: { kind: 'array', items: { kind: 'primitive', type: 'string' } },
+              required: false,
+            },
+          ],
+          headerParams: [],
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([service], [organizationModel]);
+    const content = generateResources([service], ctx)[0].content;
+    expect(content).toContain('domains?.let {');
+    expect(content).toContain('for (value in it) {');
+    expect(content).toContain('query.add(QueryParam("domains", value))');
+  });
+
+  /**
+   * The `requestOptions` doc must name the overrides `RequestOptions` actually
+   * has. It previously claimed a per-request "API key" override — copied from the
+   * iOS emitter — which no Kotlin `RequestOptions` field provides, while omitting
+   * the retry and base-URL overrides that do exist. A doc promising a capability
+   * the type lacks is worse than no doc, and it was replicated onto every
+   * generated method, so it is pinned here.
+   */
+  it('documents requestOptions with the overrides RequestOptions actually provides', () => {
+    const service: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'get_organization',
+          httpMethod: 'get',
+          path: '/organizations/{id}',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([service], [organizationModel]);
+    const content = generateResources([service], ctx)[0].content ?? '';
+
+    for (const override of ['extra headers', 'timeout', 'retries', 'base URL', 'idempotency key']) {
+      expect(content).toContain(override);
+    }
+    expect(content).not.toContain('API key');
+  });
+});

--- a/test/android/resources.test.ts
+++ b/test/android/resources.test.ts
@@ -377,6 +377,56 @@ describe('android/resources', () => {
   });
 
   /**
+   * `before` must be sent on the first auto-paged request only.
+   *
+   * `after` and `before` are alternative windows into the list, not filters.
+   * Re-sending `before` while `after` advances asks the server for a
+   * contradictory range, which can return the same page forever — and
+   * `autoPagingFlow` breaks only when `after` is null, so the failure mode is an
+   * infinite flow emitting duplicates rather than one bad page. `cursor == null`
+   * identifies the first page exactly, so the guard needs no runtime support.
+   */
+  it('sends the reverse cursor on the first auto-paged request only', () => {
+    const service: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'list_organizations',
+          httpMethod: 'get',
+          path: '/organizations',
+          pathParams: [],
+          queryParams: [
+            { name: 'before', type: { kind: 'primitive', type: 'string' }, required: false },
+            { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+            { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+          ],
+          headerParams: [],
+          response: { kind: 'model', name: 'OrganizationList' },
+          errors: [],
+          injectIdempotencyKey: false,
+          pagination: { strategy: 'cursor', param: 'after', itemType: { kind: 'model', name: 'Organization' } },
+        },
+      ],
+    };
+    const listModel: Model = {
+      name: 'OrganizationList',
+      fields: [
+        { name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Organization' } }, required: true },
+        { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+      ],
+    };
+    const ctx = makeCtx([service], [organizationModel, listModel]);
+    const content = generateResources([service], ctx)[0].content ?? '';
+
+    // the forward cursor is driven by the flow...
+    expect(content).toContain('after = cursor');
+    // ...and the reverse cursor is dropped once the walk starts.
+    expect(content).toContain('before = if (cursor == null) before else null');
+    // an unrelated filter is passed through unchanged on every page
+    expect(content).toContain('limit = limit');
+  });
+
+  /**
    * The `requestOptions` doc must name the overrides `RequestOptions` actually
    * has. It previously claimed a per-request "API key" override — copied from the
    * iOS emitter — which no Kotlin `RequestOptions` field provides, while omitting

--- a/test/android/resources.test.ts
+++ b/test/android/resources.test.ts
@@ -339,8 +339,9 @@ describe('android/resources', () => {
     };
     const content = generateResources([splitService], { ...ctx, resolvedOperations: [resolved] })[0].content ?? '';
     expect(content).toContain('public suspend fun createOAuthApplication(');
-    // the variant line...
-    expect(content).toContain('Create oauth application');
+    // the variant line, whose acronym casing must agree with the method name
+    // directly below it rather than lower-casing the raw IR wrapper name...
+    expect(content).toContain('Create OAuth application');
     // ...and the spec body beneath it. The spec's own short title is dropped as a
     // duplicate of the variant line.
     expect(content).toContain('Supports both OAuth and M2M application types.');

--- a/test/android/resources.test.ts
+++ b/test/android/resources.test.ts
@@ -377,6 +377,46 @@ describe('android/resources', () => {
   });
 
   /**
+   * A map-valued query param must expand to bracketed entries.
+   *
+   * `Map.toString()` renders Kotlin's own syntax — `{hd=example.com}` — so
+   * stringifying one sends a single opaque parameter and the provider never sees
+   * the pairs. `provider_query_params[hd]=example.com` is what the API and every
+   * other WorkOS SDK use.
+   */
+  it('expands a map query param into bracketed entries', () => {
+    const service: Service = {
+      name: 'SSO',
+      operations: [
+        {
+          name: 'get_authorization_url',
+          httpMethod: 'get',
+          path: '/sso/authorize',
+          pathParams: [],
+          queryParams: [
+            {
+              name: 'provider_query_params',
+              type: { kind: 'map', valueType: { kind: 'primitive', type: 'string' } },
+              required: false,
+            },
+          ],
+          headerParams: [],
+          response: { kind: 'primitive', type: 'unknown' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([service], [organizationModel]);
+    const content = generateResources([service], ctx)[0].content ?? '';
+
+    expect(content).toContain('for ((key, value) in it) {');
+    expect(content).toContain('query.add(QueryParam("provider_query_params[$key]", value))');
+    // the whole map must never be stringified as one value
+    expect(content).not.toContain('QueryParam("provider_query_params", it.toString())');
+  });
+
+  /**
    * `before` must be sent on the first auto-paged request only.
    *
    * `after` and `before` are alternative windows into the list, not filters.

--- a/test/android/smoke-plan.test.ts
+++ b/test/android/smoke-plan.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import type { EmitterContext, ApiSpec, Service, Model, Enum } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { generateResources } from '../../src/android/resources.js';
+import { generateClient } from '../../src/android/client.js';
+
+/**
+ * The smoke driver (`smoke/sdk-android.ts`) writes literal Kotlin calls straight
+ * from the `.oagen-android-smoke.json` sidecar, so any drift between the sidecar
+ * and the generated resource signatures is a driver COMPILE error — the slowest
+ * possible way to find out. These tests assert the two agree statically.
+ */
+
+const organizationModel: Model = {
+  name: 'Organization',
+  fields: [
+    { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+    { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+  ],
+};
+
+const createBody: Model = {
+  name: 'CreateOrganizationOptions',
+  fields: [
+    { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+    { name: 'domains', type: { kind: 'array', items: { kind: 'primitive', type: 'string' } }, required: false },
+  ],
+};
+
+const stateEnum: Enum = { name: 'OrganizationState', values: [{ name: 'active', value: 'active' }] };
+
+const service: Service = {
+  name: 'Organizations',
+  operations: [
+    {
+      name: 'create_organization',
+      httpMethod: 'post',
+      path: '/organizations',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      requestBody: { kind: 'model', name: 'CreateOrganizationOptions' },
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+    {
+      name: 'get_organization',
+      httpMethod: 'get',
+      path: '/organizations/{id}',
+      pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      queryParams: [
+        { name: 'state', type: { kind: 'enum', name: 'OrganizationState' }, required: false },
+        { name: 'limit', type: { kind: 'primitive', type: 'integer' }, required: false },
+        { name: 'object', type: { kind: 'primitive', type: 'string' }, required: false },
+      ],
+      headerParams: [],
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+  ],
+};
+
+function makeCtx(): EmitterContext {
+  const spec: ApiSpec = {
+    name: 'Test',
+    version: '1.0.0',
+    baseUrl: 'https://api.example.com',
+    services: [service],
+    models: [organizationModel, createBody],
+    enums: [stateEnum],
+    sdk: defaultSdkBehavior(),
+  };
+  return { namespace: 'workos', namespacePascal: 'WorkOS', spec };
+}
+
+interface PlanParam {
+  label: string;
+  wire: string;
+  source: string;
+  optional: boolean;
+  serialize: { kind: string; enumType?: string };
+}
+interface PlanEntry {
+  service: string;
+  method: string;
+  params: PlanParam[];
+}
+
+function readPlan(ctx: EmitterContext): Record<string, PlanEntry> {
+  const plan = generateClient(ctx).find((f) => f.path === '.oagen-android-smoke.json');
+  expect(plan).toBeDefined();
+  const parsed: unknown = JSON.parse(plan?.content ?? '{}');
+  expect(parsed).toHaveProperty('operations');
+  return (parsed as { operations: Record<string, PlanEntry> }).operations;
+}
+
+/** Parse `accessor -> resource type` out of the generated client extensions. */
+function readAccessors(ctx: EmitterContext): Map<string, string> {
+  const content = generateClient(ctx)[0].content ?? '';
+  const map = new Map<string, string>();
+  for (const m of content.matchAll(/public val WorkOSClient\.(\S+): (\S+)/g)) {
+    map.set(m[1].replace(/`/g, ''), m[2]);
+  }
+  return map;
+}
+
+/** Parse `resourceType -> method -> param names` out of the generated resources. */
+function readSignatures(ctx: EmitterContext): Map<string, Map<string, Set<string>>> {
+  const out = new Map<string, Map<string, Set<string>>>();
+  for (const file of generateResources([service], ctx)) {
+    const type = (file.path.split('/').pop() ?? '').replace(/\.kt$/, '');
+    const src = file.content ?? '';
+    const methods = new Map<string, Set<string>>();
+    for (const m of src.matchAll(/public (?:suspend )?fun (\w+|`[^`]+`)\(([\s\S]*?)\n {4}\)/g)) {
+      const params = new Set<string>();
+      for (const p of m[2].matchAll(/^ {8}(\w+|`[^`]+`):/gm)) params.add(p[1].replace(/`/g, ''));
+      methods.set(m[1].replace(/`/g, ''), params);
+    }
+    for (const m of src.matchAll(/public (?:suspend )?fun (\w+|`[^`]+`)\(\)/g)) {
+      const name = m[1].replace(/`/g, '');
+      if (!methods.has(name)) methods.set(name, new Set());
+    }
+    out.set(type, methods);
+  }
+  return out;
+}
+
+describe('android/smoke-plan', () => {
+  it('every plan entry resolves to a real accessor, method, and parameter', () => {
+    const ctx = makeCtx();
+    const plan = readPlan(ctx);
+    const accessors = readAccessors(ctx);
+    const sigs = readSignatures(ctx);
+
+    expect(Object.keys(plan).length).toBeGreaterThan(0);
+
+    for (const [httpKey, entry] of Object.entries(plan)) {
+      const resourceType = accessors.get(entry.service);
+      expect(resourceType, `${httpKey}: accessor '${entry.service}' missing on client`).toBeDefined();
+
+      const methods = sigs.get(resourceType ?? '');
+      expect(methods, `${httpKey}: no resource file for '${resourceType}'`).toBeDefined();
+
+      const params = methods?.get(entry.method);
+      expect(params, `${httpKey}: ${resourceType} has no method '${entry.method}'`).toBeDefined();
+
+      for (const p of entry.params) {
+        const label = p.label.replace(/`/g, '');
+        expect(params?.has(label), `${httpKey}: ${resourceType}.${entry.method} has no param '${label}'`).toBe(true);
+      }
+    }
+  });
+
+  it('records the resolved enum type so the driver can construct the value', () => {
+    const plan = readPlan(makeCtx());
+    const entry = plan['GET /organizations/{id}'];
+    const stateParam = entry.params.find((p) => p.wire === 'state');
+    expect(stateParam?.serialize).toEqual({ kind: 'enum', enumType: 'OrganizationState' });
+  });
+
+  it('describes integers as long, matching the generated Kotlin type', () => {
+    const plan = readPlan(makeCtx());
+    const limit = plan['GET /organizations/{id}'].params.find((p) => p.wire === 'limit');
+    // the emitter maps a format-less integer to Long, so the driver must emit `1L`
+    expect(limit?.serialize).toEqual({ kind: 'long' });
+  });
+
+  it('strips back-ticks from labels so the driver re-escapes deliberately', () => {
+    const plan = readPlan(makeCtx());
+    const objectParam = plan['GET /organizations/{id}'].params.find((p) => p.wire === 'object');
+    expect(objectParam?.label).toBe('object');
+    expect(objectParam?.label).not.toContain('`');
+  });
+
+  it('marks path params as required and query params as optional', () => {
+    const plan = readPlan(makeCtx());
+    const entry = plan['GET /organizations/{id}'];
+    expect(entry.params.find((p) => p.wire === 'id')).toMatchObject({ source: 'path', optional: false });
+    expect(entry.params.find((p) => p.wire === 'limit')).toMatchObject({ source: 'query', optional: true });
+  });
+
+  it('expands a model request body into individual body params', () => {
+    const plan = readPlan(makeCtx());
+    const entry = plan['POST /organizations'];
+    expect(entry.params.map((p) => p.wire)).toEqual(['name', 'domains']);
+    expect(entry.params.every((p) => p.source === 'body')).toBe(true);
+  });
+
+  it('is byte-stable across runs', () => {
+    const a = generateClient(makeCtx()).find((f) => f.path === '.oagen-android-smoke.json')?.content;
+    const b = generateClient(makeCtx()).find((f) => f.path === '.oagen-android-smoke.json')?.content;
+    expect(a).toBe(b);
+  });
+});

--- a/test/android/tests.test.ts
+++ b/test/android/tests.test.ts
@@ -81,6 +81,106 @@ describe('android/tests', () => {
     expect(content).not.toMatch(/assertNotNull\(client\.\w+\)/);
   });
 
+  it('asserts a real field value on responses with no string id (§6)', () => {
+    // Every response shape that used to degrade to `assertNotNull(result)`, which §6
+    // lists as an anti-pattern: the scalar must be found wherever it actually lives.
+    const models: Model[] = [
+      // no `id`, but a required string
+      {
+        name: 'TokenResponse',
+        fields: [{ name: 'access_token', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      // no scalar at all — the value is one level down, behind a required model
+      {
+        name: 'UserEnvelope',
+        fields: [{ name: 'user', type: { kind: 'model', name: 'Organization' }, required: true }],
+      },
+      // a non-paginated list envelope
+      {
+        name: 'RoleList',
+        fields: [
+          { name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Organization' } }, required: true },
+        ],
+      },
+      // required boolean, and an optional nested payload behind a safe call
+      {
+        name: 'CheckResponse',
+        fields: [{ name: 'authorized', type: { kind: 'primitive', type: 'boolean' }, required: true }],
+      },
+      {
+        name: 'OptionalPayload',
+        fields: [{ name: 'token', type: { kind: 'model', name: 'TokenResponse' }, required: false }],
+      },
+      organizationModel,
+    ];
+    const ops = models
+      .filter((m) => m.name !== 'Organization')
+      .map((m, i) => ({
+        name: `get_thing_${i}`,
+        httpMethod: 'get' as const,
+        path: `/things/${i}`,
+        pathParams: [],
+        queryParams: [],
+        headerParams: [],
+        response: { kind: 'model' as const, name: m.name },
+        errors: [],
+        injectIdempotencyKey: false,
+      }));
+    const ctx = makeCtx([{ name: 'Things', operations: ops }], models);
+    const content = generateTests(ctx.spec, ctx)[0].content ?? '';
+
+    expect(content).toContain('assertEquals("test_access_token", result.accessToken)');
+    expect(content).toContain('assertEquals("org_01234", result.user.id)');
+    expect(content).toContain('assertEquals(1, result.data.size)');
+    expect(content).toContain('assertEquals("org_01234", result.data.first().id)');
+    expect(content).toContain('assertEquals(true, result.authorized)');
+    // optional hop must use a safe call, or the Kotlin will not compile
+    expect(content).toContain('assertEquals("test_access_token", result.token?.accessToken)');
+    // and none of them fall back to the anti-pattern
+    expect(content).not.toMatch(/assertNotNull\(result\)/);
+  });
+
+  it('emits numeric literals typed to match the property (§6)', () => {
+    // `assertEquals(1, aLong)` compiles — both widen to Any — and then fails at
+    // runtime, so the literal has to carry the Kotlin type's suffix.
+    const models: Model[] = [
+      {
+        name: 'Counts',
+        fields: [
+          { name: 'total', type: { kind: 'primitive', type: 'integer' }, required: true },
+          { name: 'ratio', type: { kind: 'primitive', type: 'number' }, required: true },
+        ],
+      },
+      {
+        name: 'Small',
+        fields: [{ name: 'n', type: { kind: 'primitive', type: 'integer', format: 'int32' }, required: true }],
+      },
+      // no spec field reaches the Double branch today, so pin it here rather than
+      // discover it the first time one does.
+      {
+        name: 'Ratio',
+        fields: [{ name: 'ratio', type: { kind: 'primitive', type: 'number' }, required: true }],
+      },
+    ];
+    const ops = models.map((m, i) => ({
+      name: `get_thing_${i}`,
+      httpMethod: 'get' as const,
+      path: `/things/${i}`,
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model' as const, name: m.name },
+      errors: [],
+      injectIdempotencyKey: false,
+    }));
+    const ctx = makeCtx([{ name: 'Things', operations: ops }], models);
+    const content = generateTests(ctx.spec, ctx)[0].content ?? '';
+    expect(content).toContain('assertEquals(1L, result.total)'); // Long
+    expect(content).toContain('assertEquals(1, result.n)'); // Int (format int32)
+    expect(content).toContain('assertEquals(1.5, result.ratio)'); // Double
+    expect(content).not.toContain('assertEquals(1, result.total)');
+  });
+
   it('emits §6 error-path tests derived from the spec error policy', () => {
     const ctx = makeCtx([service], [organizationModel, createBody]);
     const content = generateTests(ctx.spec, ctx)[0].content ?? '';

--- a/test/android/tests.test.ts
+++ b/test/android/tests.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import type { EmitterContext, ApiSpec, Service, Model } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { generateTests } from '../../src/android/tests.js';
+
+const organizationModel: Model = {
+  name: 'Organization',
+  fields: [
+    { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+    { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+  ],
+};
+
+const createBody: Model = {
+  name: 'CreateOrganizationOptions',
+  fields: [{ name: 'name', type: { kind: 'primitive', type: 'string' }, required: true }],
+};
+
+const service: Service = {
+  name: 'Organizations',
+  operations: [
+    {
+      name: 'create_organization',
+      httpMethod: 'post',
+      path: '/organizations',
+      pathParams: [],
+      queryParams: [],
+      headerParams: [],
+      requestBody: { kind: 'model', name: 'CreateOrganizationOptions' },
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+    {
+      name: 'get_organization',
+      httpMethod: 'get',
+      path: '/organizations/{id}',
+      pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model', name: 'Organization' },
+      errors: [],
+      injectIdempotencyKey: false,
+    },
+  ],
+};
+
+function makeCtx(services: Service[], models: Model[]): EmitterContext {
+  const spec: ApiSpec = {
+    name: 'Test',
+    version: '1.0.0',
+    baseUrl: 'https://api.example.com',
+    services,
+    models,
+    enums: [],
+    sdk: defaultSdkBehavior(),
+  };
+  return { namespace: 'workos', namespacePascal: 'WorkOS', spec };
+}
+
+describe('android/tests', () => {
+  it('generates one JUnit suite per mount group plus the round-trip suite', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const files = generateTests(ctx.spec, ctx);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('src/test/kotlin/com/workos/android/OrganizationsTest.kt');
+    expect(paths).toContain('src/test/kotlin/com/workos/android/ModelRoundTripTest.kt');
+    const content = files[0].content;
+    expect(content).toContain('package com.workos.android');
+    expect(content).toContain('class OrganizationsTest {');
+    expect(content).toContain('import org.junit.jupiter.api.Test');
+    expect(content).toContain('import kotlinx.coroutines.test.runTest');
+    expect(content).toContain('import com.workos.android.support.testClient');
+  });
+
+  it('emits no existence-only test (runtime contract §6 anti-pattern)', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content ?? '';
+    // Reachability is proven by the per-operation calls, not by asserting a symbol exists.
+    expect(content).not.toContain('resource is reachable');
+    expect(content).not.toMatch(/assertNotNull\(client\.\w+\)/);
+  });
+
+  it('emits §6 error-path tests derived from the spec error policy', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content ?? '';
+    // names come from ErrorPolicy.statusCodeMap, not hardcoded
+    for (const [status, exc] of [
+      [401, 'AuthenticationException'],
+      [404, 'NotFoundException'],
+      [429, 'RateLimitExceededException'],
+      [400, 'BadRequestException'],
+      [422, 'UnprocessableEntityException'],
+      [500, 'ServerException'],
+    ] as const) {
+      expect(content, `missing ${status} test`).toContain(`assertFailsWith<${exc}>`);
+      expect(content).toContain(`assertEquals(${status}, error.statusCode)`);
+    }
+    // a 429 must exercise the Retry-After path
+    expect(content).toContain('mapOf("Retry-After" to "0")');
+  });
+
+  it('emits a §6 per-request-options test that asserts the header reached the wire', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content ?? '';
+    expect(content).toContain('fun `request options are honored on the wire`()');
+    expect(content).toContain('RequestOptions(headers = mapOf("X-Custom" to "value"))');
+    expect(content).toContain('assertEquals("value", request.headerValue("X-Custom"))');
+  });
+
+  it('emits §6 model round-trip tests that assert equality after encode+decode', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const rt = generateTests(ctx.spec, ctx).find((f) => f.path.endsWith('ModelRoundTripTest.kt'));
+    const content = rt?.content ?? '';
+    expect(content).toContain('class ModelRoundTripTest {');
+    expect(content).toContain('fun `Organization round-trips through JSON`()');
+    expect(content).toContain('json.encodeToString(Organization.serializer(), original)');
+    expect(content).toContain('assertEquals(original, decoded)');
+  });
+
+  it('asserts the HTTP method, path, and decoded response per operation', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content;
+    // backtick test names are the Kotlin convention
+    expect(content).toContain('fun `create sends expected request`() =');
+    expect(content).toContain('runTest {');
+    expect(content).toContain('assertEquals("POST", request.method)');
+    expect(content).toContain('assertEquals("/organizations", request.pathOnly())');
+    // required body field is passed with a named argument
+    expect(content).toContain('client.organizations.create(name = "test_name")');
+    expect(content).toContain('assertTrue(request.bodyJson().containsKey("name"))');
+    // the fixture id decodes back out
+    expect(content).toContain('assertEquals("org_01234", result.id)');
+  });
+
+  it('substitutes a sample value for path params and asserts the rendered path', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content;
+    expect(content).toContain('client.organizations.get(id = "sample-id")');
+    expect(content).toContain('assertEquals("/organizations/sample-id", request.pathOnly())');
+  });
+
+  it('escapes the fixture JSON as a Kotlin string literal', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content;
+    // quotes are escaped rather than emitted raw; a raw string would also
+    // interpolate `$`, so an escaped literal is the safe form
+    expect(content).toContain('testClient(responding = "{\\"id\\":');
+    expect(content).not.toContain('"""');
+  });
+
+  it('skips an operation whose required body cannot be sample-constructed', () => {
+    const unionService: Service = {
+      name: 'Weird',
+      operations: [
+        {
+          name: 'do_thing',
+          httpMethod: 'post',
+          path: '/weird',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          requestBody: { kind: 'model', name: 'UnionBody' },
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const unionBody: Model = {
+      name: 'UnionBody',
+      fields: [
+        {
+          name: 'payload',
+          type: {
+            kind: 'union',
+            variants: [
+              { kind: 'model', name: 'A' },
+              { kind: 'model', name: 'B' },
+            ],
+          },
+          required: true,
+        },
+      ],
+    };
+    const ctx = makeCtx([unionService], [organizationModel, unionBody]);
+    const suites = generateTests(ctx.spec, ctx).filter((f) => f.path.endsWith('WeirdTest.kt'));
+    // No sampleable operation means no tests — emit no file rather than an empty
+    // class, which would read as coverage while asserting nothing.
+    expect(suites).toHaveLength(0);
+  });
+
+  it('suppresses the deprecation warning when calling a deprecated operation', () => {
+    const deprecatedService: Service = {
+      name: 'Organizations',
+      operations: [
+        {
+          name: 'get_organization',
+          httpMethod: 'get',
+          path: '/organizations/{id}',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+          deprecated: true,
+        },
+      ],
+    };
+    const ctx = makeCtx([deprecatedService], [organizationModel]);
+    expect(generateTests(ctx.spec, ctx)[0].content).toContain('@Suppress("DEPRECATION")');
+  });
+
+  it('imports every test-support extension it calls', () => {
+    // pathOnly/bodyJson/queryParam are extension functions on RecordedRequest.
+    // Kotlin only resolves an extension that is explicitly imported, so calling
+    // one without its import is a compile error in every generated suite.
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content ?? '';
+    const support = 'com.workos.android.support';
+    for (const helper of ['pathOnly', 'bodyJson']) {
+      if (content.includes(`.${helper}()`)) {
+        expect(content, `${helper} is called but not imported`).toContain(`import ${support}.${helper}`);
+      }
+    }
+    if (content.includes('.queryParam(')) {
+      expect(content).toContain(`import ${support}.queryParam`);
+    }
+    expect(content).toContain(`import ${support}.testClient`);
+  });
+
+  it('is deterministic across runs', () => {
+    const ctx = makeCtx([service], [organizationModel, createBody]);
+    expect(generateTests(ctx.spec, ctx)[0].content).toBe(generateTests(ctx.spec, ctx)[0].content);
+  });
+});

--- a/test/android/tests.test.ts
+++ b/test/android/tests.test.ts
@@ -181,6 +181,45 @@ describe('android/tests', () => {
     expect(content).not.toContain('assertEquals(1, result.total)');
   });
 
+  it('samples date fields as LocalDate and date-time as Instant (§6)', () => {
+    // `mapPrimitive` maps `format: date` to `LocalDate` and `date-time` to
+    // `Instant`. The sample constructor must match, or the generated test would
+    // not compile: an `Instant` cannot be passed to a `LocalDate` parameter.
+    // The WorkOS spec has no `date` field, so this pins the branch here.
+    const datedBody: Model = {
+      name: 'ScheduleOptions',
+      fields: [
+        { name: 'start_date', type: { kind: 'primitive', type: 'string', format: 'date' }, required: true },
+        { name: 'created_at', type: { kind: 'primitive', type: 'string', format: 'date-time' }, required: true },
+      ],
+    };
+    const datedService: Service = {
+      name: 'Schedules',
+      operations: [
+        {
+          name: 'create_schedule',
+          httpMethod: 'post',
+          path: '/schedules',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          requestBody: { kind: 'model', name: 'ScheduleOptions' },
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const ctx = makeCtx([datedService], [organizationModel, datedBody]);
+    const content = generateTests(ctx.spec, ctx)[0].content ?? '';
+    expect(content).toContain('startDate = LocalDate.parse("2023-01-01")');
+    expect(content).toContain('createdAt = Instant.parse("2023-01-01T00:00:00Z")');
+    expect(content).toContain('import kotlinx.datetime.LocalDate');
+    expect(content).toContain('import kotlinx.datetime.Instant');
+    // the regression: a `date` field must not sample as an `Instant`
+    expect(content).not.toContain('startDate = Instant.parse(');
+  });
+
   it('emits §6 error-path tests derived from the spec error policy', () => {
     const ctx = makeCtx([service], [organizationModel, createBody]);
     const content = generateTests(ctx.spec, ctx)[0].content ?? '';

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -25,6 +25,7 @@ describe('public entrypoint (@workos/oagen-emitters)', () => {
       'rubyEmitter',
       'rustEmitter',
       'iosEmitter',
+      'androidEmitter',
       'elixirEmitter',
     ];
     for (const name of expectedEmitters) {
@@ -66,6 +67,7 @@ describe('public entrypoint (@workos/oagen-emitters)', () => {
       mod.rubyEmitter,
       mod.rustEmitter,
       mod.iosEmitter,
+      mod.androidEmitter,
       mod.elixirEmitter,
     ];
     for (const emitter of directEmitters) {

--- a/test/injection-escaping.test.ts
+++ b/test/injection-escaping.test.ts
@@ -6,6 +6,8 @@ import { generateModels as rbModels } from '../src/ruby/models.js';
 import { generateEnums as rbEnums } from '../src/ruby/enums.js';
 import { generateModels as rustModels } from '../src/rust/models.js';
 import { UnionRegistry } from '../src/rust/type-map.js';
+import { generateEnums as androidEnums } from '../src/android/enums.js';
+import { generateModels as androidModels } from '../src/android/models.js';
 
 const emptySpec: ApiSpec = {
   name: 'Test',
@@ -99,5 +101,45 @@ describe('emitter injection escaping', () => {
     expect(content).toContain('rename = "a\\")]');
     // ...so the payload never breaks out into a real struct field or free item.
     expect(content).not.toMatch(/^\s*pub owned: String,/m);
+  });
+
+  it('android: escapes `$` so enum wire values cannot become string templates', () => {
+    const enums: Enum[] = [
+      {
+        name: 'Status',
+        values: [
+          { name: 'active', value: 'active' },
+          { name: 'evil', value: '${System.getenv()}' },
+        ],
+      },
+    ];
+    const content = androidEnums(enums, ctx)
+      .map((f) => f.content)
+      .join('\n');
+    expect(content).toContain('\\${System.getenv()}');
+    expect(content).not.toMatch(/[^\\]\$\{System\.getenv\(\)\}/);
+  });
+
+  it('android: escapes KDoc block-comment terminators in field descriptions', () => {
+    const models: Model[] = [
+      {
+        name: 'Thing',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+            description: 'ends the comment */ public val pwned: String = "x" /*',
+          },
+        ],
+      },
+    ];
+    const content = androidModels(models, { ...ctx, spec: { ...emptySpec, models } })
+      .map((f) => f.content)
+      .join('\n');
+    // The terminator is neutralized, so the payload stays inert inside the KDoc...
+    expect(content).not.toContain('*/ public val pwned');
+    // ...and never becomes a real property declaration.
+    expect(content).not.toMatch(/^\s*public val pwned:/m);
   });
 });

--- a/test/ios/resources.test.ts
+++ b/test/ios/resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { EmitterContext, ApiSpec } from '@workos/oagen';
+import type { EmitterContext, ApiSpec, Service } from '@workos/oagen';
 import { defaultSdkBehavior } from '@workos/oagen';
 import { generateResources } from '../../src/ios/resources.js';
 import { buildOperationsMap } from '../../src/ios/manifest.js';
@@ -120,6 +120,42 @@ describe('ios/resources', () => {
     expect(content).toContain('var query: [URLQueryItem] = []');
     expect(content).toContain('if let limit {');
     expect(content).toContain('query.append(URLQueryItem(name: "limit", value: "\\(limit)"))');
+  });
+
+  it('emits a string-valued literal query param without redundant interpolation', () => {
+    // A `literal` TypeRef (e.g. the spec's `prompt: "login"` or
+    // `code_challenge_method: "S256"`) renders as Swift `String`, so wrapping
+    // it in `"\(value)"` is redundant. Mirrors the android-emitter regression
+    // for the SSO/UserManagement authorize params.
+    const service: Service = {
+      name: 'Sso',
+      operations: [
+        {
+          name: 'get_authorization_url',
+          httpMethod: 'get',
+          path: '/sso/authorize',
+          pathParams: [],
+          queryParams: [
+            { name: 'prompt', type: { kind: 'literal', value: 'login' }, required: false },
+            { name: 'code_challenge_method', type: { kind: 'literal', value: 'S256' }, required: false },
+          ],
+          headerParams: [],
+          response: { kind: 'model', name: 'Organization' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const literalCtx: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec: { ...spec, services: [service] },
+    };
+    const content = generateResources([service], literalCtx)[0].content;
+    expect(content).toContain('query.append(URLQueryItem(name: "prompt", value: prompt))');
+    expect(content).toContain('query.append(URLQueryItem(name: "code_challenge_method", value: codeChallengeMethod))');
+    expect(content).not.toContain('value: "\\(prompt)"');
+    expect(content).not.toContain('value: "\\(codeChallengeMethod)"');
   });
 
   it('uses requestVoid for delete operations', () => {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -13,8 +13,9 @@ describe('workosEmittersPlugin', () => {
     expect(languages).toContain('ruby');
     expect(languages).toContain('rust');
     expect(languages).toContain('ios');
+    expect(languages).toContain('android');
     expect(languages).toContain('elixir');
-    expect(languages).toHaveLength(10);
+    expect(languages).toHaveLength(11);
   });
 
   it('exports extractors for all supported languages', () => {
@@ -44,7 +45,8 @@ describe('workosEmittersPlugin', () => {
     expect(runners).toContain('dotnet');
     expect(runners).toContain('elixir');
     expect(runners).toContain('ios');
-    expect(runners).toHaveLength(10);
+    expect(runners).toContain('android');
+    expect(runners).toHaveLength(11);
   });
 
   it('smoke runner paths are absolute', () => {

--- a/test/shared/kotlin-syntax-parity.test.ts
+++ b/test/shared/kotlin-syntax-parity.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  escapeReserved as ktEscape,
+  ktStringLiteral as ktString,
+  ktLiteral as ktLit,
+} from '../../src/kotlin/naming.js';
+import {
+  escapeReserved as androidEscape,
+  ktStringLiteral as androidString,
+  ktLiteral as androidLit,
+} from '../../src/android/naming.js';
+
+/**
+ * `kotlin` and `android` are two emitters targeting the SAME language, so they each
+ * carry Kotlin-syntax primitives: the reserved-word set, string-literal escaping,
+ * and scalar-literal rendering. That is duplicated policy, and duplicated policy
+ * drifts silently.
+ *
+ * These helpers are deliberately NOT consolidated into one module yet: doing so
+ * means editing the emitter behind the published `workos-kotlin` SDK, which is out
+ * of scope for the Android work that surfaced this. This test is the interim
+ * guard — it turns silent drift into a failing build, and documents the single
+ * known divergence so it stays a deliberate choice rather than an accident.
+ *
+ * If the helpers are consolidated later, delete this file.
+ */
+describe('kotlin/android Kotlin-syntax parity', () => {
+  const reservedOf = (emitter: 'kotlin' | 'android'): Set<string> => {
+    const src = readFileSync(join(process.cwd(), 'src', emitter, 'naming.ts'), 'utf8');
+    const block = /KOTLIN_RESERVED = new Set\(\[([\s\S]*?)\]\)/.exec(src);
+    expect(block, `${emitter}: KOTLIN_RESERVED not found`).toBeTruthy();
+    return new Set([...(block?.[1] ?? '').matchAll(/'([^']+)'/g)].map((m) => m[1]));
+  };
+
+  it('reserved-word sets are identical', () => {
+    const k = reservedOf('kotlin');
+    const a = reservedOf('android');
+    expect(
+      [...a].filter((w) => !k.has(w)),
+      'words only in android',
+    ).toEqual([]);
+    expect(
+      [...k].filter((w) => !a.has(w)),
+      'words only in kotlin',
+    ).toEqual([]);
+  });
+
+  it('escapeReserved agrees on every reserved word and on ordinary identifiers', () => {
+    for (const word of reservedOf('kotlin')) {
+      expect(androidEscape(word), `escaping '${word}'`).toBe(ktEscape(word));
+    }
+    for (const word of ['id', 'name', 'organizationId', 'get', 'value', 'data']) {
+      expect(androidEscape(word), `escaping '${word}'`).toBe(ktEscape(word));
+    }
+  });
+
+  it('ktLiteral agrees on scalars', () => {
+    for (const v of ['plain', 'has "quote"', 'has $dollar', 'a\\b', 42, -1, 1.5, true, false] as const) {
+      expect(androidLit(v), `ktLiteral(${JSON.stringify(v)})`).toBe(ktLit(v));
+    }
+  });
+
+  it('ktStringLiteral agrees on everything except the documented tab divergence', () => {
+    // Both must neutralize the dangerous cases identically: `$` starts a Kotlin
+    // template, `"` closes the literal, `\` starts an escape.
+    for (const v of ['plain', 'has "quote"', '${System.getenv()}', 'a\\b', 'line\nbreak', 'ret\rurn']) {
+      expect(androidString(v), `ktStringLiteral(${JSON.stringify(v)})`).toBe(ktString(v));
+    }
+  });
+
+  it('pins the one known divergence: android escapes tab, kotlin does not', () => {
+    // Verified output-neutral for the current spec (zero literal tabs in the IR),
+    // which is why it has not forced a consolidation. If this test starts failing,
+    // one of the two emitters changed its escaping and the other must follow.
+    expect(androidString('a\tb')).toBe('"a\\tb"');
+    expect(ktString('a\tb')).toBe('"a\tb"');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `android` emitter generating the spec-driven surface of an Android
library: kotlinx.serialization data classes, forward-compatible sealed-class
enums, coroutine (`suspend`) resource methods over OkHttp, per-mount JUnit 5
suites, and a smoke-plan sidecar. The HTTP runtime, exception hierarchy and
Gradle files are hand-maintained in `workos/workos-android`.

**Why not extend the existing `kotlin` emitter.** The serialization strategy
differs, and on Android that difference is load-bearing:

| | `kotlin` | `android` |
|---|---|---|
| Serialization | Jackson (reflection) | kotlinx.serialization (compile-time) |
| R8/ProGuard | needs keep rules | none needed |
| API style | blocking | `suspend` |

Reflection-based mapping needs keep rules to survive R8, and blocking calls
cannot run on Android's main thread.

Also included: `smoke/sdk-android.ts`, `docs/sdk-architecture/android.md`,
per-generator unit tests, a non-spec coverage pin, a shared `kotlin`/`android`
syntax parity guard, and three corrections to `docs/lang-gen/workspace.md`,
which asserted that no `android` emitter existed.

## Commits after the initial review

**`414fd34` — reverse pagination cursor sent on the first page only.** Auto-paging
methods passed `before` through on every page while `after` advanced. Those are
alternative windows into a list, not filters, so sending both asks the server for
a contradictory range. `workos-kotlin` guards this and documents why: it "can
cause empty or looping results from the server". Looping matters here because
`autoPagingFlow` is a `while (true)` that breaks only when `after` is null — a
repeating page is an infinite flow emitting duplicates. Fixed at the call site
(`before = if (cursor == null) before else null`); `cursor == null` identifies the
first page exactly, so no runtime change was needed. 40 methods affected, public
API unchanged.

**`2538be3` — three review findings.** Only the first changes observable
behaviour:

1. **`formatCommand` masked its own failure.** It ended in `>/dev/null 2>&1; true`.
   `gradlew` needs a JDK and a shell running `oagen generate` frequently has no
   `JAVA_HOME`, so `ktlintFormat` never ran and every generation silently left its
   output unformatted — the real cause of "generation always dirties the tree".
   The exit code is what makes it visible: oagen's `formatTargetFiles` reports
   from its catch block and otherwise discards the child's output, so exiting 0
   with a message on stderr prints nothing. Now exits non-zero and keeps stderr.
   Generation is unaffected — oagen catches it and continues.
2. **`format: date` mapped to `Instant`.** A calendar date has no time or offset
   and cannot be parsed as an `Instant`, so the first date-only field would throw
   at decode time. Now `LocalDate`. Latent: the spec has 413 `date-time` and 0
   `date`, so no output changes.
3. **Synthetic enums were invisible to import resolution.** `resolveTypeImports`
   built its enum set from `ctx.spec.enums` only, so an enum minted from an inline
   `oneOf` would be emitted without an import and the file would not compile.
   Latent: the spec mints none (144 IR enums → 144 emitted files).

**Intentional, not a defect:** the review also flagged that form-urlencoded
operations generate JSON bodies. The IR *does* carry `requestBodyEncoding`
(`'json' | 'form-data' | 'form-urlencoded' | 'binary' | 'text'`), and the
`kotlin` and `node` emitters branch on it, but the hand-maintained Android
transport only exposes `JsonBody` — there is no `FormBody` to dispatch to.
Sending JSON is still correct for the two form-urlencoded operations (`POST
/sso/token`, User Management authenticate): the API accepts JSON for those as
well, the same fallback `workos-kotlin` documents. `renderBody` now carries a
comment stating this so the constraint is grepable; if a genuine form-only
endpoint is added, the runtime gains a `FormBody` and the branch appears there.

## Test plan

Emitter: `npm run test` (**804** tests / 102 files), `typecheck`, `lint`,
`format` — all clean.

Against the live WorkOS spec, generating into `workos/workos-android`:

- all 211 resolved operations exist on the resource named by their `mountOn`,
  with names matching `derivedName` under Kotlin casing — expected names derived
  independently via `trimMountedResourceFromMethod` + oagen's `toCamelCase` and
  compared against the emitted Kotlin, not the manifest
- each method's emitted HTTP verb and path checked against the resolved table:
  **0 wrong verbs, 0 wrong paths** across 221 methods
- 261 documented methods: 0 `@param` naming a non-existent parameter, 0
  undocumented parameters
- 0 `Dto`/`DTO`/`Urn` leaks; 2,882 model and 432 enum doc blocks all attached to
  a declaration
- SDK `script/ci` green — **590 tests, 0 failures**
- two consecutive generations byte-identical (800 files); all 30
  `@oagen-ignore-file` files untouched
- generating from an unrelated spec (`github-subset.yml`) shares 6 paths with the
  WorkOS output and 0 byte-identical files, confirming no static output is being
  generated that should be hand-maintained
- formatter behaviour verified from a clean tree both ways: with a JDK on PATH,
  formatting runs and the target repo stays clean; without one, Gradle's reason
  and an actionable marker are both reported and generation still succeeds

## Notes for review

- **H16** (SSO PKCE code exchange) is intentionally unimplemented. `POST
  /sso/token` requires `client_secret`, validated before any other check, so a
  secret-less exchange returns 422 — verified directly against the API. An app
  cannot hold a secret, so there is nothing correct to wrap. AuthKit is the
  supported end-to-end PKCE path.
- `android` and `kotlin` each define `ktStringLiteral`/`ktLiteral`/
  `escapeReserved` and an identical `KOTLIN_RESERVED` set. Left duplicated
  deliberately: `escapeReserved` feeds published method names in `workos-kotlin`,
  so sharing the module would let one edit change two SDKs' public surface. The
  parity test guards against accidental drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
