### PR TITLE
fix(elixir): use element type, not envelope, for paginated casting

### DIFF
--- a/src/elixir/fixtures.ts
+++ b/src/elixir/fixtures.ts
@@ -2,7 +2,7 @@ import type { EmitterContext, GeneratedFile, Model, Enum, TypeRef, Operation } f
 import { toSnakeCase, planOperation } from '@workos/oagen';
 import { functionName } from './naming.js';
 import { scopedMountGroups } from '../shared/resolved-ops.js';
-import { getSyntheticEnums } from '../shared/model-utils.js';
+import { getSyntheticEnums, resolvePaginationItemType } from '../shared/model-utils.js';
 
 const MAX_DEPTH = 4;
 
@@ -77,7 +77,9 @@ export function responseSample(
 ): unknown | undefined {
   const plan = planOperation(op);
   if (plan.isPaginated && op.pagination) {
-    const item = sampleForType(op.pagination.itemType, models, enums, 'item', 0, new Set());
+    // The fixture must mirror the wire: `data` holds elements, not envelopes.
+    const itemType = resolvePaginationItemType(op.pagination.itemType, models);
+    const item = sampleForType(itemType, models, enums, 'item', 0, new Set());
     return {
       [op.pagination.dataPath ?? 'data']: [item],
       list_metadata: { before: null, after: null },

--- a/src/elixir/models.ts
+++ b/src/elixir/models.ts
@@ -3,7 +3,7 @@ import { mapTypeRef, addNil } from './type-map.js';
 import { fullModuleName, moduleName, fileName, fieldName, escapeDoc, escapeString, nsPascal } from './naming.js';
 import { castExpr, dumpExpr, type CastNames } from './casting.js';
 import { isModelInScope } from '../shared/resolved-ops.js';
-import { getSyntheticEnums } from '../shared/model-utils.js';
+import { buildListScaffoldingSkip, getSyntheticEnums, isPartialListMetadataModel } from '../shared/model-utils.js';
 
 /**
  * Generate one Elixir module per IR model: `defstruct` + `@type t` +
@@ -13,9 +13,15 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
   const enumNames = new Set([...ctx.spec.enums.map((e) => e.name), ...getSyntheticEnums().map((e) => e.name)]);
   const modelNames = new Set(models.map((m) => m.name));
 
+  // List envelopes and their ListMetadata companions are replaced by
+  // `Page` at runtime, so they are not emitted as structs. The partial test
+  // also sweeps one-cursor metadata models, whose only referent is the envelope.
+  const skipListScaffolding = buildListScaffoldingSkip(models, ctx.spec.services, isPartialListMetadataModel);
+
   const files: GeneratedFile[] = [];
   for (const model of models) {
     if (!isModelInScope(model.name, ctx)) continue;
+    if (skipListScaffolding(model)) continue;
     files.push({
       path: `lib/${ctx.namespace}/${fileName(model.name)}.ex`,
       content: renderModel(model, ctx, { modelNames, enumNames }),

--- a/src/elixir/resources.ts
+++ b/src/elixir/resources.ts
@@ -32,7 +32,7 @@ import {
 } from '../shared/resolved-ops.js';
 import { buildExportedClassNameSet, resolveServiceTarget } from '../shared/service-name-collision.js';
 import { parsePathTemplate } from '../shared/path-template.js';
-import { getSyntheticEnums } from '../shared/model-utils.js';
+import { getSyntheticEnums, resolvePaginationItemType } from '../shared/model-utils.js';
 import { resolveWrapperParams, formatWrapperDescription } from '../shared/wrapper-utils.js';
 
 /**
@@ -254,6 +254,13 @@ function renderMethod(resolved: ResolvedOperation, fname: string, ctx: EmitterCo
   const hasParams = methodTakesParams(resolved);
   const isQueryMethod = ['get', 'delete', 'head'].includes(op.httpMethod);
 
+  // `Page.from_map/4` casts each element of the `data` array, so paginated ops
+  // need the element type — not the list envelope the response names.
+  const pageItemType =
+    plan.isPaginated && op.pagination
+      ? resolvePaginationItemType(op.pagination.itemType, new Map(ctx.spec.models.map((m) => [m.name, m])))
+      : null;
+
   const args = ['client', ...pathParams.map((p) => p.variable)];
   if (hasParams) args.push('params \\\\ %{}');
   args.push('opts \\\\ []');
@@ -307,8 +314,8 @@ function renderMethod(resolved: ResolvedOperation, fname: string, ctx: EmitterCo
   }
 
   // Spec
-  const returnSpec = plan.isPaginated
-    ? `${ns}.Page.t(${mapTypeRef(op.pagination!.itemType, { nsPascal: ns })})`
+  const returnSpec = pageItemType
+    ? `${ns}.Page.t(${mapTypeRef(pageItemType, { nsPascal: ns })})`
     : mapTypeRef(op.response, { nsPascal: ns });
   lines.push(`  @spec ${fname}(${specArgs.join(', ')}) ::`);
   lines.push(`          {:ok, ${returnSpec}} | {:error, ${ns}.Error.error()}`);
@@ -319,7 +326,7 @@ function renderMethod(resolved: ResolvedOperation, fname: string, ctx: EmitterCo
 
   if (plan.isPaginated && op.pagination) {
     const dataKey = op.pagination.dataPath ?? 'data';
-    const itemCaster = casterFun(op.pagination.itemType, ctx, names) ?? '&Function.identity/1';
+    const itemCaster = casterFun(pageItemType ?? op.pagination.itemType, ctx, names) ?? '&Function.identity/1';
     const cursorParam = op.pagination.param;
     const recallArgs = ['client', ...pathParams.map((p) => p.variable)];
     lines.push(`    with {:ok, body} <- ${requestCall} do`);

--- a/src/elixir/tests.ts
+++ b/src/elixir/tests.ts
@@ -2,6 +2,7 @@ import type {
   ApiSpec,
   EmitterContext,
   GeneratedFile,
+  Model,
   TypeRef,
   ResolvedOperation,
   ResolvedWrapper,
@@ -18,7 +19,7 @@ import {
   escapeString,
 } from './naming.js';
 import { buildFixtureEntries, generateFixtureFiles, fixtureName, roundTripSample } from './fixtures.js';
-import { getSyntheticEnums } from '../shared/model-utils.js';
+import { getSyntheticEnums, resolvePaginationItemType } from '../shared/model-utils.js';
 import { scopedMountGroups, getOpDefaults, isModelInScope, type MountGroup } from '../shared/resolved-ops.js';
 import { methodTakesParams } from './resources.js';
 import { buildExportedClassNameSet, resolveServiceTarget } from '../shared/service-name-collision.js';
@@ -68,13 +69,13 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
 }
 
 /** Response models reachable from a mount group's operations, in stable order. */
-function groupResponseModels(group: MountGroup, modelNames: Set<string>): string[] {
+function groupResponseModels(group: MountGroup, modelNames: Set<string>, models: Map<string, Model>): string[] {
   const out = new Set<string>();
   for (const resolved of group.resolvedOps) {
     const op = resolved.operation;
     const plan = planOperation(op);
     if (plan.isPaginated && op.pagination) {
-      const item = modelRefName(op.pagination.itemType, modelNames);
+      const item = modelRefName(resolvePaginationItemType(op.pagination.itemType, models), modelNames);
       if (item) out.add(item);
     }
     const response = modelRefName(op.response, modelNames);
@@ -119,7 +120,7 @@ function renderRoundTripTests(
   const models = new Map(ctx.spec.models.map((m) => [m.name, m]));
   const enums = new Map([...ctx.spec.enums, ...getSyntheticEnums()].map((e) => [e.name, e]));
 
-  const testable = groupResponseModels(group, modelNames)
+  const testable = groupResponseModels(group, modelNames, models)
     .map((name) => models.get(name))
     .filter((m): m is NonNullable<typeof m> => !!m && m.fields.length > 0 && isModelInScope(m.name, ctx));
   if (testable.length === 0) return null;
@@ -486,7 +487,8 @@ function successShape(resolved: ResolvedOperation, ctx: EmitterContext, modelNam
   const plan = planOperation(op);
 
   if (plan.isPaginated && op.pagination) {
-    const itemModel = modelRefName(op.pagination.itemType, modelNames);
+    const models = new Map(ctx.spec.models.map((m) => [m.name, m]));
+    const itemModel = modelRefName(resolvePaginationItemType(op.pagination.itemType, models), modelNames);
     if (itemModel) {
       const mod = fullModuleName(ctx, itemModel);
       return {

--- a/src/elixir/tests.ts
+++ b/src/elixir/tests.ts
@@ -19,7 +19,12 @@ import {
   escapeString,
 } from './naming.js';
 import { buildFixtureEntries, generateFixtureFiles, fixtureName, roundTripSample } from './fixtures.js';
-import { getSyntheticEnums, resolvePaginationItemType } from '../shared/model-utils.js';
+import {
+  buildListScaffoldingSkip,
+  getSyntheticEnums,
+  isPartialListMetadataModel,
+  resolvePaginationItemType,
+} from '../shared/model-utils.js';
 import { scopedMountGroups, getOpDefaults, isModelInScope, type MountGroup } from '../shared/resolved-ops.js';
 import { methodTakesParams } from './resources.js';
 import { buildExportedClassNameSet, resolveServiceTarget } from '../shared/service-name-collision.js';
@@ -119,10 +124,16 @@ function renderRoundTripTests(
 ): string | null {
   const models = new Map(ctx.spec.models.map((m) => [m.name, m]));
   const enums = new Map([...ctx.spec.enums, ...getSyntheticEnums()].map((e) => [e.name, e]));
+  // A paginated op's response IS the list envelope, which generateModels does
+  // not emit — round-tripping it would reference a module that was never written.
+  const skipListScaffolding = buildListScaffoldingSkip(ctx.spec.models, ctx.spec.services, isPartialListMetadataModel);
 
   const testable = groupResponseModels(group, modelNames, models)
     .map((name) => models.get(name))
-    .filter((m): m is NonNullable<typeof m> => !!m && m.fields.length > 0 && isModelInScope(m.name, ctx));
+    .filter(
+      (m): m is NonNullable<typeof m> =>
+        !!m && m.fields.length > 0 && isModelInScope(m.name, ctx) && !skipListScaffolding(m),
+    );
   if (testable.length === 0) return null;
 
   const lines: string[] = [];

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -119,6 +119,22 @@ export function isListMetadataModel(model: Model): boolean {
 }
 
 /**
+ * Like {@link isListMetadataModel}, but also matches the degenerate one-cursor
+ * shape some specs declare (e.g. `EventListListMetadata`, which has `after`
+ * only). Such a model is the same redundant pagination scaffolding, so an
+ * emitter that skips list metadata wants to skip these too — otherwise it emits
+ * a model whose only referent was the envelope it just dropped.
+ *
+ * Opt-in rather than folded into `isListMetadataModel`: widening the shared
+ * shape test would remove types from every SDK's public surface at once.
+ */
+export function isPartialListMetadataModel(model: Model): boolean {
+  if (model.fields.length === 0 || model.fields.length > 2) return false;
+
+  return model.fields.every((f) => (f.name === 'before' || f.name === 'after') && isNullableString(f));
+}
+
+/**
  * Compute the `ListMetadata`-shape model names that must still be emitted
  * because some surviving wrapper references them.
  *
@@ -134,16 +150,20 @@ export function isListMetadataModel(model: Model): boolean {
  * Pass the same `nonPaginatedRefs` set the emitter uses for its own
  * wrapper-survival decision so the two answers stay in sync.
  */
-export function collectReferencedListMetadataModels(models: Model[], nonPaginatedRefs: Set<string>): Set<string> {
+export function collectReferencedListMetadataModels(
+  models: Model[],
+  nonPaginatedRefs: Set<string>,
+  isMetadata: (model: Model) => boolean = isListMetadataModel,
+): Set<string> {
   const listMetadataNames = new Set<string>();
   for (const m of models) {
-    if (isListMetadataModel(m)) listMetadataNames.add(m.name);
+    if (isMetadata(m)) listMetadataNames.add(m.name);
   }
   if (listMetadataNames.size === 0) return new Set();
 
   const referenced = new Set<string>();
   for (const model of models) {
-    if (isListMetadataModel(model)) continue;
+    if (isMetadata(model)) continue;
     if (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) continue;
     const deps = collectFieldDependencies(model);
     for (const dep of deps.models) {
@@ -151,6 +171,38 @@ export function collectReferencedListMetadataModels(models: Model[], nonPaginate
     }
   }
   return referenced;
+}
+
+/**
+ * Build the predicate for "this model is redundant list scaffolding": a list
+ * wrapper (`data` + `list_metadata`) or its `ListMetadata` companion. Each SDK
+ * has its own pagination type that replaces the envelope at runtime, so these
+ * are not emitted as models.
+ *
+ * The exception both survival rules encode: a wrapper returned by a
+ * *non-paginated* operation (e.g. vault's `VersionListResponse`) is still
+ * referenced by name in the resource code, and must be emitted along with any
+ * `ListMetadata` model its fields reach.
+ *
+ * Emitters that decide model emission in more than one place (models, tests,
+ * fixtures) should share a single predicate so the answers cannot drift.
+ */
+export function buildListScaffoldingSkip(
+  models: Model[],
+  services: Service[],
+  /**
+   * Which models count as list metadata. Defaults to the strict two-cursor
+   * shape; pass {@link isPartialListMetadataModel} to also sweep one-cursor
+   * variants. Callers that omit it get byte-identical output to before.
+   */
+  isMetadata: (model: Model) => boolean = isListMetadataModel,
+): (model: Model) => boolean {
+  const nonPaginatedRefs = collectNonPaginatedResponseModelNames(services);
+  const listMetadataNeeded = collectReferencedListMetadataModels(models, nonPaginatedRefs, isMetadata);
+
+  return (model: Model): boolean =>
+    (isListWrapperModel(model) && !nonPaginatedRefs.has(model.name)) ||
+    (isMetadata(model) && !listMetadataNeeded.has(model.name));
 }
 
 /** Check if a field type is nullable string (nullable<string> or just string). */

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -57,6 +57,32 @@ export function isListWrapperModel(model: Model): boolean {
 }
 
 /**
+ * Resolve the element type a paginated operation's `data` array actually holds.
+ *
+ * `op.pagination.itemType` is the operation's *response* type. When the spec
+ * names a list envelope for that response (`data` + `list_metadata`), the
+ * response type is the envelope, not the element — so emitters that
+ * deserialize items one at a time must unwrap one level first. Endpoints whose
+ * response has no named wrapper already carry the element type; those are
+ * returned unchanged.
+ *
+ * Passing the envelope through to per-item deserialization is silently wrong:
+ * every element parses as an empty envelope and its real fields are dropped.
+ */
+export function resolvePaginationItemType(itemType: TypeRef, modelMap: Map<string, Model>): TypeRef {
+  if (itemType.kind === 'nullable') return resolvePaginationItemType(itemType.inner, modelMap);
+  if (itemType.kind !== 'model') return itemType;
+
+  const model = modelMap.get(itemType.name);
+  if (!model || !isListWrapperModel(model)) return itemType;
+
+  const dataField = model.fields.find((f) => f.name === 'data');
+  // isListWrapperModel already guarantees `data` is an array; re-narrow for TS.
+  if (dataField?.type.kind !== 'array') return itemType;
+  return dataField.type.items;
+}
+
+/**
  * Resolve the inner item model of a list-wrapper envelope (`data` array +
  * `list_metadata`). Returns the item model when the wrapper convention
  * matches and the item is a named model present in `modelMap`, else null.

--- a/test/elixir/models.test.ts
+++ b/test/elixir/models.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Model } from '@workos/oagen';
 import { generateModels } from '../../src/elixir/models.js';
-import { makeSpec, makeCtx } from './helpers.js';
+import { makeSpec, makeCtx, makeOp } from './helpers.js';
 
 const organization: Model = {
   name: 'Organization',
@@ -297,5 +297,123 @@ describe('elixir/models', () => {
         end
       end"
     `);
+  });
+
+  describe('list scaffolding', () => {
+    const listMetadata: Model = {
+      name: 'ListMetadata',
+      fields: [
+        { name: 'before', type: { kind: 'nullable', inner: { kind: 'primitive', type: 'string' } }, required: false },
+        { name: 'after', type: { kind: 'nullable', inner: { kind: 'primitive', type: 'string' } }, required: false },
+      ],
+    };
+
+    const organizationList: Model = {
+      name: 'OrganizationList',
+      fields: [
+        { name: 'object', type: { kind: 'literal', value: 'list' }, required: true },
+        {
+          name: 'data',
+          type: { kind: 'array', items: { kind: 'model', name: 'Organization' } },
+          required: true,
+        },
+        { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+      ],
+    };
+
+    const paginatedListOp = makeOp({
+      name: 'listOrganizations',
+      response: { kind: 'model', name: 'OrganizationList' },
+      pagination: {
+        strategy: 'cursor',
+        param: 'after',
+        dataPath: 'data',
+        itemType: { kind: 'model', name: 'OrganizationList' },
+      },
+    });
+
+    it('does not emit list envelopes or their ListMetadata — Page replaces them', () => {
+      const ctx = makeCtx(
+        makeSpec({
+          models: [organization, organizationList, listMetadata],
+          services: [{ name: 'Organizations', operations: [paginatedListOp] }],
+        }),
+      );
+
+      expect(generateModels(ctx.spec.models, ctx).map((f) => f.path)).toEqual(['lib/acme/organization.ex']);
+    });
+
+    it('sweeps one-cursor metadata models too, whose only referent was the envelope', () => {
+      const cursorOnlyMetadata: Model = {
+        name: 'EventListListMetadata',
+        fields: [
+          { name: 'after', type: { kind: 'nullable', inner: { kind: 'primitive', type: 'string' } }, required: false },
+        ],
+      };
+      const eventList: Model = {
+        name: 'EventList',
+        fields: [
+          {
+            name: 'data',
+            type: { kind: 'array', items: { kind: 'model', name: 'Organization' } },
+            required: true,
+          },
+          { name: 'list_metadata', type: { kind: 'model', name: 'EventListListMetadata' }, required: true },
+        ],
+      };
+
+      const ctx = makeCtx(
+        makeSpec({
+          models: [organization, eventList, cursorOnlyMetadata],
+          services: [
+            {
+              name: 'Organizations',
+              operations: [
+                makeOp({
+                  name: 'listEvents',
+                  response: { kind: 'model', name: 'EventList' },
+                  pagination: {
+                    strategy: 'cursor',
+                    param: 'after',
+                    dataPath: 'data',
+                    itemType: { kind: 'model', name: 'EventList' },
+                  },
+                }),
+              ],
+            },
+          ],
+        }),
+      );
+
+      expect(generateModels(ctx.spec.models, ctx).map((f) => f.path)).toEqual(['lib/acme/organization.ex']);
+    });
+
+    it('still emits an envelope returned by a non-paginated operation, and its ListMetadata', () => {
+      // e.g. GET /vault/v1/kv/{id}/versions — a list-shaped response with no
+      // pagination params, so the resource code references the envelope by name.
+      const ctx = makeCtx(
+        makeSpec({
+          models: [organization, organizationList, listMetadata],
+          services: [
+            {
+              name: 'Organizations',
+              operations: [
+                makeOp({
+                  name: 'listOrganizationVersions',
+                  path: '/organizations/versions',
+                  response: { kind: 'model', name: 'OrganizationList' },
+                }),
+              ],
+            },
+          ],
+        }),
+      );
+
+      expect(generateModels(ctx.spec.models, ctx).map((f) => f.path)).toEqual([
+        'lib/acme/organization.ex',
+        'lib/acme/organization_list.ex',
+        'lib/acme/list_metadata.ex',
+      ]);
+    });
   });
 });

--- a/test/elixir/resources.test.ts
+++ b/test/elixir/resources.test.ts
@@ -8,6 +8,20 @@ const organizationModel: Model = {
   fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
 };
 
+/** The standard paginated list envelope the spec names as a list op's response. */
+const organizationListModel: Model = {
+  name: 'OrganizationList',
+  fields: [
+    { name: 'object', type: { kind: 'literal', value: 'list' }, required: true },
+    {
+      name: 'data',
+      type: { kind: 'array', items: { kind: 'model', name: 'Organization' } },
+      required: true,
+    },
+    { name: 'list_metadata', type: { kind: 'model', name: 'ListMetadata' }, required: true },
+  ],
+};
+
 function ctxFor(services: Service[], models: Model[] = [organizationModel]): EmitterContext {
   return makeCtx(makeSpec({ services, models }));
 }
@@ -120,6 +134,36 @@ describe('elixir/resources', () => {
     expect(content).toContain('Acme.Page.next_params(params, "after", cursor)');
     expect(content).toContain('{:ok, Acme.Page.from_map(body, "data", &Acme.Organization.from_map/1, fetch_next)}');
     expect(content).toContain('Acme.Page.t(Acme.Organization.t())');
+  });
+
+  it('unwraps a list-envelope itemType to the element caster', () => {
+    // `op.pagination.itemType` is the operation *response* type, which for most
+    // list endpoints is the named envelope. Page.from_map/4 casts each element,
+    // so passing the envelope through makes every item parse as an empty
+    // envelope with its real fields dropped.
+    const services: Service[] = [
+      {
+        name: 'Organizations',
+        operations: [
+          makeOp({
+            name: 'listOrganizations',
+            response: { kind: 'model', name: 'OrganizationList' },
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'OrganizationList' },
+            },
+          }),
+        ],
+      },
+    ];
+    const files = generateResources(services, ctxFor(services, [organizationModel, organizationListModel]));
+    const content = files[0].content;
+    expect(content).toContain('{:ok, Acme.Page.from_map(body, "data", &Acme.Organization.from_map/1, fetch_next)}');
+    expect(content).toContain('Acme.Page.t(Acme.Organization.t())');
+    expect(content).not.toContain('&Acme.OrganizationList.from_map/1');
+    expect(content).not.toContain('Acme.Page.t(Acme.OrganizationList.t())');
   });
 
   it('sends body params for POST and returns the raw body for primitive responses', () => {


### PR DESCRIPTION
Fixes [workos/workos-elixir#112](https://github.com/workos/workos-elixir/issues/112).

## Summary

- **35 of 40 paginated Elixir endpoints dropped every field of every item.** `Page.from_map/4` casts each element of the `data` array, but the emitter passed `op.pagination.itemType` — the operation *response* type, which for a named list envelope is the envelope, not the element. Each membership/user/invitation parsed as an empty `%FooList{}` and `membership.organization_id` raised `KeyError`.
- **Nothing caught it because the fixtures and assertions were wrong in the same direction.** The generated fixture nested an envelope inside `data` (a shape the API never returns), the generated test asserted the envelope struct, and the `@spec` claimed `Page.t(FooList.t())` so dialyzer saw a consistent story. Green suite, broken SDK.
- **Python and Go already unwrap this; only Elixir did not.** The new `resolvePaginationItemType` lives in `shared/model-utils.ts` rather than becoming a third private copy, so the three emitters can converge instead of drifting.
- **Second commit removes the list envelope models entirely.** Once the caster was fixed, 24 of 27 were unreferenced by generated code, along with their `*ListListMetadata` companions. This applies the rule Go and Python already use, behind a shared predicate: skip the envelope and its metadata unless a non-paginated op returns it by name (vault's `VersionListResponse` and `GroupRoleAssignmentList` survive on that exception).
- **`isPartialListMetadataModel` is opt-in, and only Elixir passes it.** It sweeps one-cursor metadata models that the strict two-cursor shape test misses. Go and Python output is byte-identical — verified by their goldens in the suite.

## Verification

- Emitter suite: **743 passed**, typecheck and lint clean.
- New regression test asserts an envelope `itemType` resolves to the element caster. Confirmed it **fails on the old code** and passes on the new — the previous test only covered endpoints whose `itemType` was already an element, which is why this shipped.
- New tests cover both envelope-skip paths, including the non-paginated survival exception.
- Regenerated `workos-elixir` and ran its full CI: **528 tests, credo 0 issues, dialyzer 0 errors.** All 40 call sites now use element casters; no doubly-nested fixtures and no unreferenced modules remain.
- The reporter's exact payload now yields `%WorkOS.UserOrganizationMembership{}` with `organization_id`, `user_id`, `id`, and `role.slug` populated.

## Downstream impact

Regenerating the Elixir SDK removes 47 modules from its public surface, so that release needs a major. Nothing else consumes these emitters differently — Go, Python, and every other language emit exactly what they did before.
