### PR TITLE
feat(go): emit sealed wrappers for discriminated unions

### DIFF
--- a/docs/sdk-architecture/go.md
+++ b/docs/sdk-architecture/go.md
@@ -51,7 +51,8 @@ Go convention preserves full-caps for common acronyms: `ID`, `URL`, `SSO`, `API`
 | `model`                      | `*ModelName` (pointer for nested) |
 | `enum`                       | `EnumType`                        |
 | `nullable`                   | `*T` (pointer)                    |
-| `union`                      | `interface{}`                     |
+| `union` (discriminated)      | `*NameUnion` (see below)          |
+| `union` (untagged)           | `interface{}`                     |
 | `map`                        | `map[string]T`                    |
 | `literal:string`             | `string`                          |
 | `literal:null`               | `interface{}`                     |
@@ -74,6 +75,45 @@ type Organization struct {
 - Optional fields: pointer types with `omitempty`
 - Nested models: always pointers
 - JSON tags: snake_case matching the API wire format
+
+## Discriminated Union Pattern
+
+Go has no sum types, so a discriminated `oneOf` on a model field becomes a
+sealed wrapper in `unions.go`: the discriminator plus one nil-able pointer per
+variant. Each arm decodes into its own struct, so a payload never lands in the
+wrong variant and no variant loses a field the others don't have.
+
+```go
+// APIKeyOwnerUnion is a discriminated union: exactly one variant pointer is set,
+// and Type says which. Use the As* accessors to read a variant safely.
+type APIKeyOwnerUnion struct {
+    Type         APIKeyOwnerUnionType `json:"type"`
+    Organization *APIKeyOwner         `json:"-"`
+    User         *UserAPIKeyOwner     `json:"-"`
+
+    raw json.RawMessage
+}
+
+type APIKeyOwnerUnionType string
+
+const (
+    APIKeyOwnerUnionTypeOrganization APIKeyOwnerUnionType = "organization"
+    APIKeyOwnerUnionTypeUser         APIKeyOwnerUnionType = "user"
+)
+
+if user, ok := key.Owner.AsUser(); ok {
+    fmt.Println(user.OrganizationID)
+}
+```
+
+- Named `{FirstVariant}Union`; the discriminator type is `{Wrapper}{Field}`
+- `UnmarshalJSON` switches on the discriminator; `MarshalJSON` encodes the set variant
+- Unexported `raw` replays an unrecognized discriminator value, so a variant this
+  SDK version predates round-trips instead of being dropped
+- Single-variant unions get a wrapper too, so adding a variant later is additive
+- **Model fields only.** Per-operation error unions are discriminated as well, but
+  the parser names every leading variant after the status code (dozens of unrelated
+  unions all want `Error400`), so those keep collapsing to their first variant
 
 ## Enum Pattern
 
@@ -331,6 +371,7 @@ workos-go/
 +-- client.go              // Client struct, HTTP request execution, retry logic
 +-- errors.go              // Error types
 +-- pagination.go          // Iterator[T]
++-- unions.go              // Sealed wrappers for discriminated unions
 +-- {service}.go           // Models, enums, params, service client for each service
 +-- {service}_test.go      // Tests for each service
 +-- testdata/

--- a/src/go/index.ts
+++ b/src/go/index.ts
@@ -10,6 +10,7 @@ import type {
 } from '@workos/oagen';
 
 import { generateModels } from './models.js';
+import { emittableModelPredicate, generateUnions, hasUnionWrapper, prepareGoUnions } from './unions.js';
 import { enrichModelsFromSpec, getSyntheticEnums } from '../shared/model-utils.js';
 import { flattenDiscriminatedUnionFields } from '../shared/union-flatten.js';
 import { generateEnums } from './enums.js';
@@ -53,11 +54,15 @@ export const goEmitter: Emitter = {
       }
       return m;
     });
-    // Go has no sum types: a discriminated-union field (e.g. ApiKey.owner)
-    // renders as its first variant, dropping fields that only exist on later
-    // variants (organization_id on the user owner). Flatten such unions into a
-    // single superset struct so every variant field survives.
-    return ensureTrailingNewlines(generateModels(flattenDiscriminatedUnionFields(goModels), ctx));
+    // Resolve the discriminated-union wrappers before anything maps a TypeRef:
+    // the flatten opt-out below and the type map both read that registry, so
+    // they can never disagree about which unions have a wrapper type.
+    const unions = prepareGoUnions(goModels, ctx.spec.enums, emittableModelPredicate(goModels, ctx));
+    // A wrapped union (e.g. ApiKey.owner) keeps its union TypeRef so unions.go
+    // can see the variants. Anything left still flattens into a superset struct
+    // — without that, fields present only on a later variant would be dropped.
+    const flatModels = flattenDiscriminatedUnionFields(goModels, { skipUnion: hasUnionWrapper });
+    return ensureTrailingNewlines([...generateModels(flatModels, ctx), ...generateUnions(unions, ctx)]);
   },
 
   generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {

--- a/src/go/type-map.ts
+++ b/src/go/type-map.ts
@@ -1,6 +1,7 @@
 import type { TypeRef, PrimitiveType, UnionType } from '@workos/oagen';
 import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
 import { className } from './naming.js';
+import { unionWrapperName } from './unions.js';
 
 /**
  * Map an IR TypeRef to a Go type string.
@@ -80,11 +81,19 @@ function joinUnionVariants(_ref: UnionType, variants: string[]): string {
   if (_ref.compositionKind === 'allOf') {
     return variants[0] ?? 'interface{}';
   }
+  // A discriminated union of named variants becomes a sealed wrapper struct
+  // (see unions.ts). Checked before the single-variant collapse below so a
+  // one-member union still gets the wrapper, which makes adding a second
+  // member later a purely additive change to the generated SDK.
+  const wrapper = unionWrapperName(_ref);
+  if (wrapper) return `*${wrapper}`;
+
   const unique = [...new Set(variants)];
   if (unique.length === 1) return unique[0];
-  // Discriminated unions: Go has no sum types, so widen to the discriminator-
-  // resolver type when one is registered downstream (see resolveDiscriminatedUnionType).
-  // Fall back to interface{} for non-discriminated heterogeneous unions.
+  // Discriminated unions no wrapper can represent — an empty mapping, or a
+  // variant that isn't a named model. Widen to the first model variant, which
+  // at least keeps one arm typed. Non-discriminated heterogeneous unions fall
+  // through to interface{}.
   if (_ref.discriminator && _ref.discriminator.mapping) {
     const resolverName = unionResolverName(_ref);
     if (resolverName) return resolverName;
@@ -93,14 +102,11 @@ function joinUnionVariants(_ref: UnionType, variants: string[]): string {
 }
 
 /**
- * Pick a stable type name for a discriminated union's runtime resolver. Today
- * we emit no resolver struct, so we treat the union's first model variant as
- * the public type — matching the pre-discriminator behavior where Go just
- * referenced one variant directly. The Owner field stays typed, callers
- * can still inspect Type to detect the user variant (data loss on
- * non-overlapping fields like organization_id is documented in the SDK
- * compat report rather than fixed in the emitter — Go callers who need the
- * user-only fields can json.Unmarshal the raw payload manually).
+ * Fallback public type for a discriminated union that {@link unionWrapperName}
+ * cannot wrap — the discriminator resolved but carries no mapping, or a variant
+ * isn't a named model. Treat the union's first model variant as the public
+ * type. Fields that exist only on later variants are lost; callers who need
+ * them can json.Unmarshal the raw payload manually.
  */
 function unionResolverName(ref: UnionType): string | null {
   for (const v of ref.variants) {

--- a/src/go/unions.ts
+++ b/src/go/unions.ts
@@ -1,0 +1,378 @@
+import type { EmitterContext, Enum, GeneratedFile, Model, TypeRef, UnionType } from '@workos/oagen';
+import { className, fieldName } from './naming.js';
+import { isModelInScope, isScopedRun } from '../shared/resolved-ops.js';
+import { readPriorFile, parseFlatGoBlocks } from './flat-merge.js';
+
+/**
+ * Go has no sum types, so a discriminated `oneOf` on a model field is emitted
+ * as a *sealed wrapper*: a struct carrying the discriminator value plus one
+ * nil-able pointer per variant, with an `UnmarshalJSON` that switches on the
+ * discriminator and decodes the payload into the matching field.
+ *
+ * The alternative — rendering the union as its first variant — silently drops
+ * every field that only exists on a later variant, and cannot represent a
+ * shared field whose type differs across variants (`value` as
+ * `boolean | string | number` keyed on `value_type`). The wrapper keeps each
+ * variant in its own typed field, so no variant loses data and no payload is
+ * decoded into the wrong Go type.
+ *
+ * Scope is deliberately **model fields only**. Per-operation error unions
+ * (`Error400` and friends) are also discriminated, but the parser names every
+ * one of their leading variants after the status code, so dozens of unrelated
+ * unions would claim a single wrapper name. Naming those needs operation
+ * context the IR doesn't attach to a `TypeRef`; they keep collapsing to their
+ * first variant exactly as before.
+ *
+ * {@link prepareGoUnions} resolves the wrapper set once per run and every other
+ * entry point reads that registry, so the type map, the flatten opt-out, and
+ * the rendered file can never disagree about which unions have a wrapper.
+ */
+
+/** One variant arm of a discriminated union wrapper. */
+export interface UnionArm {
+  /** Discriminator value on the wire that selects this arm. */
+  value: string;
+  /** IR model name of the variant payload. */
+  modelName: string;
+  /** Exported Go field / accessor suffix, derived from the wire value. */
+  field: string;
+  /** Go type of the variant payload. */
+  goType: string;
+  /** Name of the generated discriminator constant for this arm. */
+  constName: string;
+}
+
+/** A discriminated union wrapper to emit. */
+export interface GoUnion {
+  /** Go type name of the wrapper struct. */
+  name: string;
+  /** Wire name of the discriminator property. */
+  property: string;
+  /** Exported Go field name holding the discriminator. */
+  discriminatorField: string;
+  /** Go named-string type enumerating the discriminator values. */
+  discriminatorType: string;
+  arms: UnionArm[];
+}
+
+/**
+ * Wrappers resolved for the current run, keyed by {@link unionSignature}.
+ * Reset by {@link prepareGoUnions}; empty until then, so any entry point that
+ * runs without it degrades to the pre-wrapper behavior rather than emitting a
+ * reference to a type that was never generated. Mirrors the per-run registry
+ * the Rust emitter keeps for its synthesised oneOf enums.
+ */
+let registry = new Map<string, GoUnion>();
+
+/**
+ * Whether a union has the shape a wrapper can represent. Necessary but not
+ * sufficient — {@link prepareGoUnions} also has to be able to name it
+ * unambiguously. Use {@link hasUnionWrapper} to ask whether one was actually
+ * generated.
+ */
+export function isWrappableDiscriminatedUnion(ref: UnionType): boolean {
+  // allOf is inheritance, not an exclusive union — it keeps collapsing to its
+  // first member.
+  if (ref.compositionKind === 'allOf') return false;
+  const disc = ref.discriminator;
+  if (!disc || Object.keys(disc.mapping).length === 0) return false;
+  if (ref.variants.length === 0) return false;
+  // Every variant must be a named model: the wrapper gives each arm a typed
+  // field, which requires a struct to point at. Untagged primitive unions
+  // carry no discriminator and never reach here, but guard anyway.
+  return ref.variants.every((v) => v.kind === 'model');
+}
+
+/**
+ * Name a wrapper would take. Single-variant unions get one too: emitting the
+ * wrapper up front makes adding a second variant later a purely additive change
+ * to the generated SDK rather than a type replacement.
+ */
+function baseWrapperName(ref: UnionType): string | null {
+  const first = ref.variants.find((v) => v.kind === 'model');
+  if (!first || first.kind !== 'model') return null;
+  return `${className(first.name)}Union`;
+}
+
+/** Go type name of a union's wrapper, or null when this run generated none. */
+export function unionWrapperName(ref: UnionType): string | null {
+  if (!isWrappableDiscriminatedUnion(ref)) return null;
+  return registry.get(unionSignature(ref))?.name ?? null;
+}
+
+/** Whether this union is emitted as a wrapper (so the flatten must skip it). */
+export function hasUnionWrapper(ref: UnionType): boolean {
+  return unionWrapperName(ref) !== null;
+}
+
+/** Stable identity of a union: two refs with the same signature share a wrapper. */
+function unionSignature(ref: UnionType): string {
+  return JSON.stringify({
+    property: ref.discriminator?.property ?? null,
+    mapping: ref.discriminator?.mapping ?? null,
+    variants: ref.variants.map((v) => (v.kind === 'model' ? v.name : v.kind)),
+  });
+}
+
+/** Visit every union node reachable from a TypeRef. */
+function forEachUnion(ref: TypeRef, visit: (union: UnionType) => void): void {
+  switch (ref.kind) {
+    case 'union':
+      visit(ref);
+      for (const v of ref.variants) forEachUnion(v, visit);
+      break;
+    case 'array':
+      forEachUnion(ref.items, visit);
+      break;
+    case 'nullable':
+      forEachUnion(ref.inner, visit);
+      break;
+    case 'map':
+      if (ref.keyType) forEachUnion(ref.keyType, visit);
+      forEachUnion(ref.valueType, visit);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Resolve the wrapper set for this run and return it in emit order. Call once,
+ * before anything maps a TypeRef, so every consumer sees the same registry.
+ *
+ * `emittableModel` gates which variant models an arm may point at: in a scoped
+ * run a brand-new out-of-scope model is never written to `models.go`, so an arm
+ * referencing it would not compile.
+ */
+export function prepareGoUnions(
+  models: Model[],
+  enums: Enum[],
+  emittableModel: (modelName: string) => boolean,
+): GoUnion[] {
+  registry = new Map();
+
+  // Candidate unions, deduplicated by signature and in first-seen order.
+  const candidates = new Map<string, UnionType>();
+  for (const model of models) {
+    for (const field of model.fields) {
+      forEachUnion(field.type, (union) => {
+        if (!isWrappableDiscriminatedUnion(union)) return;
+        const signature = unionSignature(union);
+        if (!candidates.has(signature)) candidates.set(signature, union);
+      });
+    }
+  }
+  if (candidates.size === 0) return [];
+
+  // A wrapper name must be unambiguous. Two structurally different unions whose
+  // leading variant shares a name (the `Error400` shape) cannot both own it, and
+  // picking a winner would silently give the loser the wrong variants — so
+  // neither is wrapped and both keep the first-variant collapse.
+  const claimants = new Map<string, number>();
+  for (const union of candidates.values()) {
+    const base = baseWrapperName(union);
+    if (base) claimants.set(base, (claimants.get(base) ?? 0) + 1);
+  }
+
+  // The wrapper is a new top-level declaration in the same flat package, so it
+  // must not collide with a model or enum that is already declared there.
+  const declared = new Set<string>([...models.map((m) => className(m.name)), ...enums.map((e) => className(e.name))]);
+
+  for (const [signature, union] of candidates) {
+    const base = baseWrapperName(union);
+    if (!base) continue;
+    if (claimants.get(base) !== 1) {
+      console.warn(
+        `[oagen:go] ${claimants.get(base)} distinct discriminated unions would all be named "${base}"; ` +
+          'emitting none of them as a wrapper. Disambiguate by renaming the leading variant of each in the spec.',
+      );
+      continue;
+    }
+    if (declared.has(base)) {
+      console.warn(`[oagen:go] discriminated union wrapper "${base}" collides with an existing type; skipping it.`);
+      continue;
+    }
+    registry.set(signature, buildUnion(base, union, emittableModel));
+  }
+
+  return [...registry.values()];
+}
+
+function buildUnion(name: string, union: UnionType, emittableModel: (modelName: string) => boolean): GoUnion {
+  const disc = union.discriminator!;
+  const discriminatorField = fieldName(disc.property);
+  const discriminatorType = `${name}${discriminatorField}`;
+
+  // Variant models the union declares, so an explicit `mapping:` entry that
+  // points outside the union can't smuggle in an unrelated type.
+  const variantNames = new Set(union.variants.flatMap((v) => (v.kind === 'model' ? [v.name] : [])));
+
+  const taken = new Set<string>([discriminatorField]);
+  const arms: UnionArm[] = [];
+  for (const [value, modelName] of Object.entries(disc.mapping)) {
+    if (!variantNames.has(modelName)) continue;
+    if (!emittableModel(modelName)) continue;
+
+    let field = className(value);
+    if (!field) continue;
+    if (taken.has(field)) {
+      let n = 2;
+      while (taken.has(`${field}${n}`)) n++;
+      field = `${field}${n}`;
+    }
+    taken.add(field);
+
+    arms.push({
+      value,
+      modelName,
+      field,
+      goType: className(modelName),
+      constName: `${discriminatorType}${field}`,
+    });
+  }
+
+  return { name, property: disc.property, discriminatorField, discriminatorType, arms };
+}
+
+/** Backtick, kept out of the template literals that build struct tags. */
+const TICK = '`';
+
+function renderUnion(u: GoUnion): string {
+  const l: string[] = [];
+  const { name, discriminatorField: df, discriminatorType: dt } = u;
+
+  l.push(`// ${name} is a discriminated union: exactly one variant pointer is set,`);
+  l.push(`// and ${df} says which. Use the As* accessors to read a variant safely.`);
+  l.push(`type ${name} struct {`);
+  l.push(`\t// ${df} identifies which variant this union holds.`);
+  l.push(`\t${df} ${dt} ${TICK}json:"${u.property}"${TICK}`);
+  for (const arm of u.arms) {
+    l.push(`\t// ${arm.field} is set when ${df} is ${arm.constName}.`);
+    l.push(`\t${arm.field} *${arm.goType} ${TICK}json:"-"${TICK}`);
+  }
+  l.push('');
+  l.push('\t// raw retains the payload as received so an unrecognized discriminator');
+  l.push('\t// value survives an unmarshal/marshal round trip instead of being dropped.');
+  l.push('\traw json.RawMessage');
+  l.push('}');
+  l.push('');
+
+  l.push(`// ${dt} identifies the variant held by ${articleFor(name)} ${name}.`);
+  l.push(`type ${dt} string`);
+  if (u.arms.length > 0) {
+    l.push('');
+    l.push('const (');
+    for (const arm of u.arms) {
+      l.push(`\t// ${arm.constName} selects the ${arm.goType} variant.`);
+      l.push(`\t${arm.constName} ${dt} = "${escapeGoString(arm.value)}"`);
+    }
+    l.push(')');
+  }
+
+  for (const arm of u.arms) {
+    l.push('');
+    l.push(`// As${arm.field} returns the ${arm.goType} variant and reports whether it is set.`);
+    l.push(`func (u ${name}) As${arm.field}() (*${arm.goType}, bool) {`);
+    l.push(`\treturn u.${arm.field}, u.${arm.field} != nil`);
+    l.push('}');
+  }
+
+  l.push('');
+  l.push(`// UnmarshalJSON decodes the payload into the variant selected by the`);
+  l.push(`// "${escapeGoString(u.property)}" discriminator. An unrecognized value leaves every`);
+  l.push(`// variant nil; ${df} still reports what the wire said.`);
+  l.push(`func (u *${name}) UnmarshalJSON(data []byte) error {`);
+  l.push('\tvar discriminator struct {');
+  l.push(`\t\tValue ${dt} ${TICK}json:"${u.property}"${TICK}`);
+  l.push('\t}');
+  l.push('\tif err := json.Unmarshal(data, &discriminator); err != nil {');
+  l.push('\t\treturn err');
+  l.push('\t}');
+  l.push('');
+  l.push(`\t*u = ${name}{${df}: discriminator.Value, raw: append(json.RawMessage(nil), data...)}`);
+  if (u.arms.length > 0) {
+    l.push('');
+    l.push(`\tswitch discriminator.Value {`);
+    for (const arm of u.arms) {
+      l.push(`\tcase ${arm.constName}:`);
+      l.push(`\t\tvar v ${arm.goType}`);
+      l.push('\t\tif err := json.Unmarshal(data, &v); err != nil {');
+      l.push('\t\t\treturn err');
+      l.push('\t\t}');
+      l.push(`\t\tu.${arm.field} = &v`);
+    }
+    l.push('\t}');
+  }
+  l.push('');
+  l.push('\treturn nil');
+  l.push('}');
+
+  l.push('');
+  l.push(`// MarshalJSON encodes the variant selected by ${df}.`);
+  l.push(`func (u ${name}) MarshalJSON() ([]byte, error) {`);
+  if (u.arms.length > 0) {
+    l.push(`\tswitch u.${df} {`);
+    for (const arm of u.arms) {
+      l.push(`\tcase ${arm.constName}:`);
+      l.push(`\t\tif u.${arm.field} != nil {`);
+      l.push(`\t\t\treturn json.Marshal(u.${arm.field})`);
+      l.push('\t\t}');
+    }
+    l.push('\t}');
+    l.push('');
+  }
+  l.push('\t// No variant set: replay the original payload when we have one, so a');
+  l.push('\t// value produced by UnmarshalJSON always round trips.');
+  l.push('\tif len(u.raw) > 0 {');
+  l.push('\t\treturn u.raw, nil');
+  l.push('\t}');
+  l.push(`\tif u.${df} == "" {`);
+  l.push('\t\treturn []byte("null"), nil');
+  l.push('\t}');
+  l.push(`\treturn json.Marshal(map[string]string{"${escapeGoString(u.property)}": string(u.${df})})`);
+  l.push('}');
+
+  return l.join('\n');
+}
+
+/** "an" before a vowel-initial type name, "a" otherwise. */
+function articleFor(name: string): string {
+  return /^[AEIOU]/.test(name) ? 'an' : 'a';
+}
+
+/** Escape a spec-supplied string for embedding in a Go interpreted string literal. */
+function escapeGoString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+}
+
+/** True when a model will exist in `models.go` after this run. */
+export function emittableModelPredicate(models: Model[], ctx: EmitterContext): (modelName: string) => boolean {
+  // Mirror models.ts: in a scoped run only models that are in scope (emitted
+  // fresh) or already on disk (left untouched) exist after the run.
+  if (!isScopedRun(ctx)) {
+    const known = new Set(models.map((m) => m.name));
+    return (name) => known.has(name);
+  }
+  const prior = new Set(parseFlatGoBlocks(readPriorFile('models.go', ctx) ?? '').blocks.flatMap((b) => b.names));
+  return (name) => isModelInScope(name, ctx) || prior.has(className(name));
+}
+
+/**
+ * Render `unions.go` from the wrappers {@link prepareGoUnions} resolved.
+ * Returns no file when this run produced none.
+ */
+export function generateUnions(unions: GoUnion[], ctx: EmitterContext): GeneratedFile[] {
+  if (unions.length === 0) return [];
+
+  const lines: string[] = [];
+  lines.push(`package ${ctx.namespace}`);
+  lines.push('');
+  lines.push('import "encoding/json"');
+  lines.push('');
+  for (const u of unions) {
+    lines.push(renderUnion(u));
+    lines.push('');
+  }
+
+  return [{ path: 'unions.go', content: lines.join('\n'), overwriteExisting: true }];
+}

--- a/src/shared/union-flatten.ts
+++ b/src/shared/union-flatten.ts
@@ -1,5 +1,11 @@
 import type { Model, Field, TypeRef, UnionType } from '@workos/oagen';
 
+/** Options for {@link flattenDiscriminatedUnionFields}. */
+export interface FlattenOptions {
+  /** Return true to leave a union un-flattened (the caller emits it itself). */
+  skipUnion?: (union: UnionType) => boolean;
+}
+
 /**
  * Flatten field-level discriminated unions into a single superset model for
  * the flat-emit languages (Go, Kotlin, Node) that have no native sum type.
@@ -26,8 +32,14 @@ import type { Model, Field, TypeRef, UnionType } from '@workos/oagen';
  * Returns a new models array; the input models are not mutated. Union-emitting
  * languages (Python, PHP, Rust, Ruby, .NET) must NOT call this — they emit a
  * real discriminated union and lose nothing.
+ *
+ * `options.skipUnion` opts individual unions out of the flatten so the caller
+ * can emit a real union for them instead. Go uses this for the unions it emits
+ * as sealed wrappers; those keep their `union` TypeRef so the wrapper emitter
+ * can still see the variants. Callers that pass nothing get the flatten for
+ * every discriminated union, unchanged.
  */
-export function flattenDiscriminatedUnionFields(models: Model[]): Model[] {
+export function flattenDiscriminatedUnionFields(models: Model[], options: FlattenOptions = {}): Model[] {
   const byName = new Map(models.map((m) => [m.name, m]));
   // Canonical (first-variant) model name → its merged superset field list.
   const mergedFieldsByCanonical = new Map<string, Field[]>();
@@ -39,6 +51,8 @@ export function flattenDiscriminatedUnionFields(models: Model[]): Model[] {
    */
   function planUnion(union: UnionType): string | null {
     if (!union.discriminator) return null;
+    // The caller emits this one as a real union; leave the TypeRef intact.
+    if (options.skipUnion?.(union)) return null;
 
     const variantNames = union.variants.map((v) => (v.kind === 'model' ? v.name : null));
     // Require that *every* variant is a model ref (the inline-object oneOf

--- a/test/go/unions.test.ts
+++ b/test/go/unions.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect } from 'vitest';
+import type { ApiSpec, EmitterContext, Model, TypeRef, UnionType } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { goEmitter } from '../../src/index.js';
+import {
+  emittableModelPredicate,
+  hasUnionWrapper,
+  isWrappableDiscriminatedUnion,
+  prepareGoUnions,
+  unionWrapperName,
+} from '../../src/go/unions.js';
+import { mapTypeRef } from '../../src/go/type-map.js';
+
+/**
+ * A `value` field whose type differs per variant (`boolean | string | number`,
+ * keyed on `value_type`). The flat-superset flatten cannot represent this — it
+ * throws — so it is the shape that forces a real wrapper.
+ */
+function flagValueUnion(): UnionType {
+  return {
+    kind: 'union',
+    compositionKind: 'oneOf',
+    discriminator: {
+      property: 'value_type',
+      mapping: { boolean: 'FlagValue', string: 'StringFlagValue', number: 'NumberFlagValue' },
+    },
+    variants: [
+      { kind: 'model', name: 'FlagValue' },
+      { kind: 'model', name: 'StringFlagValue' },
+      { kind: 'model', name: 'NumberFlagValue' },
+    ],
+  };
+}
+
+/** A discriminated oneOf with exactly one member. */
+function singleMemberUnion(): UnionType {
+  return {
+    kind: 'union',
+    compositionKind: 'oneOf',
+    discriminator: { property: 'type', mapping: { organization: 'SettingTarget' } },
+    variants: [{ kind: 'model', name: 'SettingTarget' }],
+  };
+}
+
+function variantModels(): Model[] {
+  return [
+    {
+      name: 'FlagValue',
+      fields: [
+        { name: 'value_type', type: { kind: 'literal', value: 'boolean' }, required: true },
+        { name: 'value', type: { kind: 'primitive', type: 'boolean' }, required: true },
+      ],
+    },
+    {
+      name: 'StringFlagValue',
+      fields: [
+        { name: 'value_type', type: { kind: 'literal', value: 'string' }, required: true },
+        { name: 'value', type: { kind: 'primitive', type: 'string' }, required: true },
+      ],
+    },
+    {
+      name: 'NumberFlagValue',
+      fields: [
+        { name: 'value_type', type: { kind: 'literal', value: 'number' }, required: true },
+        { name: 'value', type: { kind: 'primitive', type: 'number' }, required: true },
+      ],
+    },
+    {
+      name: 'SettingTarget',
+      fields: [
+        { name: 'type', type: { kind: 'literal', value: 'organization' }, required: true },
+        { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+      ],
+    },
+  ];
+}
+
+function modelsWith(fieldType: TypeRef, extra: Model[] = variantModels()): Model[] {
+  return [{ name: 'FeatureFlag', fields: [{ name: 'value', type: fieldType, required: true }] }, ...extra];
+}
+
+function contextFor(models: Model[], overrides: Partial<EmitterContext> = {}): EmitterContext {
+  const spec: ApiSpec = {
+    name: 'Test',
+    version: '1.0.0',
+    baseUrl: '',
+    services: [],
+    models,
+    enums: [],
+    sdk: defaultSdkBehavior(),
+  };
+  return { namespace: 'workos', namespacePascal: 'WorkOS', spec, ...overrides };
+}
+
+/** Run the emitter end to end and return the generated files by path. */
+function emit(models: Model[], overrides: Partial<EmitterContext> = {}): Map<string, string> {
+  const ctx = contextFor(models, overrides);
+  return new Map(goEmitter.generateModels(models, ctx).map((f) => [f.path, f.content]));
+}
+
+/** Prime the per-run registry the way the emitter does, then return the names. */
+function prime(models: Model[]): string[] {
+  const ctx = contextFor(models);
+  return prepareGoUnions(models, ctx.spec.enums, emittableModelPredicate(models, ctx)).map((u) => u.name);
+}
+
+describe('go/unions — wrappable detection', () => {
+  it('accepts a discriminated oneOf of named variants', () => {
+    expect(isWrappableDiscriminatedUnion(flagValueUnion())).toBe(true);
+    prime(modelsWith(flagValueUnion()));
+    expect(unionWrapperName(flagValueUnion())).toBe('FlagValueUnion');
+  });
+
+  it('accepts a single-member discriminated oneOf', () => {
+    expect(isWrappableDiscriminatedUnion(singleMemberUnion())).toBe(true);
+    prime(modelsWith(singleMemberUnion()));
+    expect(unionWrapperName(singleMemberUnion())).toBe('SettingTargetUnion');
+  });
+
+  it('rejects a union with no discriminator', () => {
+    const union: UnionType = {
+      kind: 'union',
+      compositionKind: 'oneOf',
+      variants: [
+        { kind: 'primitive', type: 'string' },
+        { kind: 'primitive', type: 'boolean' },
+      ],
+    };
+    expect(isWrappableDiscriminatedUnion(union)).toBe(false);
+    expect(unionWrapperName(union)).toBeNull();
+    expect(hasUnionWrapper(union)).toBe(false);
+  });
+
+  it('reports hasUnionWrapper only for unions this run actually wrapped', () => {
+    // This is the flatten opt-out: a union that shape-qualifies but got no
+    // wrapper must still be flattened, or its later-variant fields vanish.
+    prime([]);
+    expect(isWrappableDiscriminatedUnion(flagValueUnion())).toBe(true);
+    expect(hasUnionWrapper(flagValueUnion())).toBe(false);
+
+    prime(modelsWith(flagValueUnion()));
+    expect(hasUnionWrapper(flagValueUnion())).toBe(true);
+  });
+
+  it('rejects an allOf composition', () => {
+    const union = { ...flagValueUnion(), compositionKind: 'allOf' as const };
+    expect(isWrappableDiscriminatedUnion(union)).toBe(false);
+  });
+
+  it('rejects a discriminator with an empty mapping', () => {
+    const union: UnionType = { ...flagValueUnion(), discriminator: { property: 'value_type', mapping: {} } };
+    expect(isWrappableDiscriminatedUnion(union)).toBe(false);
+  });
+
+  it('rejects a union whose variants are not all named models', () => {
+    const union: UnionType = {
+      ...flagValueUnion(),
+      variants: [
+        { kind: 'model', name: 'FlagValue' },
+        { kind: 'primitive', type: 'string' },
+      ],
+    };
+    expect(isWrappableDiscriminatedUnion(union)).toBe(false);
+  });
+});
+
+describe('go/type-map — union references', () => {
+  it('points a discriminated-union field at the wrapper', () => {
+    prime(modelsWith(flagValueUnion()));
+    expect(mapTypeRef(flagValueUnion())).toBe('*FlagValueUnion');
+  });
+
+  it('points a single-member discriminated union at the wrapper too', () => {
+    // Not collapsed to the lone variant: adding a second member later must be
+    // additive rather than a type replacement.
+    prime(modelsWith(singleMemberUnion()));
+    expect(mapTypeRef(singleMemberUnion())).toBe('*SettingTargetUnion');
+  });
+
+  it('leaves a non-discriminated heterogeneous union as interface{}', () => {
+    const union: UnionType = {
+      kind: 'union',
+      compositionKind: 'oneOf',
+      variants: [
+        { kind: 'primitive', type: 'string' },
+        { kind: 'primitive', type: 'boolean' },
+      ],
+    };
+    expect(mapTypeRef(union)).toBe('interface{}');
+  });
+
+  it('falls back to the first model variant when the mapping is empty', () => {
+    const union: UnionType = { ...flagValueUnion(), discriminator: { property: 'value_type', mapping: {} } };
+    prime(modelsWith(union));
+    expect(mapTypeRef(union)).toBe('*FlagValue');
+  });
+
+  it('falls back to the first model variant when no wrapper was generated', () => {
+    // An emitter entry point that runs without prepareGoUnions must not name a
+    // wrapper type that was never written to unions.go.
+    prime([]);
+    expect(mapTypeRef(flagValueUnion())).toBe('*FlagValue');
+  });
+});
+
+describe('go/unions — emitted wrapper', () => {
+  it('emits a wrapper instead of throwing when a shared field conflicts across variants', () => {
+    // `value` is boolean | string | number — the flat-superset flatten rejects
+    // this outright, so reaching a wrapper at all is the regression guard.
+    const files = emit(modelsWith(flagValueUnion()));
+    expect(files.has('unions.go')).toBe(true);
+    expect(files.get('models.go')).toContain('Value *FlagValueUnion `json:"value"`');
+  });
+
+  it('gives every variant its own typed field', () => {
+    const go = emit(modelsWith(flagValueUnion())).get('unions.go')!;
+    expect(go).toContain('type FlagValueUnion struct {');
+    expect(go).toContain('ValueType FlagValueUnionValueType `json:"value_type"`');
+    expect(go).toContain('Boolean *FlagValue `json:"-"`');
+    expect(go).toContain('String *StringFlagValue `json:"-"`');
+    expect(go).toContain('Number *NumberFlagValue `json:"-"`');
+  });
+
+  it('emits discriminator constants for every mapped value', () => {
+    const go = emit(modelsWith(flagValueUnion())).get('unions.go')!;
+    expect(go).toContain('type FlagValueUnionValueType string');
+    expect(go).toContain('FlagValueUnionValueTypeBoolean FlagValueUnionValueType = "boolean"');
+    expect(go).toContain('FlagValueUnionValueTypeString FlagValueUnionValueType = "string"');
+    expect(go).toContain('FlagValueUnionValueTypeNumber FlagValueUnionValueType = "number"');
+  });
+
+  it('emits a typed accessor per variant', () => {
+    const go = emit(modelsWith(flagValueUnion())).get('unions.go')!;
+    expect(go).toContain('func (u FlagValueUnion) AsBoolean() (*FlagValue, bool) {');
+    expect(go).toContain('func (u FlagValueUnion) AsString() (*StringFlagValue, bool) {');
+    expect(go).toContain('func (u FlagValueUnion) AsNumber() (*NumberFlagValue, bool) {');
+  });
+
+  it('dispatches UnmarshalJSON on the discriminator', () => {
+    const go = emit(modelsWith(flagValueUnion())).get('unions.go')!;
+    expect(go).toContain('func (u *FlagValueUnion) UnmarshalJSON(data []byte) error {');
+    expect(go).toContain('Value FlagValueUnionValueType `json:"value_type"`');
+    expect(go).toContain('switch discriminator.Value {');
+    // Each arm decodes into its own variant struct, so a string payload can
+    // never be decoded into the boolean variant.
+    expect(go).toContain('case FlagValueUnionValueTypeString:\n\t\tvar v StringFlagValue');
+    expect(go).toContain('case FlagValueUnionValueTypeNumber:\n\t\tvar v NumberFlagValue');
+  });
+
+  it('emits a MarshalJSON that encodes the selected variant', () => {
+    const go = emit(modelsWith(flagValueUnion())).get('unions.go')!;
+    expect(go).toContain('func (u FlagValueUnion) MarshalJSON() ([]byte, error) {');
+    expect(go).toContain('return json.Marshal(u.String)');
+    // An unrecognized discriminator replays the original payload rather than
+    // silently dropping it.
+    expect(go).toContain('if len(u.raw) > 0 {');
+  });
+
+  it('imports encoding/json exactly once', () => {
+    const go = emit(modelsWith(flagValueUnion())).get('unions.go')!;
+    expect(go.match(/import "encoding\/json"/g)).toHaveLength(1);
+    expect(go.startsWith('package workos\n')).toBe(true);
+  });
+
+  it('emits the wrapper shape for a single-member union', () => {
+    const go = emit(modelsWith(singleMemberUnion())).get('unions.go')!;
+    expect(go).toContain('type SettingTargetUnion struct {');
+    expect(go).toContain('Organization *SettingTarget `json:"-"`');
+    expect(go).toContain('SettingTargetUnionTypeOrganization SettingTargetUnionType = "organization"');
+    expect(go).toContain('func (u SettingTargetUnion) AsOrganization() (*SettingTarget, bool) {');
+    expect(go).toContain('func (u *SettingTargetUnion) UnmarshalJSON(data []byte) error {');
+  });
+
+  it('still emits every variant model as its own struct', () => {
+    const models = emit(modelsWith(flagValueUnion())).get('models.go')!;
+    expect(models).toContain('type FlagValue struct {');
+    expect(models).toContain('type StringFlagValue struct {');
+    expect(models).toContain('type NumberFlagValue struct {');
+    // The variant-specific field types survive — the whole point of the wrapper.
+    expect(models).toContain('Value bool `json:"value"`');
+    expect(models).toContain('Value string `json:"value"`');
+    expect(models).toContain('Value float64 `json:"value"`');
+  });
+
+  it('emits no unions.go when the spec has no discriminated unions', () => {
+    const files = emit([
+      { name: 'Organization', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+    ]);
+    expect(files.has('unions.go')).toBe(false);
+    expect(files.has('models.go')).toBe(true);
+  });
+});
+
+describe('go/unions — collection', () => {
+  it('deduplicates a union referenced from several fields', () => {
+    const models: Model[] = [
+      { name: 'A', fields: [{ name: 'value', type: flagValueUnion(), required: true }] },
+      { name: 'B', fields: [{ name: 'value', type: flagValueUnion(), required: true }] },
+      ...variantModels(),
+    ];
+    expect(prime(models)).toEqual(['FlagValueUnion']);
+  });
+
+  it('finds unions nested in arrays and nullables', () => {
+    const nested: TypeRef = { kind: 'array', items: { kind: 'nullable', inner: flagValueUnion() } };
+    expect(prime(modelsWith(nested))).toEqual(['FlagValueUnion']);
+  });
+
+  it('drops an arm whose variant model will not be emitted', () => {
+    const models = modelsWith(flagValueUnion()).filter((m) => m.name !== 'NumberFlagValue');
+    const ctx = contextFor(models);
+    const unions = prepareGoUnions(models, ctx.spec.enums, emittableModelPredicate(models, ctx));
+    expect(unions[0].arms.map((a) => a.value)).toEqual(['boolean', 'string']);
+  });
+
+  it('ignores a mapping entry that is not one of the union variants', () => {
+    const union: UnionType = {
+      ...flagValueUnion(),
+      discriminator: {
+        property: 'value_type',
+        mapping: { boolean: 'FlagValue', elsewhere: 'SomeUnrelatedModel' },
+      },
+    };
+    const models = modelsWith(union);
+    const ctx = contextFor(models);
+    const unions = prepareGoUnions(models, ctx.spec.enums, emittableModelPredicate(models, ctx));
+    expect(unions[0].arms.map((a) => a.goType)).toEqual(['FlagValue']);
+  });
+
+  it('wraps neither union when two distinct ones would claim the same name', () => {
+    // The per-operation `Error400` shape: many unrelated unions whose leading
+    // variant shares a name. Picking a winner would give the loser the wrong
+    // variants, so both keep the first-variant collapse.
+    const other: UnionType = {
+      kind: 'union',
+      compositionKind: 'oneOf',
+      discriminator: { property: 'value_type', mapping: { boolean: 'FlagValue' } },
+      variants: [{ kind: 'model', name: 'FlagValue' }],
+    };
+    const models: Model[] = [
+      { name: 'A', fields: [{ name: 'value', type: flagValueUnion(), required: true }] },
+      { name: 'B', fields: [{ name: 'value', type: other, required: true }] },
+      ...variantModels(),
+    ];
+    expect(prime(models)).toEqual([]);
+    expect(mapTypeRef(flagValueUnion())).toBe('*FlagValue');
+  });
+
+  it('skips a wrapper whose name collides with an existing model', () => {
+    const models = [...modelsWith(flagValueUnion()), { name: 'FlagValueUnion', fields: [] }];
+    expect(prime(models)).toEqual([]);
+  });
+
+  it('ignores discriminated unions that are not on a model field', () => {
+    // Operation-level error unions keep collapsing to their first variant.
+    const models = variantModels();
+    const ctx = contextFor(models);
+    ctx.spec.services = [
+      {
+        name: 'Flags',
+        operations: [
+          {
+            name: 'get',
+            httpMethod: 'get',
+            path: '/flags',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            response: flagValueUnion(),
+            errors: [],
+            injectIdempotencyKey: false,
+          },
+        ],
+      },
+    ];
+    expect(prepareGoUnions(models, ctx.spec.enums, emittableModelPredicate(models, ctx))).toEqual([]);
+  });
+});
+
+describe('go/unions — golden output', () => {
+  it('renders the full wrapper for a multi-member union with a conflicting shared field', () => {
+    expect(emit(modelsWith(flagValueUnion())).get('unions.go')).toMatchInlineSnapshot(`
+      "package workos
+
+      import "encoding/json"
+
+      // FlagValueUnion is a discriminated union: exactly one variant pointer is set,
+      // and ValueType says which. Use the As* accessors to read a variant safely.
+      type FlagValueUnion struct {
+      	// ValueType identifies which variant this union holds.
+      	ValueType FlagValueUnionValueType \`json:"value_type"\`
+      	// Boolean is set when ValueType is FlagValueUnionValueTypeBoolean.
+      	Boolean *FlagValue \`json:"-"\`
+      	// String is set when ValueType is FlagValueUnionValueTypeString.
+      	String *StringFlagValue \`json:"-"\`
+      	// Number is set when ValueType is FlagValueUnionValueTypeNumber.
+      	Number *NumberFlagValue \`json:"-"\`
+
+      	// raw retains the payload as received so an unrecognized discriminator
+      	// value survives an unmarshal/marshal round trip instead of being dropped.
+      	raw json.RawMessage
+      }
+
+      // FlagValueUnionValueType identifies the variant held by a FlagValueUnion.
+      type FlagValueUnionValueType string
+
+      const (
+      	// FlagValueUnionValueTypeBoolean selects the FlagValue variant.
+      	FlagValueUnionValueTypeBoolean FlagValueUnionValueType = "boolean"
+      	// FlagValueUnionValueTypeString selects the StringFlagValue variant.
+      	FlagValueUnionValueTypeString FlagValueUnionValueType = "string"
+      	// FlagValueUnionValueTypeNumber selects the NumberFlagValue variant.
+      	FlagValueUnionValueTypeNumber FlagValueUnionValueType = "number"
+      )
+
+      // AsBoolean returns the FlagValue variant and reports whether it is set.
+      func (u FlagValueUnion) AsBoolean() (*FlagValue, bool) {
+      	return u.Boolean, u.Boolean != nil
+      }
+
+      // AsString returns the StringFlagValue variant and reports whether it is set.
+      func (u FlagValueUnion) AsString() (*StringFlagValue, bool) {
+      	return u.String, u.String != nil
+      }
+
+      // AsNumber returns the NumberFlagValue variant and reports whether it is set.
+      func (u FlagValueUnion) AsNumber() (*NumberFlagValue, bool) {
+      	return u.Number, u.Number != nil
+      }
+
+      // UnmarshalJSON decodes the payload into the variant selected by the
+      // "value_type" discriminator. An unrecognized value leaves every
+      // variant nil; ValueType still reports what the wire said.
+      func (u *FlagValueUnion) UnmarshalJSON(data []byte) error {
+      	var discriminator struct {
+      		Value FlagValueUnionValueType \`json:"value_type"\`
+      	}
+      	if err := json.Unmarshal(data, &discriminator); err != nil {
+      		return err
+      	}
+
+      	*u = FlagValueUnion{ValueType: discriminator.Value, raw: append(json.RawMessage(nil), data...)}
+
+      	switch discriminator.Value {
+      	case FlagValueUnionValueTypeBoolean:
+      		var v FlagValue
+      		if err := json.Unmarshal(data, &v); err != nil {
+      			return err
+      		}
+      		u.Boolean = &v
+      	case FlagValueUnionValueTypeString:
+      		var v StringFlagValue
+      		if err := json.Unmarshal(data, &v); err != nil {
+      			return err
+      		}
+      		u.String = &v
+      	case FlagValueUnionValueTypeNumber:
+      		var v NumberFlagValue
+      		if err := json.Unmarshal(data, &v); err != nil {
+      			return err
+      		}
+      		u.Number = &v
+      	}
+
+      	return nil
+      }
+
+      // MarshalJSON encodes the variant selected by ValueType.
+      func (u FlagValueUnion) MarshalJSON() ([]byte, error) {
+      	switch u.ValueType {
+      	case FlagValueUnionValueTypeBoolean:
+      		if u.Boolean != nil {
+      			return json.Marshal(u.Boolean)
+      		}
+      	case FlagValueUnionValueTypeString:
+      		if u.String != nil {
+      			return json.Marshal(u.String)
+      		}
+      	case FlagValueUnionValueTypeNumber:
+      		if u.Number != nil {
+      			return json.Marshal(u.Number)
+      		}
+      	}
+
+      	// No variant set: replay the original payload when we have one, so a
+      	// value produced by UnmarshalJSON always round trips.
+      	if len(u.raw) > 0 {
+      		return u.raw, nil
+      	}
+      	if u.ValueType == "" {
+      		return []byte("null"), nil
+      	}
+      	return json.Marshal(map[string]string{"value_type": string(u.ValueType)})
+      }
+      "
+    `);
+  });
+
+  it('renders the full wrapper for a single-member union', () => {
+    expect(emit(modelsWith(singleMemberUnion())).get('unions.go')).toMatchInlineSnapshot(`
+      "package workos
+
+      import "encoding/json"
+
+      // SettingTargetUnion is a discriminated union: exactly one variant pointer is set,
+      // and Type says which. Use the As* accessors to read a variant safely.
+      type SettingTargetUnion struct {
+      	// Type identifies which variant this union holds.
+      	Type SettingTargetUnionType \`json:"type"\`
+      	// Organization is set when Type is SettingTargetUnionTypeOrganization.
+      	Organization *SettingTarget \`json:"-"\`
+
+      	// raw retains the payload as received so an unrecognized discriminator
+      	// value survives an unmarshal/marshal round trip instead of being dropped.
+      	raw json.RawMessage
+      }
+
+      // SettingTargetUnionType identifies the variant held by a SettingTargetUnion.
+      type SettingTargetUnionType string
+
+      const (
+      	// SettingTargetUnionTypeOrganization selects the SettingTarget variant.
+      	SettingTargetUnionTypeOrganization SettingTargetUnionType = "organization"
+      )
+
+      // AsOrganization returns the SettingTarget variant and reports whether it is set.
+      func (u SettingTargetUnion) AsOrganization() (*SettingTarget, bool) {
+      	return u.Organization, u.Organization != nil
+      }
+
+      // UnmarshalJSON decodes the payload into the variant selected by the
+      // "type" discriminator. An unrecognized value leaves every
+      // variant nil; Type still reports what the wire said.
+      func (u *SettingTargetUnion) UnmarshalJSON(data []byte) error {
+      	var discriminator struct {
+      		Value SettingTargetUnionType \`json:"type"\`
+      	}
+      	if err := json.Unmarshal(data, &discriminator); err != nil {
+      		return err
+      	}
+
+      	*u = SettingTargetUnion{Type: discriminator.Value, raw: append(json.RawMessage(nil), data...)}
+
+      	switch discriminator.Value {
+      	case SettingTargetUnionTypeOrganization:
+      		var v SettingTarget
+      		if err := json.Unmarshal(data, &v); err != nil {
+      			return err
+      		}
+      		u.Organization = &v
+      	}
+
+      	return nil
+      }
+
+      // MarshalJSON encodes the variant selected by Type.
+      func (u SettingTargetUnion) MarshalJSON() ([]byte, error) {
+      	switch u.Type {
+      	case SettingTargetUnionTypeOrganization:
+      		if u.Organization != nil {
+      			return json.Marshal(u.Organization)
+      		}
+      	}
+
+      	// No variant set: replay the original payload when we have one, so a
+      	// value produced by UnmarshalJSON always round trips.
+      	if len(u.raw) > 0 {
+      		return u.raw, nil
+      	}
+      	if u.Type == "" {
+      		return []byte("null"), nil
+      	}
+      	return json.Marshal(map[string]string{"type": string(u.Type)})
+      }
+      "
+    `);
+  });
+});

--- a/test/shared/union-flatten.test.ts
+++ b/test/shared/union-flatten.test.ts
@@ -171,4 +171,35 @@ describe('flattenDiscriminatedUnionFields', () => {
     expect(canonicalBefore.fields.length).toBe(fieldCountBefore);
     expect(models.find((m) => m.name === 'ApiKey')!.fields[0].type).toEqual(ownerUnion());
   });
+  describe('skipUnion opt-out', () => {
+    it('leaves an opted-out union as a union TypeRef', () => {
+      const out = flattenDiscriminatedUnionFields(baseModels(ownerUnion()), { skipUnion: () => true });
+      expect(out.find((m) => m.name === 'ApiKey')!.fields[0].type).toEqual(ownerUnion());
+    });
+
+    it('does not merge variant fields into the canonical model when opted out', () => {
+      const out = flattenDiscriminatedUnionFields(baseModels(ownerUnion()), { skipUnion: () => true });
+      const canonical = out.find((m) => m.name === 'ApiKeyOwner')!;
+      expect(canonical.fields.find((f) => f.name === 'organization_id')).toBeUndefined();
+    });
+
+    it('does not throw on conflicting shared field types when opted out', () => {
+      const models = baseModels(ownerUnion());
+      const user = models.find((m) => m.name === 'UserApiKeyOwner')!;
+      user.fields = user.fields.map((f) =>
+        f.name === 'id' ? { ...f, type: { kind: 'primitive', type: 'number' } } : f,
+      );
+      expect(() => flattenDiscriminatedUnionFields(models, { skipUnion: () => true })).not.toThrow();
+    });
+
+    it('still flattens unions the predicate does not opt out', () => {
+      const out = flattenDiscriminatedUnionFields(baseModels(ownerUnion()), { skipUnion: () => false });
+      expect(out.find((m) => m.name === 'ApiKey')!.fields[0].type).toEqual({ kind: 'model', name: 'ApiKeyOwner' });
+    });
+
+    it('flattens everything when no options are passed (default for other emitters)', () => {
+      const out = flattenDiscriminatedUnionFields(baseModels(ownerUnion()));
+      expect(out.find((m) => m.name === 'ApiKey')!.fields[0].type).toEqual({ kind: 'model', name: 'ApiKeyOwner' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Go collapsed every discriminated `oneOf` to its first variant, so fields unique to a later variant vanished — a user-owned API key lost `organization_id`. `flattenDiscriminatedUnionFields` papered over that by merging all variants into one superset struct, but a flat struct cannot hold a shared field whose type differs across variants (`value` as `boolean | string | number` keyed on `value_type`), so it throws outright.

Emit a sealed wrapper into a new `unions.go` instead:

```go
type APIKeyOwnerUnion struct {
    Type         APIKeyOwnerUnionType `json:"type"`
    Organization *APIKeyOwner         `json:"-"`
    User         *UserAPIKeyOwner     `json:"-"`

    raw json.RawMessage
}

if user, ok := key.Owner.AsUser(); ok {
    fmt.Println(user.OrganizationID) // previously dropped
}
```

- Discriminator field + one nil-able pointer per variant, `AsX() (*T, bool)` accessors, and constants for each discriminator value
- `UnmarshalJSON` switches on the discriminator; each arm decodes into its own generated struct, so a payload can never land in the wrong variant (no shape-sniffing, so `encoding/json`'s number→`float64` behavior is irrelevant here)
- Unexported `raw` replays an unrecognized discriminator instead of dropping its payload, so a variant this SDK version predates still round-trips
- Single-variant unions get a wrapper too, so adding a second variant later is additive rather than a type replacement

## Scope: model fields only

Per-operation error unions are discriminated as well, but the parser names every leading variant after the status code, so on the WorkOS spec **13 structurally distinct unions all want the name `Error400`** (`Error409` 6, `Error422` 3, `Error403` 3). Naming those needs operation context the IR doesn't attach to a `TypeRef`, so they keep collapsing to their first variant — unchanged from today, and they never reached the flatten that motivated this. A run-scoped registry (mirroring rust's `UnionRegistry`) is the single source of truth for which unions got a wrapper, so the type map and the flatten opt-out cannot disagree. A name collision warns and falls back to the old collapse rather than aborting generation.

## Other emitters are untouched

`flattenDiscriminatedUnionFields` takes a new optional `skipUnion` predicate; callers that pass nothing get exactly the previous behavior. Verified rather than assumed — see below.

## ⚠️ Breaking change to the generated Go SDK

`ApiKey.Owner` goes `*APIKeyOwner` → `*APIKeyOwnerUnion`, across 5 fields (`ApiKey.owner`, `ApiKeyCreated/Revoked/UpdatedData.owner`, `AgentRegistrationCredentialIssuedData.detail`). Callers reading `owner.ID` now go through `AsOrganization()` / `AsUser()`. The variant structs also shed the fields flattening grafted onto them — `APIKeyCreatedDataOwner` loses its injected optional `OrganizationID`, which now lives on `UserAPIKeyCreatedDataOwner` where it belongs.

This will trip `sdk-compat` on the openapi-spec sync PR and wants a major bump on workos-go. Flagging rather than deciding.

## Test plan

- **Unit**: 31 new tests in `test/go/unions.test.ts` covering both requested fixtures — a single-member discriminated `oneOf`, and a multi-member one with `value` as `boolean | string | number` keyed on `value_type` — plus inline-snapshot goldens of the full generated `unions.go` for each. 5 more in `test/shared/union-flatten.test.ts` pinning that the default path is unchanged. Suite 839 → 875, no existing tests edited.
- **Real spec**: generated Go from `workos/openapi-spec` — 5 wrappers, exactly the 5 uniquely-nameable unions. Blast radius across 550 files is **one new file plus 47 diff lines in `models.go`**; the other 540 are byte-identical.
- **Compiles and behaves**: generated `models.go` + `enums.go` + `unions.go` build clean, `go vet` clean, and `unions.go` needs no `gofmt` fixup. Go tests confirm a string-valued payload resolves to the string variant and never into `*bool`, an unknown discriminator round-trips byte-for-byte, and a zero value marshals to `null`.
- **Real SDK**: regenerated the oagen-managed `workos-go` (branch `oagen/batch-3e7992ec`) via `--target`. Builds, vets, and its **full test suite passes**. An end-to-end test through the real client confirmed a user-owned key surfaces `OrganizationID` and does not populate the Organization variant.
- **No cross-emitter regression**: regenerated Python, Rust, Node, Kotlin, Ruby, PHP and .NET from the same spec before and after — **byte-identical** (Python differs only inside `.ruff_cache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
