### PR TITLE
fix(python,ruby): freeze out-of-scope round-trip blocks in scoped runs

### DIFF
--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -35,6 +35,7 @@ import {
   fileExistsAfterRun,
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
+import { type AggregateBlock, readPriorFile, reconcileScopedBlocks } from '../shared/scoped-aggregate-merge.js';
 import { pythonLiteral } from './wrappers.js';
 import { computeSchemaPlacement } from './shared-schemas.js';
 
@@ -108,14 +109,21 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
 
   // Generate per-mount-target test files (merges all sub-services into one file)
   const mountGroups = scopedMountGroups(ctx);
-  const testEntries: Array<{ name: string; operations: Operation[]; resolvedOps?: ResolvedOperation[] }> =
+  const testEntries: Array<{
+    name: string;
+    operations: Operation[];
+    resolvedOps?: ResolvedOperation[];
+  }> =
     mountGroups.size > 0 || ctx.scopedServices?.size
       ? [...mountGroups].map(([name, group]) => ({
           name,
           operations: group.operations,
           resolvedOps: group.resolvedOps,
         }))
-      : spec.services.map((s) => ({ name: resolveResourceClassName(s, ctx), operations: s.operations }));
+      : spec.services.map((s) => ({
+          name: resolveResourceClassName(s, ctx),
+          operations: s.operations,
+        }));
 
   for (const { name: mountName, operations, resolvedOps } of testEntries) {
     if (operations.length === 0) continue;
@@ -382,7 +390,10 @@ function generateServiceTest(
         const discModel = unwrappedItemName ? spec.models.find((m) => m.name === unwrappedItemName) : null;
         const disc =
           discModel && (discModel as any).discriminator
-            ? ((discModel as any).discriminator as { property: string; mapping: Record<string, string> })
+            ? ((discModel as any).discriminator as {
+                property: string;
+                mapping: Record<string, string>;
+              })
             : null;
         const discEntries = disc ? Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b)) : [];
         if (disc && discEntries.length > 0) {
@@ -697,7 +708,10 @@ function generateServiceTest(
         const discModel = unwrappedItemName ? spec.models.find((m) => m.name === unwrappedItemName) : null;
         const disc =
           discModel && (discModel as any).discriminator
-            ? ((discModel as any).discriminator as { property: string; mapping: Record<string, string> })
+            ? ((discModel as any).discriminator as {
+                property: string;
+                mapping: Record<string, string>;
+              })
             : null;
         const discEntries = disc ? Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b)) : [];
         if (disc && discEntries.length > 0) {
@@ -1030,7 +1044,11 @@ function pickAssertableFields(
       results.push({ field: domainFieldName(f), value: `"${val}"` });
     } else if (typeof val === 'boolean') {
       // Use "is True/False" to satisfy ruff E712
-      results.push({ field: domainFieldName(f), value: val ? 'True' : 'False', isBool: true });
+      results.push({
+        field: domainFieldName(f),
+        value: val ? 'True' : 'False',
+        isBool: true,
+      });
     } else if (typeof val === 'number') {
       results.push({ field: domainFieldName(f), value: String(val) });
     }
@@ -1549,13 +1567,15 @@ function buildDirRoundTripFile(
 
   const modelMap = new Map(spec.models.map((m) => [m.name, m]));
   const enumMap = new Map(spec.enums.map((e) => [e.name, e]));
-  const body: string[] = [];
 
-  if (roundTripModels.length > 0) {
-    body.push('');
-    body.push('');
-    body.push('class TestModelRoundTrip:');
+  // Per-model method groups, kept as discrete blocks so a scoped run can freeze
+  // out-of-scope models to their prior on-disk text (see reconciliation below).
+  const roundTripBlocks: AggregateBlock[] = [];
+  const discriminatorBlocks: AggregateBlock[] = [];
+
+  {
     for (const model of roundTripModels) {
+      const body: string[] = [];
       // Deduplicate fields by DOMAIN identifier (mirrors models.ts, which honors
       // `domainName`); the wire key stays `field.name`.
       const seenFieldNames = new Set<string>();
@@ -1576,7 +1596,6 @@ function buildDirRoundTripFile(
       const nullablePayload = buildPayloadWithNullableFieldsSetToNull(dedupModel, fullFixture);
       const unknownEnumPayload = buildPayloadWithUnknownEnumValue(dedupModel, fullFixture);
 
-      body.push('');
       body.push(`    def test_${fileName(model.name)}_round_trip(self):`);
       body.push(`        data = load_fixture("${fixtureName}")`);
       body.push(`        instance = ${modelClass}.from_dict(data)`);
@@ -1630,15 +1649,22 @@ function buildDirRoundTripFile(
         body.push(`        instance = ${modelClass}.from_dict(data)`);
         body.push('        assert instance.to_dict() == data');
       }
+
+      roundTripBlocks.push({
+        key: fileName(model.name),
+        text: body.join('\n'),
+        inScope: isModelInScope(model.name, ctx),
+      });
     }
   }
 
-  if (discriminatorModels.length > 0) {
-    body.push('');
-    body.push('');
-    body.push('class TestDiscriminatorDispatch:');
+  {
     for (const model of discriminatorModels) {
-      const disc = (model as any).discriminator as { property: string; mapping: Record<string, string> };
+      const body: string[] = [];
+      const disc = (model as any).discriminator as {
+        property: string;
+        mapping: Record<string, string>;
+      };
       const modelClass = className(model.name);
       const unknownClass = `${modelClass}Unknown`;
 
@@ -1652,7 +1678,6 @@ function buildDirRoundTripFile(
       addImport(model.name, unknownClass);
       addImport(firstVariantName, firstVariantClass);
 
-      body.push('');
       body.push(`    def test_${fileName(model.name)}_dispatches_known_variant(self):`);
       body.push(`        data = load_fixture("${firstVariantFixture}")`);
       body.push(`        result = ${modelClass}.from_dict(data)`);
@@ -1679,7 +1704,74 @@ function buildDirRoundTripFile(
       body.push(`        data = {**data, "${disc.property}": None}`);
       body.push('        with pytest.raises(Exception):');
       body.push(`            ${modelClass}.from_dict(data)`);
+
+      discriminatorBlocks.push({
+        key: fileName(model.name),
+        text: body.join('\n'),
+        inScope: isModelInScope(model.name, ctx),
+      });
     }
+  }
+
+  // Freeze out-of-scope models' method groups to their prior on-disk text. Their
+  // per-model `.py` was NOT regenerated this run, but the payloads above are
+  // synthesized from the CURRENT spec — re-rendering them would assert a shape
+  // the stale model can't produce (e.g. a field the spec gained since the model
+  // was last written, which `to_dict` then never emits). Only the
+  // `load_fixture`-driven test would survive, and only because the fixture is
+  // stale in lockstep. Freezing also keeps an unrelated same-delta change to an
+  // out-of-scope model out of a scoped batch.
+  const path = `tests/test_${dirName.replace(/\//g, '_')}_models_round_trip.py`;
+  const scoped = isScopedRun(ctx);
+  let prior: PriorRoundTripFile = {
+    roundTrip: [],
+    discriminator: [],
+    imports: new Map(),
+  };
+  if (scoped) {
+    try {
+      prior = parsePriorRoundTripFile(readPriorFile(path, ctx));
+    } catch (err) {
+      // The prior file exists but is unreadable. Emitting now would reconcile
+      // against an empty prior and silently drop every out-of-scope method
+      // group; leave the on-disk copy untouched instead.
+      console.warn(
+        `[oagen] python: leaving ${path} untouched — could not read prior file: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return null;
+    }
+  }
+  const roundTripMethods = reconcileScopedBlocks(roundTripBlocks, prior.roundTrip, scoped);
+  const discriminatorMethods = reconcileScopedBlocks(discriminatorBlocks, prior.discriminator, scoped);
+  if (roundTripMethods.length === 0 && discriminatorMethods.length === 0) return null;
+
+  const body: string[] = [];
+  if (roundTripMethods.length > 0) {
+    body.push('', '', 'class TestModelRoundTrip:');
+    for (const method of roundTripMethods) body.push('', ...method.split('\n'));
+  }
+  if (discriminatorMethods.length > 0) {
+    body.push('', '', 'class TestDiscriminatorDispatch:');
+    for (const method of discriminatorMethods) body.push('', ...method.split('\n'));
+  }
+  const bodyText = body.join('\n');
+
+  // Imports: the fresh ones this run computed, plus any the prior file carried
+  // (a frozen block may reference a class the current spec no longer produces).
+  // Keep only symbols the reconciled body actually references, so a frozen-out
+  // block never leaves behind an import of a class whose file may not exist.
+  const importsByModule = new Map<string, Set<string>>();
+  const addModuleImport = (module: string, symbol: string) => {
+    if (!importsByModule.has(module)) importsByModule.set(module, new Set());
+    importsByModule.get(module)!.add(symbol);
+  };
+  for (const [dir, names] of importsByDir) {
+    for (const name of names) addModuleImport(`${ctx.namespace}.${dirToModule(dir)}.models`, name);
+  }
+  for (const [module, names] of prior.imports) {
+    for (const name of names) addModuleImport(module, name);
   }
 
   const lines: string[] = [];
@@ -1689,16 +1781,93 @@ function buildDirRoundTripFile(
   lines.push('');
   lines.push('from tests.generated_helpers import load_fixture');
   lines.push('');
-  for (const [dir, names] of [...importsByDir].sort(([a], [b]) => a.localeCompare(b))) {
-    lines.push(`from ${ctx.namespace}.${dirToModule(dir)}.models import ${[...names].sort().join(', ')}`);
+  for (const [module, names] of [...importsByModule].sort(([a], [b]) => a.localeCompare(b))) {
+    const used = [...names].filter((name) => new RegExp(`\\b${name}\\b`).test(bodyText)).sort();
+    if (used.length > 0) lines.push(`from ${module} import ${used.join(', ')}`);
   }
 
   return {
-    path: `tests/test_${dirName.replace(/\//g, '_')}_models_round_trip.py`,
+    path,
     content: [...lines, ...body].join('\n'),
     integrateTarget: true,
     overwriteExisting: true,
   };
+}
+
+interface PriorRoundTripFile {
+  /** `TestModelRoundTrip` method groups, keyed by the model's snake_case file name. */
+  roundTrip: AggregateBlock[];
+  /** `TestDiscriminatorDispatch` method groups, keyed the same way. */
+  discriminator: AggregateBlock[];
+  /** `from <module> import <names>` lines, excluding the fixed test-helper imports. */
+  imports: Map<string, Set<string>>;
+}
+
+/**
+ * Parse a prior round-trip file into per-model method groups so a scoped run can
+ * freeze out-of-scope groups verbatim.
+ *
+ * A group starts at its model's FIRST method — always `_round_trip` in
+ * `TestModelRoundTrip` and `_dispatches_known_variant` in
+ * `TestDiscriminatorDispatch`, by construction above — and runs to just before
+ * the next such anchor (or the end of the class). Anchoring on the first method
+ * rather than enumerating every suffix keeps the parser correct when a new
+ * per-model assertion is added: it lands inside the preceding group.
+ */
+function parsePriorRoundTripFile(content: string | null): PriorRoundTripFile {
+  const result: PriorRoundTripFile = {
+    roundTrip: [],
+    discriminator: [],
+    imports: new Map(),
+  };
+  if (!content) return result;
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    const imp = line.match(/^from (\S+) import (.+)$/);
+    if (!imp || imp[1] === 'tests.generated_helpers') continue;
+    const names = imp[2]
+      .split(',')
+      .map((n) => n.trim())
+      .filter((n) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(n));
+    if (names.length === 0) continue;
+    if (!result.imports.has(imp[1])) result.imports.set(imp[1], new Set());
+    for (const name of names) result.imports.get(imp[1])!.add(name);
+  }
+
+  const anchors: { cls: string; re: RegExp; into: AggregateBlock[] }[] = [
+    {
+      cls: 'TestModelRoundTrip',
+      re: /^ {4}def test_(.+)_round_trip\(self\):$/,
+      into: result.roundTrip,
+    },
+    {
+      cls: 'TestDiscriminatorDispatch',
+      re: /^ {4}def test_(.+)_dispatches_known_variant\(self\):$/,
+      into: result.discriminator,
+    },
+  ];
+
+  for (const { cls, re, into } of anchors) {
+    const start = lines.findIndex((l) => l === `class ${cls}:`);
+    if (start === -1) continue;
+    let end = start + 1;
+    while (end < lines.length && !/^\S/.test(lines[end])) end++;
+
+    const starts: number[] = [];
+    for (let i = start + 1; i < end; i++) if (re.test(lines[i])) starts.push(i);
+    for (let s = 0; s < starts.length; s++) {
+      const from = starts[s];
+      let to = (s + 1 < starts.length ? starts[s + 1] : end) - 1;
+      while (to > from && lines[to].trim() === '') to--;
+      into.push({
+        key: lines[from].match(re)![1],
+        text: lines.slice(from, to + 1).join('\n'),
+      });
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -23,6 +23,7 @@ import {
   isScopedRun,
   fileExistsAfterRun,
 } from '../shared/resolved-ops.js';
+import { type AggregateBlock, readPriorFile, reconcileScopedBlocks } from '../shared/scoped-aggregate-merge.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { classifyUnassignedModel } from './models.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
@@ -66,7 +67,12 @@ export function generateTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile
     lines.push('  end');
 
     const emittedTestMethods = new Set<string>();
-    const authMethodManifest: { method: string; httpMethodSym: string; stubUrl: string; callArgs: string }[] = [];
+    const authMethodManifest: {
+      method: string;
+      httpMethodSym: string;
+      stubUrl: string;
+      callArgs: string;
+    }[] = [];
 
     for (const op of group.operations) {
       const ownerService = group.resolvedOps.find((r) => r.operation === op)?.service;
@@ -230,16 +236,24 @@ const LEGACY_ROUNDTRIP_PATH = 'test/workos/test_model_round_trip.rb';
  * non-wrapper model in that dir through `.new(json)`/`.to_h`, asserting a Hash
  * result and that seeded keys survive.
  *
- * Only IN-SCOPE models are emitted (`isModelInScope`: everything on a full run,
- * selected-only under `--services`), so a scoped run regenerates a dir's
- * round-trip file in lockstep with that dir's regenerated per-model `.rb`
- * files. This replaces the former single wholesale file, which a scoped run
- * skipped entirely — leaving it asserting the OLD shape of a model the same run
- * had just regenerated (the failure this fixes). Dirs with no in-scope models
- * are skipped, so untouched services' files are left byte-for-byte alone
- * (scoped runs never prune). Because every emitted model is in-scope, its
- * `WorkOS::<Class>` constant is written by this same run — the reference can't
- * dangle into an `uninitialized constant`.
+ * A dir's file is regenerated only when at least one of its models is IN SCOPE
+ * (`isModelInScope`: everything on a full run, selected-only under
+ * `--services`), so it moves in lockstep with that dir's regenerated per-model
+ * `.rb` files. This replaces the former single wholesale file, which a scoped
+ * run skipped entirely — leaving it asserting the OLD shape of a model the same
+ * run had just regenerated. Dirs with no in-scope models are skipped, so
+ * untouched services' files are left byte-for-byte alone (scoped runs never
+ * prune).
+ *
+ * A regenerated dir covers in-scope ∪ on-disk models (`fileExistsAfterRun`) so
+ * out-of-scope models keep their coverage, and every referenced
+ * `WorkOS::<Class>` still has a file on disk for Zeitwerk to autoload. Their
+ * METHODS are frozen to the prior on-disk text (`reconcileScopedBlocks`) rather
+ * than re-rendered: the fixture is synthesized from the CURRENT spec, but an
+ * out-of-scope model's `.rb` was not rewritten this run, so re-rendering asserts
+ * a shape the stale model can't produce — a spec-added field lands in the
+ * fixture and `to_h` never returns it. Freezing also keeps an unrelated
+ * same-delta change to an out-of-scope model out of a scoped batch.
  */
 function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const models = (spec.models as Model[]).filter((m) => !isListWrapperModel(m) && !isListMetadataModel(m));
@@ -281,14 +295,19 @@ function generateModelRoundTripTests(spec: ApiSpec, ctx: EmitterContext): Genera
 
   const files: GeneratedFile[] = [];
   for (const [dirName, dirModels] of [...modelsByDir].sort(([a], [b]) => a.localeCompare(b))) {
-    const file = buildDirRoundTripFile(dirName, dirModels, enumNames);
+    const file = buildDirRoundTripFile(dirName, dirModels, enumNames, ctx);
     if (file) files.push(file);
   }
   return files;
 }
 
 /** Build one service dir's round-trip test file, or null when it has no models. */
-function buildDirRoundTripFile(dirName: string, dirModels: Model[], enumNames: Set<string>): GeneratedFile | null {
+function buildDirRoundTripFile(
+  dirName: string,
+  dirModels: Model[],
+  enumNames: Set<string>,
+  ctx: EmitterContext,
+): GeneratedFile | null {
   // Each dir gets a distinct test-class name so two files never reopen the same
   // Minitest class (which would merge — and clash — their methods).
   const dirClass = dirName
@@ -297,20 +316,17 @@ function buildDirRoundTripFile(dirName: string, dirModels: Model[], enumNames: S
     .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
     .join('');
 
-  const lines: string[] = [];
-  lines.push(`require 'test_helper'`);
-  lines.push('');
-  lines.push(`class ${dirClass}ModelRoundTripTest < Minitest::Test`);
+  const path = `test/workos/test_${dirName.replace(/\//g, '_')}_model_round_trip.rb`;
+  const scoped = isScopedRun(ctx);
 
+  const newBlocks: AggregateBlock[] = [];
   const emitted = new Set<string>();
-  let count = 0;
   for (const model of dirModels) {
     // Avoid duplicate test names when two IR model names collapse to the same
     // snake_case file name (we use the file name as the test suffix).
     const fileBase = fileName(model.name);
     if (emitted.has(fileBase)) continue;
     emitted.add(fileBase);
-    count += 1;
 
     // Build a fixture hash with string keys and stub values for every field.
     const fixtureEntries: string[] = [];
@@ -344,37 +360,92 @@ function buildDirRoundTripFile(dirName: string, dirModels: Model[], enumNames: S
       }
     }
 
-    lines.push('');
-    lines.push(`  def test_${fileBase}_round_trip`);
+    const block: string[] = [];
+    block.push(`  def test_${fileBase}_round_trip`);
     if (fixtureEntries.length === 0) {
-      lines.push(`    model = WorkOS::${className(model.name)}.new('{}')`);
-      lines.push('    json = model.to_h');
-      lines.push('    assert_kind_of Hash, json');
+      block.push(`    model = WorkOS::${className(model.name)}.new('{}')`);
+      block.push('    json = model.to_h');
+      block.push('    assert_kind_of Hash, json');
     } else {
-      lines.push('    fixture = {');
-      for (const line of fixtureEntries) lines.push(line);
-      lines.push('    }');
-      lines.push(`    model = WorkOS::${className(model.name)}.new(fixture.to_json)`);
-      lines.push('    json = model.to_h');
-      lines.push('    assert_kind_of Hash, json');
-      for (const a of assertions) lines.push(a);
+      block.push('    fixture = {');
+      for (const line of fixtureEntries) block.push(line);
+      block.push('    }');
+      block.push(`    model = WorkOS::${className(model.name)}.new(fixture.to_json)`);
+      block.push('    json = model.to_h');
+      block.push('    assert_kind_of Hash, json');
+      for (const a of assertions) block.push(a);
       // T23: Assert every fixture key round-trips into to_h (handles both symbol and string keys).
-      lines.push(
+      block.push(
         '    fixture.each_key { |k| assert json.key?(k.to_sym) || json.key?(k), "Expected to_h to include key #{k}" }',
       );
     }
-    lines.push('  end');
+    block.push('  end');
+
+    newBlocks.push({
+      key: fileBase,
+      text: block.join('\n'),
+      inScope: isModelInScope(model.name, ctx),
+    });
   }
 
+  // Freeze out-of-scope models' methods to their prior on-disk text. Their
+  // `.rb` was NOT regenerated this run, so re-rendering their fixture from the
+  // CURRENT spec would assert a shape the stale model can't produce (e.g. a
+  // field the spec gained since the model was last written).
+  let priorBlocks: AggregateBlock[] = [];
+  if (scoped) {
+    try {
+      priorBlocks = parseRoundTripMethods(readPriorFile(path, ctx));
+    } catch (err) {
+      // The prior file exists but is unreadable. Emitting now would reconcile
+      // against an empty prior and silently drop every out-of-scope method;
+      // leave the on-disk copy untouched instead.
+      console.warn(
+        `[oagen] ruby: leaving ${path} untouched — could not read prior file: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return null;
+    }
+  }
+  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped);
+  if (methods.length === 0) return null;
+
+  const lines: string[] = [];
+  lines.push(`require 'test_helper'`);
+  lines.push('');
+  lines.push(`class ${dirClass}ModelRoundTripTest < Minitest::Test`);
+  for (const method of methods) lines.push('', ...method.split('\n'));
   lines.push('end');
-  if (count === 0) return null;
 
   return {
-    path: `test/workos/test_${dirName.replace(/\//g, '_')}_model_round_trip.rb`,
+    path,
     content: lines.join('\n'),
     integrateTarget: true,
     overwriteExisting: true,
   };
+}
+
+/**
+ * Parse a prior round-trip file's per-model `def test_<base>_round_trip` methods,
+ * keyed by `<base>` (the model's snake_case file name), so a scoped run can
+ * freeze out-of-scope methods verbatim. Each generated method runs from its
+ * `  def ` line to the first `  end` at method indent — the emitted bodies are
+ * flat (hash literal + assertions), so no inner 2-space `end` can appear.
+ */
+function parseRoundTripMethods(content: string | null): AggregateBlock[] {
+  if (!content) return [];
+  const lines = content.split('\n');
+  const blocks: AggregateBlock[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^ {2}def (test_(.+)_round_trip)$/);
+    if (!m) continue;
+    let end = i + 1;
+    while (end < lines.length && lines[end] !== '  end') end++;
+    if (end < lines.length) blocks.push({ key: m[2], text: lines.slice(i, end + 1).join('\n') });
+    i = end;
+  }
+  return blocks;
 }
 
 /**

--- a/test/python/scoped-aggregates.test.ts
+++ b/test/python/scoped-aggregates.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { generateModels } from '../../src/python/models.js';
 import { generateTests } from '../../src/python/tests.js';
 import type { EmitterContext, ApiSpec, Service, Model } from '@workos/oagen';
@@ -21,7 +24,13 @@ const services: Service[] = [
         name: 'getWidget',
         httpMethod: 'get',
         path: '/widgets/{id}',
-        pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        pathParams: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
         queryParams: [],
         headerParams: [],
         response: { kind: 'model', name: 'WidgetA' },
@@ -37,7 +46,13 @@ const services: Service[] = [
         name: 'getGadgetBrandNew',
         httpMethod: 'get',
         path: '/gadgets/brand-new/{id}',
-        pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        pathParams: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
         queryParams: [],
         headerParams: [],
         response: { kind: 'model', name: 'GadgetBrandNew' },
@@ -48,7 +63,13 @@ const services: Service[] = [
         name: 'getGadgetOnDisk',
         httpMethod: 'get',
         path: '/gadgets/on-disk/{id}',
-        pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        pathParams: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
         queryParams: [],
         headerParams: [],
         response: { kind: 'model', name: 'GadgetOnDisk' },
@@ -63,22 +84,46 @@ const models: Model[] = [
   {
     name: 'WidgetA',
     fields: [
-      { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
-      { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+      {
+        name: 'id',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
+      {
+        name: 'name',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
     ],
   },
   {
     name: 'GadgetBrandNew',
     fields: [
-      { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
-      { name: 'color', type: { kind: 'primitive', type: 'string' }, required: true },
+      {
+        name: 'id',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
+      {
+        name: 'color',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
     ],
   },
   {
     name: 'GadgetOnDisk',
     fields: [
-      { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
-      { name: 'size', type: { kind: 'primitive', type: 'string' }, required: true },
+      {
+        name: 'id',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
+      {
+        name: 'size',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
     ],
   },
 ];
@@ -252,7 +297,13 @@ describe('python scoped aggregates', () => {
       name,
       httpMethod: 'get' as const,
       path,
-      pathParams: [{ name: 'id', type: { kind: 'primitive' as const, type: 'string' as const }, required: true }],
+      pathParams: [
+        {
+          name: 'id',
+          type: { kind: 'primitive' as const, type: 'string' as const },
+          required: true,
+        },
+      ],
       queryParams: [],
       headerParams: [],
       response: { kind: 'model' as const, name: model },
@@ -261,11 +312,38 @@ describe('python scoped aggregates', () => {
     });
     const localModels: Model[] = [
       // In scope this run.
-      { name: 'WidgetA', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      {
+        name: 'WidgetA',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
       // Out of scope this run, but its model + fixture are on disk (prior manifest).
-      { name: 'WidgetLegacy', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      {
+        name: 'WidgetLegacy',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
       // Out of scope AND brand-new (no fixture on disk) → nothing to test.
-      { name: 'WidgetBrandNew', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      {
+        name: 'WidgetBrandNew',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
     ];
     const localSpec: ApiSpec = {
       name: 'TestAPI',
@@ -288,32 +366,136 @@ describe('python scoped aggregates', () => {
     // Scoped to Widgets; only WidgetA is regenerated this run. The prior manifest
     // records WidgetLegacy's model + fixture (left untouched on disk), but NOT
     // WidgetBrandNew's.
-    const ctx = {
-      namespace: 'workos',
-      namespacePascal: 'WorkOS',
-      spec: localSpec,
-      scopedServices: new Set(['Widgets']),
-      scopedModelNames: new Set(['WidgetA']),
-      scopedEnumNames: new Set<string>(),
-      priorTargetManifestPaths: new Set([
-        'src/workos/widgets/models/widget_a.py',
-        'src/workos/widgets/models/widget_legacy.py',
-        'tests/fixtures/widget_a.json',
-        'tests/fixtures/widget_legacy.json',
-      ]),
-    } as EmitterContext;
+    const RT_PATH = 'tests/test_widgets_models_round_trip.py';
+    const mkCtx = (outputDir: string) =>
+      ({
+        namespace: 'workos',
+        namespacePascal: 'WorkOS',
+        spec: localSpec,
+        outputDir,
+        scopedServices: new Set(['Widgets']),
+        scopedModelNames: new Set(['WidgetA']),
+        scopedEnumNames: new Set<string>(),
+        priorTargetManifestPaths: new Set([
+          'src/workos/widgets/models/widget_a.py',
+          'src/workos/widgets/models/widget_legacy.py',
+          'tests/fixtures/widget_a.json',
+          'tests/fixtures/widget_legacy.json',
+        ]),
+      }) as EmitterContext;
+
+    /** Seed a prior round-trip file carrying WidgetLegacy's method group. */
+    const seedPrior = (methodBody: string[]): string => {
+      const outputDir = mkdtempSync(join(tmpdir(), 'oagen-py-rt-'));
+      const abs = join(outputDir, RT_PATH);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(
+        abs,
+        [
+          '"""Model round-trip tests: from_dict(to_dict()) preserves data."""',
+          '',
+          'import pytest',
+          '',
+          'from tests.generated_helpers import load_fixture',
+          '',
+          'from workos.widgets.models import WidgetLegacy',
+          '',
+          '',
+          'class TestModelRoundTrip:',
+          '',
+          ...methodBody,
+          '',
+        ].join('\n'),
+      );
+      return outputDir;
+    };
 
     it('RETAINS the out-of-scope on-disk model and excludes the brand-new one', () => {
-      const files = generateTests(localSpec, ctx);
-      const rt = files.find((f) => f.path === 'tests/test_widgets_models_round_trip.py');
+      // The out-of-scope model's coverage is carried over from the prior on-disk
+      // file, so seed one — with a `legacy_only` assertion the current spec
+      // wouldn't produce, proving the group is frozen rather than re-rendered.
+      const outputDir = seedPrior([
+        '    def test_widget_legacy_round_trip(self):',
+        '        data = load_fixture("widget_legacy.json")',
+        '        instance = WidgetLegacy.from_dict(data)',
+        '        serialized = instance.to_dict()',
+        '        assert serialized == data',
+        '        assert "legacy_only" not in serialized',
+      ]);
+
+      const files = generateTests(localSpec, mkCtx(outputDir));
+      const rt = files.find((f) => f.path === RT_PATH);
       expect(rt).toBeDefined();
-      // In-scope model is covered.
+      // In-scope model is covered, refreshed from the current spec.
       expect(rt!.content).toContain('def test_widget_a_round_trip(self):');
-      // Out-of-scope model still on disk → coverage retained (the regression).
+      // Out-of-scope model still on disk → coverage retained (the regression),
+      // frozen to its prior group, with its import carried over.
       expect(rt!.content).toContain('def test_widget_legacy_round_trip(self):');
       expect(rt!.content).toContain('WidgetLegacy');
+      expect(rt!.content).toContain('assert "legacy_only" not in serialized');
       // Out-of-scope model with no on-disk fixture → no test, no dangling import.
       expect(rt!.content).not.toContain('WidgetBrandNew');
+
+      rmSync(outputDir, { recursive: true, force: true });
+    });
+
+    it('freezes an out-of-scope group instead of re-synthesizing payloads from the current spec', () => {
+      // The bug: the payload assertions below are synthesized from the CURRENT
+      // spec, but an out-of-scope model's `.py` was NOT regenerated this run —
+      // so a spec-added field landed in `data` while `to_dict()` never emits it
+      // (`KeyError`). Re-rendering must not happen; the prior group stands.
+      const drifted: ApiSpec = {
+        ...localSpec,
+        models: localModels.map((m) =>
+          m.name === 'WidgetLegacy'
+            ? {
+                ...m,
+                fields: [
+                  ...m.fields,
+                  // Added to the spec after the on-disk model was last written.
+                  {
+                    name: 'waitlist_id',
+                    type: {
+                      kind: 'nullable' as const,
+                      inner: {
+                        kind: 'primitive' as const,
+                        type: 'string' as const,
+                      },
+                    },
+                    required: false,
+                  },
+                ],
+              }
+            : m,
+        ),
+      };
+
+      // A FULL run does pick the new field up — it regenerates the model too.
+      const fullRt = generateTests(drifted, {
+        namespace: 'workos',
+        namespacePascal: 'WorkOS',
+        spec: drifted,
+      } as EmitterContext).find((f) => f.path === RT_PATH);
+      expect(fullRt!.content).toContain('waitlist_id');
+
+      const outputDir = seedPrior([
+        '    def test_widget_legacy_round_trip(self):',
+        '        data = load_fixture("widget_legacy.json")',
+        '        instance = WidgetLegacy.from_dict(data)',
+        '        serialized = instance.to_dict()',
+        '        assert serialized == data',
+      ]);
+      const scopedCtx = {
+        ...mkCtx(outputDir),
+        spec: drifted,
+      } as EmitterContext;
+      const rt = generateTests(drifted, scopedCtx).find((f) => f.path === RT_PATH);
+      // Coverage retained...
+      expect(rt!.content).toContain('def test_widget_legacy_round_trip(self):');
+      // ...but the spec-added field is NOT asserted against the untouched model.
+      expect(rt!.content).not.toContain('waitlist_id');
+
+      rmSync(outputDir, { recursive: true, force: true });
     });
   });
 
@@ -326,7 +508,13 @@ describe('python scoped aggregates', () => {
             name: 'getWidget',
             httpMethod: 'get',
             path: '/widgets/{id}',
-            pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+            pathParams: [
+              {
+                name: 'id',
+                type: { kind: 'primitive', type: 'string' },
+                required: true,
+              },
+            ],
             queryParams: [],
             headerParams: [],
             response: { kind: 'model', name: 'WidgetA' },
@@ -342,7 +530,13 @@ describe('python scoped aggregates', () => {
             name: 'getAgent',
             httpMethod: 'get',
             path: '/agents/{id}',
-            pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+            pathParams: [
+              {
+                name: 'id',
+                type: { kind: 'primitive', type: 'string' },
+                required: true,
+              },
+            ],
             queryParams: [],
             headerParams: [],
             response: { kind: 'model', name: 'AgentThing' },
@@ -353,8 +547,26 @@ describe('python scoped aggregates', () => {
       },
     ];
     const localModels: Model[] = [
-      { name: 'WidgetA', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
-      { name: 'AgentThing', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      {
+        name: 'WidgetA',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'AgentThing',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
     ];
     const localSpec: ApiSpec = {
       name: 'TestAPI',

--- a/test/ruby/tests.test.ts
+++ b/test/ruby/tests.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import type { EmitterContext, ApiSpec, Service, Model, ResolvedOperation } from '@workos/oagen';
 import { defaultSdkBehavior, toSnakeCase, toPascalCase } from '@workos/oagen';
 import { generateTests } from '../../src/ruby/tests.js';
@@ -36,11 +39,38 @@ function buildResolvedOps(services: Service[]): ResolvedOperation[] {
 
 const models: Model[] = [
   // In-scope: selected service's model.
-  { name: 'Organization', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+  {
+    name: 'Organization',
+    fields: [
+      {
+        name: 'id',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
+    ],
+  },
   // On-disk: out-of-scope this run, but its file is recorded in the prior manifest.
-  { name: 'Connection', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+  {
+    name: 'Connection',
+    fields: [
+      {
+        name: 'id',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
+    ],
+  },
   // Brand-new out-of-scope: out-of-scope AND not in the prior manifest.
-  { name: 'Directory', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+  {
+    name: 'Directory',
+    fields: [
+      {
+        name: 'id',
+        type: { kind: 'primitive', type: 'string' },
+        required: true,
+      },
+    ],
+  },
 ];
 
 const services: Service[] = [
@@ -123,7 +153,13 @@ describe('ruby/tests model round-trip per-service scoping', () => {
       name,
       httpMethod: 'get' as const,
       path,
-      pathParams: [{ name: 'id', type: { kind: 'primitive' as const, type: 'string' as const }, required: true }],
+      pathParams: [
+        {
+          name: 'id',
+          type: { kind: 'primitive' as const, type: 'string' as const },
+          required: true,
+        },
+      ],
       queryParams: [],
       headerParams: [],
       response: { kind: 'model' as const, name: model },
@@ -131,16 +167,37 @@ describe('ruby/tests model round-trip per-service scoping', () => {
       injectIdempotencyKey: false,
     });
     const localModels: Model[] = [
-      { name: 'Organization', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+      {
+        name: 'Organization',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
       // Out of scope this run, but its per-model file is on disk (prior manifest).
       {
         name: 'OrganizationDomain',
-        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
       },
       // Out of scope AND brand-new (no file on disk) → nothing to test.
       {
         name: 'OrganizationBrandNew',
-        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
       },
     ];
     const localServices: Service[] = [
@@ -169,10 +226,37 @@ describe('ruby/tests model round-trip per-service scoping', () => {
     expect(rtFull).toBeDefined();
     const dir = rtFull!.path.replace(/^test\/workos\/test_/, '').replace(/_model_round_trip\.rb$/, '');
 
+    // The out-of-scope model's coverage is carried over from the prior on-disk
+    // test file, so seed one — including a `legacy` key the current spec's model
+    // no longer has, to prove the block is frozen rather than re-rendered.
+    const outputDir = mkdtempSync(join(tmpdir(), 'oagen-rb-rt-'));
+    const rtPath = join(outputDir, `test/workos/test_${dir}_model_round_trip.rb`);
+    mkdirSync(dirname(rtPath), { recursive: true });
+    writeFileSync(
+      rtPath,
+      [
+        `require 'test_helper'`,
+        '',
+        `class ${dir.replace(/(^|_)(\w)/g, (_m, _p, c) => c.toUpperCase())}ModelRoundTripTest < Minitest::Test`,
+        '',
+        '  def test_organization_domain_round_trip',
+        '    fixture = {',
+        '    "id" => "stub",',
+        '    "legacy" => "kept",',
+        '    }',
+        '    model = WorkOS::OrganizationDomain.new(fixture.to_json)',
+        '    json = model.to_h',
+        '    assert_kind_of Hash, json',
+        '  end',
+        'end',
+      ].join('\n'),
+    );
+
     const ctx: EmitterContext = {
       namespace: 'workos',
       namespacePascal: 'WorkOS',
       spec: localSpec,
+      outputDir,
       resolvedOperations: buildResolvedOps(localServices),
       scopedServices: new Set(['Organizations']),
       scopedModelNames: new Set(['Organization']),
@@ -182,12 +266,135 @@ describe('ruby/tests model round-trip per-service scoping', () => {
       ]),
     };
     const combined = roundTripContent(generateTests(localSpec, ctx));
-    // In-scope model is covered.
+    // In-scope model is covered, refreshed from the current spec.
     expect(combined).toContain('WorkOS::Organization.new');
-    // Out-of-scope model still on disk → coverage retained (the regression).
+    // Out-of-scope model still on disk → coverage retained (the regression),
+    // frozen to its prior block so the fresh spec never drifts past the
+    // untouched on-disk model.
     expect(combined).toContain('WorkOS::OrganizationDomain.new');
+    expect(combined).toContain('"legacy" => "kept"');
     // Out-of-scope model with no file on disk → no test (no dangling constant).
     expect(combined).not.toContain('WorkOS::OrganizationBrandNew.new');
+
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('scoped run: freezes an out-of-scope model whose SPEC gained a field its on-disk model lacks', () => {
+    // The bug: a spec-added field on an out-of-scope model landed in the freshly
+    // rendered fixture, but the model's `.rb` was not regenerated this run — so
+    // `to_h` never returns it and the emitted
+    // `assert json.key?(...)` failed. The block must be frozen instead.
+    const mkOp = (name: string, path: string, model: string) => ({
+      name,
+      httpMethod: 'get' as const,
+      path,
+      pathParams: [
+        {
+          name: 'id',
+          type: { kind: 'primitive' as const, type: 'string' as const },
+          required: true,
+        },
+      ],
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'model' as const, name: model },
+      errors: [],
+      injectIdempotencyKey: false,
+    });
+    const localModels: Model[] = [
+      {
+        name: 'Organization',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'OrganizationDomain',
+        fields: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+          // Added to the spec after the on-disk model was last generated.
+          {
+            name: 'waitlist_id',
+            type: { kind: 'primitive', type: 'string' },
+            required: true,
+          },
+        ],
+      },
+    ];
+    const localServices: Service[] = [
+      {
+        name: 'Organizations',
+        operations: [
+          mkOp('getOrganization', '/organizations/{id}', 'Organization'),
+          mkOp('getOrganizationDomain', '/organizations/domains/{id}', 'OrganizationDomain'),
+        ],
+      },
+    ];
+    const localSpec = makeSpec(localServices, localModels);
+
+    const fullFiles = generateTests(localSpec, {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec: localSpec,
+      resolvedOperations: buildResolvedOps(localServices),
+    } as EmitterContext);
+    const rtFull = fullFiles.find(
+      (f) => f.path.endsWith('_model_round_trip.rb') && f.content.includes('WorkOS::OrganizationDomain.new'),
+    )!;
+    // A FULL run does pick the new field up — it regenerates the model too.
+    expect(rtFull.content).toContain('"waitlist_id"');
+    const dir = rtFull.path.replace(/^test\/workos\/test_/, '').replace(/_model_round_trip\.rb$/, '');
+
+    const outputDir = mkdtempSync(join(tmpdir(), 'oagen-rb-drift-'));
+    const rtPath = join(outputDir, `test/workos/test_${dir}_model_round_trip.rb`);
+    mkdirSync(dirname(rtPath), { recursive: true });
+    writeFileSync(
+      rtPath,
+      [
+        `require 'test_helper'`,
+        '',
+        `class ${dir.replace(/(^|_)(\w)/g, (_m, _p, c) => c.toUpperCase())}ModelRoundTripTest < Minitest::Test`,
+        '',
+        '  def test_organization_domain_round_trip',
+        '    fixture = {',
+        '    "id" => "stub",',
+        '    }',
+        '    model = WorkOS::OrganizationDomain.new(fixture.to_json)',
+        '    json = model.to_h',
+        '    assert_kind_of Hash, json',
+        '  end',
+        'end',
+      ].join('\n'),
+    );
+
+    const ctx: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec: localSpec,
+      outputDir,
+      resolvedOperations: buildResolvedOps(localServices),
+      scopedServices: new Set(['Organizations']),
+      scopedModelNames: new Set(['Organization']),
+      priorTargetManifestPaths: new Set([
+        `lib/workos/${dir}/organization.rb`,
+        `lib/workos/${dir}/organization_domain.rb`,
+      ]),
+    };
+    const combined = roundTripContent(generateTests(localSpec, ctx));
+    // Coverage retained...
+    expect(combined).toContain('WorkOS::OrganizationDomain.new');
+    // ...but the spec-added field is NOT asserted against the untouched model.
+    expect(combined).not.toContain('"waitlist_id"');
+
+    rmSync(outputDir, { recursive: true, force: true });
   });
 
   it('scoped run: overwrites the pre-split monolith with an inert placeholder while it is on disk', () => {


### PR DESCRIPTION
## Summary

- **The bug:** a scoped run (`--services`) regenerates a dir's model round-trip test whenever _any one_ of its models is in scope, and covers in-scope ∪ already-on-disk models so out-of-scope models keep their coverage. But every block was re-rendered from the **current spec**, while an out-of-scope model's own file was left untouched — so a field the spec gained since that model was last written landed in the test and never in the model.
- **How it surfaced:** `WaitlistUser.waitlist_id` is referenced only as a webhook payload, so it owns no service and can never enter scope. [openapi-spec run 31195345529](https://github.com/workos/openapi-spec/actions/runs/31195345529), scoped to `Pipes,SSO,UserManagement,Webhooks`, failed with `KeyError: 'waitlist_id'` (Python, 5 tests) and `Expected to_h to include key waitlist_id` (Ruby, 1 test). iOS was unaffected — its emitter did regenerate the model.
- **The fix:** build per-model method groups as discrete blocks and run them through the existing `reconcileScopedBlocks` helper, exactly as the Kotlin emitter already does. In-scope blocks refresh from the spec; out-of-scope blocks freeze byte-for-byte to the prior on-disk file.
- **Why this shape:** dropping out-of-scope models would undo the coverage fix that added them (python#696 / ruby#525, ~330 and ~140 tests), and widening the write set to regenerate them would leak unrelated services into a scoped batch. Freezing preserves both properties.
