### PR TITLE
fix(dotnet): qualify delete helper calls with base. when captured

### DIFF
--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -302,12 +302,65 @@ function groupsNeedJsonConvert(operations: Operation[], models: Model[]): boolea
   return false;
 }
 
+/**
+ * Number of leading value parameters (path params, bearer token, options) the
+ * generated signature for `op` carries before the trailing
+ * `RequestOptions?`/`CancellationToken` pair. Mirrors the signature
+ * construction in generateMethod.
+ */
+function leadingParamCount(
+  op: Operation,
+  plan: OperationPlan,
+  ctx: EmitterContext,
+  resolvedOp?: ResolvedOperation,
+): number {
+  const hidden = buildHiddenParams(resolvedOp);
+  const groupedParams = collectGroupedParamNames(op);
+  const hasGroups = (op.parameterGroups?.length ?? 0) > 0;
+  const hasVisibleQueryParams =
+    op.queryParams.filter((qp) => !hidden.has(qp.name) && !groupedParams.has(qp.name)).length > 0;
+  const hasBody = plan.hasBody && op.requestBody;
+  let hasVisibleBodyFields = false;
+  if (hasBody && op.requestBody?.kind === 'model') {
+    const bodyModel = ctx.spec.models.find((m) => op.requestBody?.kind === 'model' && m.name === op.requestBody.name);
+    if (bodyModel) hasVisibleBodyFields = bodyModel.fields.some((f) => !hidden.has(f.name));
+  } else if (hasBody) {
+    hasVisibleBodyFields = true;
+  }
+  const hasParams = hasVisibleBodyFields || hasVisibleQueryParams || hasGroups;
+  const hasBearerOverride = op.security?.some((s: any) => s.schemeName !== 'bearerAuth') ?? false;
+  return op.pathParams.length + (hasBearerOverride ? 1 : 0) + (hasParams ? 1 : 0);
+}
+
 function generateServiceFile(mountName: string, operations: Operation[], ctx: EmitterContext): GeneratedFile | null {
   const lines: string[] = [];
   const svcTypeName = serviceTypeName(mountName);
   const csFile = `Services/${className(mountName)}/${svcTypeName}.cs`;
 
   const resolvedLookup = buildResolvedLookup(ctx);
+
+  // A generated method named DeleteAsync with exactly two leading parameters
+  // (e.g. two path params) hides Service.DeleteAsync from the 4-argument
+  // helper calls the isDelete branch emits: C# discards base-class overloads
+  // once any derived candidate is applicable, so `this.DeleteAsync(path,
+  // null, requestOptions, ct)` binds to the API method itself — CS8625 on the
+  // null literal, or silent recursion. Those call sites must say `base.`, and
+  // only those: StyleCop SA1100 (warnings-as-errors in workos-dotnet) rejects
+  // `base.` wherever `this.` already resolves to the same helper.
+  let hasCapturingDeleteAsync = false;
+  {
+    const seen = new Set<string>();
+    for (const op of operations) {
+      const resolvedOp = lookupResolved(op, resolvedLookup);
+      if ((resolvedOp?.wrappers?.length ?? 0) > 0) continue;
+      const method = resolveCsMethodName(op, mountName, ctx);
+      if (seen.has(method)) continue;
+      seen.add(method);
+      if (method !== 'DeleteAsync') continue;
+      hasCapturingDeleteAsync = leadingParamCount(op, planOperation(op), ctx, resolvedOp) === 2;
+      break;
+    }
+  }
 
   lines.push(`namespace ${ctx.namespacePascal}`);
   lines.push('{');
@@ -357,7 +410,17 @@ function generateServiceFile(mountName: string, operations: Operation[], ctx: Em
     // get a 422 from the API. Only emit the typed AuthenticateWith* wrappers.
     if (!isUnionSplit) {
       lines.push('');
-      const methodCode = generateMethod(svcTypeName, mountName, method, methodStem, op, plan, ctx, resolvedOp);
+      const methodCode = generateMethod(
+        svcTypeName,
+        mountName,
+        method,
+        methodStem,
+        op,
+        plan,
+        ctx,
+        resolvedOp,
+        hasCapturingDeleteAsync,
+      );
       lines.push(methodCode);
 
       if (!(resolvedOp?.urlBuilder ?? false) && method !== methodStem) {
@@ -599,6 +662,7 @@ function generateMethod(
   plan: OperationPlan,
   ctx: EmitterContext,
   resolvedOp?: ResolvedOperation,
+  hasCapturingDeleteAsync = false,
 ): string {
   const lines: string[] = [];
   const isPaginated = plan.isPaginated;
@@ -771,7 +835,17 @@ function generateMethod(
       lines.push('            await this.Client.MakeRawAPIRequest(request, cancellationToken);');
     }
   } else if (isDelete) {
-    lines.push(`            await this.DeleteAsync(${pathExpr}, ${optionsArg}, requestOptions, cancellationToken);`);
+    // See hasCapturingDeleteAsync in generateServiceFile. A null argument is
+    // captured by any two-leading-parameter DeleteAsync in the class; a typed
+    // options argument only by this method itself (no other DeleteAsync can
+    // take this options class, and string parameters don't accept it).
+    const captured = optionsClass
+      ? method === 'DeleteAsync' && op.pathParams.length + 1 === 2
+      : hasCapturingDeleteAsync;
+    const receiver = captured ? 'base' : 'this';
+    lines.push(
+      `            await ${receiver}.DeleteAsync(${pathExpr}, ${optionsArg}, requestOptions, cancellationToken);`,
+    );
   } else if (returnType.startsWith('Task<')) {
     const innerType = returnType.slice(5, -1);
     const helper = httpMethodHelperName(op.httpMethod);

--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -840,7 +840,7 @@ function generateMethod(
     // options argument only by this method itself (no other DeleteAsync can
     // take this options class, and string parameters don't accept it).
     const captured = optionsClass
-      ? method === 'DeleteAsync' && op.pathParams.length + 1 === 2
+      ? method === 'DeleteAsync' && leadingParamCount(op, plan, ctx, resolvedOp) === 2
       : hasCapturingDeleteAsync;
     const receiver = captured ? 'base' : 'this';
     lines.push(

--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -347,18 +347,33 @@ function generateServiceFile(mountName: string, operations: Operation[], ctx: Em
   // null literal, or silent recursion. Those call sites must say `base.`, and
   // only those: StyleCop SA1100 (warnings-as-errors in workos-dotnet) rejects
   // `base.` wherever `this.` already resolves to the same helper.
+  // The scan mirrors the emission loop's name reservation below: a
+  // union-split operation claims its raw method name without emitting it
+  // (suppressing any later operation that resolves to the same name) and
+  // emits typed wrappers instead, whose signatures are path params plus a
+  // required options parameter (see emitWrapperMethod).
   let hasCapturingDeleteAsync = false;
   {
     const seen = new Set<string>();
     for (const op of operations) {
-      const resolvedOp = lookupResolved(op, resolvedLookup);
-      if ((resolvedOp?.wrappers?.length ?? 0) > 0) continue;
       const method = resolveCsMethodName(op, mountName, ctx);
       if (seen.has(method)) continue;
       seen.add(method);
-      if (method !== 'DeleteAsync') continue;
-      hasCapturingDeleteAsync = leadingParamCount(op, planOperation(op), ctx, resolvedOp) === 2;
-      break;
+      const resolvedOp = lookupResolved(op, resolvedLookup);
+      const wrappers = resolvedOp?.wrappers ?? [];
+      if (wrappers.length === 0) {
+        if (method === 'DeleteAsync' && leadingParamCount(op, planOperation(op), ctx, resolvedOp) === 2) {
+          hasCapturingDeleteAsync = true;
+        }
+        continue;
+      }
+      for (const w of wrappers) {
+        const wrapperMethod = appendAsyncSuffix(methodName(w.name));
+        seen.add(wrapperMethod);
+        if (wrapperMethod === 'DeleteAsync' && op.pathParams.length + 1 === 2) {
+          hasCapturingDeleteAsync = true;
+        }
+      }
     }
   }
 

--- a/src/dotnet/wrappers.ts
+++ b/src/dotnet/wrappers.ts
@@ -118,7 +118,13 @@ function emitWrapperMethod(
       `            return await this.${helper}<${responseType}>(${pathExpr}, options, requestOptions, cancellationToken);`,
     );
   } else if (helper === 'DeleteAsync') {
-    lines.push(`            await this.${helper}(${pathExpr}, options, requestOptions, cancellationToken);`);
+    // A wrapper named DeleteAsync with one path parameter has the shape
+    // (string, XOptions, RequestOptions?, CancellationToken), so this call
+    // would bind to the wrapper itself instead of Service.DeleteAsync and
+    // recurse. Only then may the call say `base.` — StyleCop SA1100 rejects
+    // it wherever `this.` already resolves to the helper.
+    const receiver = method === 'DeleteAsync' && op.pathParams.length + 1 === 2 ? 'base' : 'this';
+    lines.push(`            await ${receiver}.${helper}(${pathExpr}, options, requestOptions, cancellationToken);`);
   } else {
     lines.push(`            await this.${helper}<object>(${pathExpr}, options, requestOptions, cancellationToken);`);
   }

--- a/test/dotnet/resources.test.ts
+++ b/test/dotnet/resources.test.ts
@@ -92,6 +92,70 @@ describe('dotnet/resources', () => {
     expect(content).toContain('DeleteAsync');
   });
 
+  it('qualifies delete helper calls with base. when a generated DeleteAsync would capture them', () => {
+    const stringParam = (name: string) => ({
+      name,
+      type: { kind: 'primitive', type: 'string' } as const,
+      required: true,
+    });
+    const deleteOp = (name: string, path: string, pathParams: string[]) => ({
+      name,
+      httpMethod: 'delete' as const,
+      path,
+      pathParams: pathParams.map(stringParam),
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'primitive', type: 'unknown' } as const,
+      errors: [],
+      injectIdempotencyKey: false,
+    });
+
+    const services: Service[] = [
+      {
+        // Bare `delete` op with two path params emits DeleteAsync(string, string, ...),
+        // which hides Service.DeleteAsync from the 4-argument helper calls.
+        name: 'ItContacts',
+        operations: [
+          deleteOp('delete', '/organizations/{organization_id}/it_contacts/{contact_id}', [
+            'organization_id',
+            'contact_id',
+          ]),
+          // Sibling delete in the same class is captured too and must also use base.
+          deleteOp('deleteInvitation', '/organizations/{organization_id}/it_contacts/{contact_id}/invitation', [
+            'organization_id',
+            'contact_id',
+          ]),
+        ],
+      },
+      {
+        // One leading param: DeleteAsync(string, RequestOptions?, CT) cannot take the
+        // 4-argument call, so `this.` still reaches the helper — and `base.` here
+        // would trip StyleCop SA1100.
+        name: 'Widgets',
+        operations: [deleteOp('delete', '/widgets/{id}', ['id'])],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services, models: [] },
+    };
+
+    const files = generateResources(services, ctxWithServices);
+    const itContacts = files.find((f) => f.path.includes('ItContactsService.cs'))!.content;
+    const widgets = files.find((f) => f.path.includes('WidgetsService.cs'))!.content;
+
+    expect(itContacts).toContain(
+      'await base.DeleteAsync($"/organizations/{Uri.EscapeDataString(organizationId)}/it_contacts/{Uri.EscapeDataString(contactId)}", null, requestOptions, cancellationToken);',
+    );
+    expect(itContacts).not.toContain('await this.DeleteAsync(');
+    expect(widgets).toContain(
+      'await this.DeleteAsync($"/widgets/{Uri.EscapeDataString(id)}", null, requestOptions, cancellationToken);',
+    );
+    expect(widgets).not.toContain('await base.DeleteAsync(');
+  });
+
   it('generates options classes for operations with params', () => {
     const models: Model[] = [
       {

--- a/test/dotnet/resources.test.ts
+++ b/test/dotnet/resources.test.ts
@@ -156,6 +156,72 @@ describe('dotnet/resources', () => {
     expect(widgets).not.toContain('await base.DeleteAsync(');
   });
 
+  it('counts a bearer-override parameter when detecting DeleteAsync capture', () => {
+    const models: Model[] = [
+      {
+        name: 'RevokeSessionRequest',
+        fields: [{ name: 'session_id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      },
+    ];
+
+    const services: Service[] = [
+      {
+        name: 'Sessions',
+        operations: [
+          {
+            // Bearer override + typed options and no path params: emits
+            // DeleteAsync(string accessToken, SessionsDeleteOptions options, ...) —
+            // two leading params, so it captures the sibling's 4-argument call.
+            // Its own body uses the inlined WorkOSRequest form (bearer overrides
+            // never reach the helper one-liner).
+            name: 'delete',
+            httpMethod: 'delete' as const,
+            path: '/sessions',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'RevokeSessionRequest' } as const,
+            response: { kind: 'primitive', type: 'unknown' } as const,
+            errors: [],
+            injectIdempotencyKey: false,
+            security: [{ schemeName: 'access_token', scopes: [] }],
+          },
+          {
+            name: 'deleteToken',
+            httpMethod: 'delete' as const,
+            path: '/sessions/tokens/{id}',
+            pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'primitive', type: 'unknown' } as const,
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services, models },
+    };
+
+    const files = generateResources(services, ctxWithServices);
+    const sessions = files.find((f) => f.path.includes('SessionsService.cs'))!.content;
+
+    // The bearer-override delete keeps the inlined request form — no helper
+    // call it could recurse into.
+    expect(sessions).toContain('AccessToken = accessToken,');
+    expect(sessions).not.toContain('this.DeleteAsync("/sessions"');
+    expect(sessions).not.toContain('base.DeleteAsync("/sessions"');
+    // The sibling's null-argument call is captured by the two-leading-parameter
+    // DeleteAsync signature and must be qualified with base.
+    expect(sessions).toContain(
+      'await base.DeleteAsync($"/sessions/tokens/{Uri.EscapeDataString(id)}", null, requestOptions, cancellationToken);',
+    );
+  });
+
   it('generates options classes for operations with params', () => {
     const models: Model[] = [
       {

--- a/test/dotnet/resources.test.ts
+++ b/test/dotnet/resources.test.ts
@@ -222,6 +222,98 @@ describe('dotnet/resources', () => {
     );
   });
 
+  it('mirrors emission-loop name reservation for union-split wrappers named DeleteAsync', () => {
+    const deleteOp = (name: string, path: string, pathParams: string[]) => ({
+      name,
+      httpMethod: 'delete' as const,
+      path,
+      pathParams: pathParams.map((p) => ({
+        name: p,
+        type: { kind: 'primitive', type: 'string' } as const,
+        required: true,
+      })),
+      queryParams: [],
+      headerParams: [],
+      response: { kind: 'primitive', type: 'unknown' } as const,
+      errors: [],
+      injectIdempotencyKey: false,
+    });
+    const deleteWrapper = {
+      name: 'delete',
+      targetVariant: 'RevokeRequest',
+      defaults: {},
+      inferFromClient: [],
+      exposedParams: [],
+    };
+
+    const services: Service[] = [
+      {
+        // The `delete` wrapper claims the DeleteAsync name and emits
+        // DeleteAsync(TokensDeleteOptions, ...) — one leading parameter, so it
+        // captures nothing. The suppressed two-path-param op must NOT be
+        // treated as capturing: `base.` in the sibling would trip SA1100.
+        name: 'Tokens',
+        operations: [
+          deleteOp('revokeAll', '/tokens', []),
+          deleteOp('delete', '/tokens/{group_id}/{token_id}', ['group_id', 'token_id']),
+          deleteOp('deleteThing', '/tokens/things/{id}', ['id']),
+        ],
+      },
+      {
+        // Here the union-split op has one path param, so the `delete` wrapper
+        // emits DeleteAsync(string, GrantsDeleteOptions, ...) — two leading
+        // parameters. It captures the sibling's null-argument call AND its own
+        // helper call, so both must be qualified with base.
+        name: 'Grants',
+        operations: [
+          deleteOp('revokeAll', '/grants/{id}/revoke', ['id']),
+          deleteOp('deleteThing', '/grants/things/{id}', ['id']),
+        ],
+      },
+    ];
+
+    // Resolve every op (real runs do — generateResources groups by the
+    // resolved set when one is present); the `revokeAll` ops are union-split.
+    const resolvedOperations = services.flatMap((service) =>
+      service.operations.map((operation) => ({
+        service,
+        operation,
+        methodName: operation.name,
+        mountOn: service.name,
+        ...(operation.name === 'revokeAll' ? { wrappers: [deleteWrapper] } : {}),
+      })),
+    ) as never[];
+
+    primeEnumAliases([]);
+    const ctxWithServices: EmitterContext = {
+      ...ctx,
+      spec: { ...emptySpec, services, models: [] },
+      resolvedOperations: resolvedOperations as never,
+    };
+
+    const files = generateResources(services, ctxWithServices);
+    const tokens = files.find((f) => f.path.includes('TokensService.cs'))!.content;
+    const grants = files.find((f) => f.path.includes('GrantsService.cs'))!.content;
+
+    // Tokens: wrapper DeleteAsync exists but does not capture; the suppressed
+    // raw op leaves no two-string-param overload behind.
+    expect(tokens).toContain('public async Task DeleteAsync(DeleteOptions options');
+    expect(tokens).not.toContain('DeleteAsync(string groupId');
+    expect(tokens).not.toContain('await base.DeleteAsync(');
+    expect(tokens).toContain(
+      'await this.DeleteAsync($"/tokens/things/{Uri.EscapeDataString(id)}", null, requestOptions, cancellationToken);',
+    );
+
+    // Grants: the capturing wrapper qualifies its own call and the sibling's.
+    expect(grants).toContain(
+      'await base.DeleteAsync($"/grants/{Uri.EscapeDataString(id)}/revoke", options, requestOptions, cancellationToken);',
+    );
+    expect(grants).toContain(
+      'await base.DeleteAsync($"/grants/things/{Uri.EscapeDataString(id)}", null, requestOptions, cancellationToken);',
+    );
+    expect(grants).not.toContain('await this.DeleteAsync(');
+  });
+
   it('generates options classes for operations with params', () => {
     const models: Model[] = [
       {


### PR DESCRIPTION
## Summary

- workos/openapi-spec#109 (spec update adding the organizations `it_contacts` endpoints) broke the dotnet SDK build: the new resource's bare `delete` operation generates `DeleteAsync(string organizationId, string contactId, ...)`, and the emitted body `await this.DeleteAsync(path, null, requestOptions, cancellationToken)` binds to that method instead of the `Service.DeleteAsync` helper — C# discards base-class overloads once any derived candidate is applicable. Result: `CS8625` (`null` into the non-nullable `contactId`), and silent infinite recursion had it compiled.
- The `isDelete` one-liner now emits `base.DeleteAsync(...)`, but only when a generated `DeleteAsync` in the class would actually capture the 4-argument call (method named `DeleteAsync` with exactly two leading parameters). A blanket `this.` → `base.` swap is not an option: workos-dotnet builds with StyleCop warnings-as-errors, and SA1100 rejects `base.` anywhere `this.` already resolves to the same symbol — it would have broken every non-colliding service (~13 files).
- Typed-options delete calls only need `base.` on self-capture (no sibling `DeleteAsync` can accept another method's options class); null-argument calls use the class-wide scan. Generic helper calls (`GetAsync<T>` etc.) are immune — arity mismatch excludes non-generic derived methods.
- Union-split wrappers (`wrappers.ts`) share the helper-call pattern but pass typed options, which existing derived signatures can't capture; left unchanged.

## Verification

- Regenerated workos-dotnet (main) from the openapi-spec PR #109 spec with this emitter: exactly one call site changes (`OrganizationsItContactsService.cs:76` → `base.DeleteAsync`); the other 28 delete call sites keep `this.`.
- `dotnet build` on the regenerated SDK: 0 warnings, 0 errors (previously `CS8625`). `dotnet test`: 567/567 pass, including the generated ItContacts tests.
- Emitter suite: 836/836 pass, plus a new regression test covering capture, sibling capture, and the non-capturing case that must keep `this.`.
