### PR TITLE
fix(rust): no Some() for required Vec query params

### DIFF
--- a/src/rust/tests.ts
+++ b/src/rust/tests.ts
@@ -534,6 +534,11 @@ function encodesQueryParamsTest(
   lines.push('        .mount(&server)');
   lines.push('        .await;');
   lines.push('    let client = common::test_client(&server).await;');
+  // Required params are `Vec<String>`; optional ones are `Option<Vec<String>>`
+  // and need a `Some(...)` wrapper to compile.
+  const arrayValue = target.required
+    ? `vec!["foo".to_string(), "bar".to_string()]`
+    : `Some(vec!["foo".to_string(), "bar".to_string()])`;
   // Clippy's `field_reassign_with_default` fires when fields are mutated on a
   // value created via `T::default()`. Use struct-update syntax in that case;
   // otherwise (`Type::new(...)` etc.), fall back to the mutable-binding form
@@ -541,12 +546,12 @@ function encodesQueryParamsTest(
   if (paramsExpr.endsWith('::default()')) {
     const ty = paramsExpr.slice(0, -'::default()'.length);
     lines.push(`    let params = ${ty} {`);
-    lines.push(`        ${fieldIdent(target.name)}: Some(vec!["foo".to_string(), "bar".to_string()]),`);
+    lines.push(`        ${fieldIdent(target.name)}: ${arrayValue},`);
     lines.push('        ..Default::default()');
     lines.push('    };');
   } else {
     lines.push(`    let mut params = ${paramsExpr};`);
-    lines.push(`    params.${fieldIdent(target.name)} = Some(vec!["foo".to_string(), "bar".to_string()]);`);
+    lines.push(`    params.${fieldIdent(target.name)} = ${arrayValue};`);
   }
   // Drop the array param onto the params; ignore any required-cursor fields
   // — they're already populated by buildCallArgs.

--- a/test/rust/tests.test.ts
+++ b/test/rust/tests.test.ts
@@ -458,6 +458,67 @@ describe('rust/tests', () => {
     expect(content).toContain('tags=foo&tags=bar');
   });
 
+  it('does not wrap a required Vec<String> query param in Some()', () => {
+    const services: Service[] = [
+      {
+        name: 'Events',
+        operations: [
+          {
+            name: 'listEvents',
+            httpMethod: 'get',
+            path: '/events',
+            pathParams: [],
+            queryParams: [
+              {
+                name: 'events',
+                type: {
+                  kind: 'array',
+                  items: { kind: 'primitive', type: 'string' },
+                },
+                required: true,
+                explode: false,
+              },
+            ],
+            headerParams: [],
+            response: { kind: 'model', name: 'EventList' },
+            errors: [],
+            injectIdempotencyKey: false,
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'EventSchema' },
+            },
+          },
+        ],
+      },
+    ];
+    const files = generateTests(
+      { ...baseSpec, services },
+      ctxWithResolved(services, [
+        {
+          name: 'EventList',
+          fields: [
+            {
+              name: 'data',
+              type: {
+                kind: 'array',
+                items: { kind: 'model', name: 'EventSchema' },
+              },
+              required: true,
+            },
+          ],
+        },
+      ]),
+    );
+    const content = getMountTestFile(files, 'events');
+    expect(content).toContain('async fn events_list_events_encodes_query_params()');
+    // A required param is `Vec<String>`, not `Option<Vec<String>>`, so the
+    // generated fixture must not wrap it in `Some(...)` (which would be E0308).
+    expect(content).not.toContain('Some(vec!["foo".to_string(), "bar".to_string()])');
+    expect(content).toContain('vec!["foo".to_string(), "bar".to_string()]');
+  });
+
   it('skips encodes_query_params for ops with no Vec<String> query params', () => {
     const services: Service[] = [
       {


### PR DESCRIPTION
- Generated Rust test fixtures wrapped every `Vec<String>` query param
  in `Some(...)`, regardless of whether the param was required or
  optional.
- Required query params are typed `Vec<String>`, not
  `Option<Vec<String>>`, so the `Some(...)` wrapper produced `E0308`
  (mismatched types) and the fixtures wouldn't compile.
- The test generator now emits `Some(...)` only when the param is
  optional, and a bare `vec![...]` expression when it's required.
- Adds a test asserting a required array query param is emitted
  without `Some(...)`.
