### PR TITLE
fix(kotlin): sort required wrapper params before optional ones

### DIFF
--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -33,9 +33,9 @@ import {
   isScopedRun,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
-import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { type AggregateBlock, readPriorFile, reconcileScopedBlocks } from '../shared/scoped-aggregate-merge.js';
 import { isHandwrittenOverride } from './overrides.js';
+import { resolveKotlinWrapperParams } from './wrappers.js';
 
 const TEST_PREFIX = 'src/test/kotlin/';
 
@@ -532,7 +532,7 @@ function buildWrapperTest(op: Operation, wrapper: ResolvedWrapper, ctx: EmitterC
 
   for (const _pp of op.pathParams) argParts.push(ktStringLiteral('sample-arg'));
 
-  const resolved = resolveWrapperParams(wrapper, ctx);
+  const resolved = resolveKotlinWrapperParams(wrapper, ctx);
   for (const rp of resolved) {
     if (rp.isOptional) continue;
     if (!rp.field) {

--- a/src/kotlin/wrappers.ts
+++ b/src/kotlin/wrappers.ts
@@ -9,10 +9,21 @@ import {
   maybeShortenEnumParamDescription,
 } from './naming.js';
 import { mapTypeRef, mapTypeRefOptional } from './type-map.js';
-import { resolveWrapperParams } from '../shared/wrapper-utils.js';
+import { resolveWrapperParams, type ResolvedWrapperParam } from '../shared/wrapper-utils.js';
 import { sortPathParamsByTemplateOrder } from './resources.js';
 import { buildKotlinPathExpression } from './path-expression.js';
 import { emitSuspendVariant, type SuspendParam } from './suspend.js';
+
+/**
+ * Resolve wrapper params with required params sorted before optional ones
+ * (stable, so relative order within each group is preserved). Kotlin wrapper
+ * signatures give optional params `= null` defaults; a required param after a
+ * defaulted one cannot be bound positionally (generated tests call wrappers
+ * positionally) and defeats the `@JvmOverloads` overloads for Java callers.
+ */
+export function resolveKotlinWrapperParams(wrapper: ResolvedWrapper, ctx: EmitterContext): ResolvedWrapperParam[] {
+  return resolveWrapperParams(wrapper, ctx).sort((a, b) => Number(a.isOptional) - Number(b.isOptional));
+}
 
 /**
  * Emit Kotlin wrapper methods for a union-split operation. Each wrapper
@@ -37,7 +48,7 @@ export function generateWrapperMethods(resolvedOp: ResolvedOperation, ctx: Emitt
 function emitWrapperMethod(resolvedOp: ResolvedOperation, wrapper: ResolvedWrapper, ctx: EmitterContext): string[] {
   const op = resolvedOp.operation;
   const method = propertyName(wrapper.name);
-  const resolvedParams = resolveWrapperParams(wrapper, ctx);
+  const resolvedParams = resolveKotlinWrapperParams(wrapper, ctx);
   const responseClass = wrapper.responseModelName ? className(wrapper.responseModelName) : null;
 
   const pathParams = sortPathParamsByTemplateOrder(op);

--- a/test/kotlin/wrappers.test.ts
+++ b/test/kotlin/wrappers.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { defaultSdkBehavior, type ApiSpec, type EmitterContext, type Service } from '@workos/oagen';
+import { generateWrapperMethods } from '../../src/kotlin/wrappers.js';
+import { generateTests } from '../../src/kotlin/tests.js';
+import { generateEnums } from '../../src/kotlin/enums.js';
+
+// Regression: a required wrapper param that appears after optional params in
+// the spec (e.g. pending_authentication_token after verification_id and
+// phone_number in the Radar SMS challenge grant) must be sorted before the
+// `= null` defaulted params, or positional callers — including the generated
+// tests — cannot bind it (Kotlin: "No value passed for parameter ...").
+
+const services: Service[] = [
+  {
+    name: 'UserManagement',
+    operations: [
+      {
+        name: 'authenticate',
+        httpMethod: 'post',
+        path: '/user_management/authenticate',
+        pathParams: [],
+        queryParams: [],
+        headerParams: [],
+        response: { kind: 'model', name: 'AuthenticateResponse' },
+        errors: [],
+        injectIdempotencyKey: false,
+      },
+    ],
+  },
+];
+
+const spec: ApiSpec = {
+  name: 'Test',
+  version: '1.0.0',
+  baseUrl: 'https://api.workos.com',
+  services,
+  models: [
+    {
+      name: 'AuthenticateResponse',
+      fields: [{ name: 'access_token', type: { kind: 'primitive', type: 'string' }, required: true }],
+    },
+    {
+      name: 'RadarSmsChallengeAuthenticateRequest',
+      fields: [
+        { name: 'code', type: { kind: 'primitive', type: 'string' }, required: true },
+        { name: 'verification_id', type: { kind: 'primitive', type: 'string' }, required: false },
+        { name: 'phone_number', type: { kind: 'primitive', type: 'string' }, required: false },
+        { name: 'pending_authentication_token', type: { kind: 'primitive', type: 'string' }, required: true },
+      ],
+    },
+  ],
+  enums: [],
+  sdk: defaultSdkBehavior(),
+};
+
+const resolvedOp = {
+  service: services[0],
+  operation: services[0].operations[0],
+  methodName: 'authenticate',
+  mountOn: 'UserManagement',
+  wrappers: [
+    {
+      name: 'authenticate_with_radar_sms_challenge',
+      targetVariant: 'RadarSmsChallengeAuthenticateRequest',
+      defaults: { grant_type: 'urn:workos:oauth:grant-type:radar-sms-challenge' },
+      inferFromClient: ['client_id', 'client_secret'],
+      exposedParams: ['code', 'verification_id', 'phone_number', 'pending_authentication_token'],
+      responseModelName: 'AuthenticateResponse',
+    },
+  ],
+} as never;
+
+const ctx: EmitterContext = {
+  namespace: 'workos',
+  namespacePascal: 'WorkOS',
+  spec,
+  resolvedOperations: [resolvedOp],
+};
+
+describe('kotlin/wrappers', () => {
+  it('sorts required wrapper params before optional defaulted params', () => {
+    const lines = generateWrapperMethods(resolvedOp, ctx).join('\n');
+
+    expect(lines).toContain(
+      [
+        '  fun authenticateWithRadarSmsChallenge(',
+        '    code: String,',
+        '    pendingAuthenticationToken: String,',
+        '    verificationId: String? = null,',
+        '    phoneNumber: String? = null,',
+        '    requestOptions: RequestOptions? = null',
+      ].join('\n'),
+    );
+  });
+
+  it('generates wrapper test whose positional args match the sorted signature', () => {
+    generateEnums([], ctx);
+    const files = generateTests(spec, ctx);
+    const testFile = files.find((f) => f.path.includes('UserManagementTest.kt'))!;
+
+    // Two positional args bind the two required params (code,
+    // pendingAuthenticationToken) now that they lead the signature.
+    expect(testFile.content).toContain('api().authenticateWithRadarSmsChallenge("sample-arg", "sample-arg")');
+  });
+});


### PR DESCRIPTION
## Summary

- Kotlin wrapper methods now emit required parameters before optional (`= null` defaulted) ones, via a stable sort that preserves relative order within each group.
- Root cause was two emitters with conflicting assumptions: the wrapper signature emitter preserved spec order, while the test emitter dropped optionals and passed remaining required args positionally. Both now share a single resolver (`resolveKotlinWrapperParams`) so they cannot diverge again.
- Required-first ordering also restores usable `@JvmOverloads` overloads for Java callers (a non-default param after defaulted params defeats them).
- No-op for every wrapper on current specs — required params already led all existing signatures — so no existing SDK surface reorders.
- Regression coverage: `test/kotlin/wrappers.test.ts` mirrors the failing shape (required → optional → optional → required) and asserts both the sorted signature and that the generated test's positional args match it; verified it fails without the sort.
