### PR TITLE
fix(dotnet,python): keep list-metadata models a wrapper needs

### DIFF
--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -25,6 +25,7 @@ import {
   isListWrapperModel,
   isListMetadataModel,
   collectNonPaginatedResponseModelNames,
+  collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
 import { isModelInScope } from '../shared/resolved-ops.js';
 export { isListWrapperModel, isListMetadataModel };
@@ -85,6 +86,14 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
   // code references them by name and the pagination iterator doesn't unwrap them.
   const nonPaginatedRefs = collectNonPaginatedResponseModelNames(ctx.spec.services);
   const skipAsListWrapper = (m: Model): boolean => isListWrapperModel(m) && !nonPaginatedRefs.has(m.name);
+  // A metadata model referenced by a surviving non-paginated wrapper must be
+  // emitted — the wrapper's list_metadata property names it. `ListMetadata`
+  // itself is the exception: the SDK ships a hand-written WorkOS.ListMetadata
+  // (Services/_common/Entities) that generated references resolve against, so
+  // emitting the spec's model of the same name would duplicate the type.
+  const listMetadataNeeded = collectReferencedListMetadataModels(models, nonPaginatedRefs);
+  const skipAsListMetadata = (m: Model): boolean =>
+    isListMetadataModel(m) && (!listMetadataNeeded.has(m.name) || modelClassName(m.name) === 'ListMetadata');
 
   // Build a lookup of base model field C# names → C# types for inheritance.
   // Variant models skip inherited fields and use `new` for type-divergent ones.
@@ -108,7 +117,7 @@ export function generateModels(models: Model[], ctx: EmitterContext, discCtx?: D
   }
 
   for (const model of models) {
-    if (skipAsListWrapper(model) || isListMetadataModel(model)) continue;
+    if (skipAsListWrapper(model) || skipAsListMetadata(model)) continue;
     if (requestBodyOnlyNames.has(model.name)) continue;
 
     const csClassName = modelClassName(model.name);

--- a/src/python/shared-schemas.ts
+++ b/src/python/shared-schemas.ts
@@ -1,7 +1,7 @@
 import type { ApiSpec, EmitterContext, Enum, Model, Service } from '@workos/oagen';
 import { assignModelsToServices, collectFieldDependencies, planOperation, walkTypeRef } from '@workos/oagen';
 import { fileName } from './naming.js';
-import { detectDiscriminators } from '../shared/model-utils.js';
+import { buildListScaffoldingSkip, detectDiscriminators } from '../shared/model-utils.js';
 
 /**
  * Walk every operation across all services and tally, per schema, the set of
@@ -332,12 +332,14 @@ function canAliasModels(canonical: string, alias: string, usage: ModelUsage): bo
 export function computeModelAliases(spec: ApiSpec): Map<string, string> {
   const recursiveHashes = buildRecursiveHashMap(spec.models, spec.enums);
   const usage = collectModelUsage(spec);
+  // List scaffolding the emitter never writes (paginated wrappers and their
+  // metadata) must not participate in dedup: a surviving metadata model whose
+  // canonical is a skipped twin would alias to a module that doesn't exist.
+  const skipScaffolding = buildListScaffoldingSkip(spec.models, spec.services);
 
   const hashGroups = new Map<string, string[]>();
   for (const model of spec.models) {
-    if (model.fields.length === 0 && !(model as { discriminator?: unknown }).discriminator) {
-      // skipped by emit anyway when listmeta/wrapper, but we rely on emit-side filter.
-    }
+    if (skipScaffolding(model)) continue;
     const hash = recursiveHashes.get(model.name) ?? '';
     if (!hashGroups.has(hash)) hashGroups.set(hash, []);
     hashGroups.get(hash)!.push(model.name);

--- a/test/dotnet/models.test.ts
+++ b/test/dotnet/models.test.ts
@@ -332,4 +332,124 @@ describe('dotnet/models', () => {
     expect(baseFile.content).toContain('/// <remarks>');
     expect(baseFile.content).toContain('forward-compatible');
   });
+
+  it('emits a list-metadata model referenced by a surviving non-paginated wrapper', () => {
+    const service: Service = {
+      name: 'OrganizationsItContacts',
+      operations: [
+        {
+          name: 'listItContacts',
+          httpMethod: 'get',
+          path: '/organizations/{organization_id}/it_contacts',
+          pathParams: [{ name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          // No pagination: the wrapper survives as a real model, so its
+          // list_metadata field type must be emitted too.
+          response: { kind: 'model', name: 'ItContactList' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const models: Model[] = [
+      {
+        name: 'ItContact',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'ItContactList',
+        fields: [
+          {
+            name: 'data',
+            type: { kind: 'array', items: { kind: 'model', name: 'ItContact' } },
+            required: true,
+          },
+          {
+            name: 'list_metadata',
+            type: { kind: 'model', name: 'ItContactListListMetadata' },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'ItContactListListMetadata',
+        fields: [
+          { name: 'before', type: { kind: 'primitive', type: 'string' }, required: false },
+          { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+        ],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const files = generateModels(models, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], models },
+    });
+    const filePaths = files.map((f) => f.path);
+
+    expect(filePaths).toContain('Entities/ItContactList.cs');
+    expect(filePaths).toContain('Entities/ItContactListListMetadata.cs');
+  });
+
+  it('never emits ListMetadata itself — the SDK ships a hand-written one', () => {
+    const service: Service = {
+      name: 'Authorization',
+      operations: [
+        {
+          name: 'setRoleAssignments',
+          httpMethod: 'put',
+          path: '/authorization/groups/{id}/role_assignments',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          // Non-paginated wrapper response referencing ListMetadata by name.
+          response: { kind: 'model', name: 'GroupRoleAssignmentList' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const models: Model[] = [
+      {
+        name: 'GroupRoleAssignment',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'GroupRoleAssignmentList',
+        fields: [
+          {
+            name: 'data',
+            type: { kind: 'array', items: { kind: 'model', name: 'GroupRoleAssignment' } },
+            required: true,
+          },
+          {
+            name: 'list_metadata',
+            type: { kind: 'model', name: 'ListMetadata' },
+            required: true,
+          },
+        ],
+      },
+      {
+        name: 'ListMetadata',
+        fields: [
+          { name: 'before', type: { kind: 'primitive', type: 'string' }, required: false },
+          { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+        ],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const files = generateModels(models, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service], models },
+    });
+    const filePaths = files.map((f) => f.path);
+
+    expect(filePaths).toContain('Entities/GroupRoleAssignmentList.cs');
+    // Emitting it would duplicate the hand-written WorkOS.ListMetadata.
+    expect(filePaths).not.toContain('Entities/ListMetadata.cs');
+  });
 });

--- a/test/python/models.test.ts
+++ b/test/python/models.test.ts
@@ -1037,4 +1037,112 @@ describe('generateModels', () => {
     expect(files.find((f) => f.path === 'src/workos/authorization/models/pinned_thing.py')).toBeDefined();
     expect(files.find((f) => f.path === 'src/workos/common/models/pinned_thing.py')).toBeUndefined();
   });
+
+  it('emits a dataclass for a needed list-metadata model whose structural twin is skipped scaffolding', () => {
+    // A paginated wrapper's metadata model is skipped (the pagination
+    // machinery subsumes it), but a structurally identical metadata model
+    // referenced by a NON-paginated wrapper must be emitted. It must not be
+    // deduped into a TypeAlias of the skipped twin — that file is never
+    // written, so the alias would import a module that doesn't exist.
+    const authorization: Service = {
+      name: 'Authorization',
+      operations: [
+        {
+          name: 'listPermissions',
+          httpMethod: 'get',
+          path: '/authorization/permissions',
+          pathParams: [],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'AuthorizationPermissionList' },
+          errors: [],
+          injectIdempotencyKey: false,
+          pagination: {
+            strategy: 'cursor',
+            param: 'after',
+            dataPath: 'data',
+            itemType: { kind: 'model', name: 'AuthorizationPermission' },
+          },
+        },
+      ],
+    };
+    const itContacts: Service = {
+      name: 'OrganizationsItContacts',
+      operations: [
+        {
+          name: 'listItContacts',
+          httpMethod: 'get',
+          path: '/organizations/{organization_id}/it_contacts',
+          pathParams: [{ name: 'organization_id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [],
+          headerParams: [],
+          response: { kind: 'model', name: 'ItContactList' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const cursorFields = [
+      { name: 'before', type: { kind: 'primitive', type: 'string' }, required: false },
+      { name: 'after', type: { kind: 'primitive', type: 'string' }, required: false },
+    ] as Model['fields'];
+
+    const models: Model[] = [
+      {
+        name: 'AuthorizationPermission',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'AuthorizationPermissionList',
+        fields: [
+          {
+            name: 'data',
+            type: { kind: 'array', items: { kind: 'model', name: 'AuthorizationPermission' } },
+            required: true,
+          },
+          {
+            name: 'list_metadata',
+            type: { kind: 'model', name: 'AuthorizationPermissionListListMetadata' },
+            required: true,
+          },
+        ],
+      },
+      { name: 'AuthorizationPermissionListListMetadata', fields: cursorFields },
+      {
+        name: 'ItContact',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+      {
+        name: 'ItContactList',
+        fields: [
+          {
+            name: 'data',
+            type: { kind: 'array', items: { kind: 'model', name: 'ItContact' } },
+            required: true,
+          },
+          {
+            name: 'list_metadata',
+            type: { kind: 'model', name: 'ItContactListListMetadata' },
+            required: true,
+          },
+        ],
+      },
+      { name: 'ItContactListListMetadata', fields: cursorFields },
+    ];
+
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services: [authorization, itContacts], models },
+    };
+
+    const files = generateModels(models, ctxWithServices);
+    const metadataFile = files.find((f) => f.path.endsWith('it_contact_list_list_metadata.py'));
+    expect(metadataFile).toBeDefined();
+    // A real dataclass, not a TypeAlias re-export of the never-emitted twin.
+    expect(metadataFile!.content).toContain('class ItContactListListMetadata');
+    expect(metadataFile!.content).not.toContain('authorization_permission_list_list_metadata');
+    // The paginated twin stays skipped.
+    expect(files.some((f) => f.path.endsWith('authorization_permission_list_list_metadata.py'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- A list wrapper (`data` + `list_metadata`) returned by a **non-paginated** operation survives as a real emitted model and references its `list_metadata` type by name. Both emitters were still treating every metadata model as pagination scaffolding, so that referenced type went missing.
- **.NET**: the metadata file the surviving wrapper imports was never written, leaving the generated entity referencing a nonexistent type. It now emits metadata models reached from surviving wrappers, while still suppressing `ListMetadata` itself — the SDK ships a hand-written `WorkOS.ListMetadata` in `Services/_common/Entities`, and emitting the spec's same-named model would duplicate the type.
- **Python**: structural dedup let a skipped paginated twin win as canonical, so a needed metadata model was emitted as a `TypeAlias` importing a module that is never written. Skipped scaffolding is now excluded from dedup grouping entirely.
- Both emitters route through the shared `buildListScaffoldingSkip` / `collectReferencedListMetadataModels` helpers so the "does this scaffolding survive?" answer cannot drift between emitters.
- Also replaces a dead no-op `if` block in the Python dedup path that documented the intent but did nothing.
