### PR TITLE
fix(shared): drop stale aggregate blocks for in-scope models

### DIFF
--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -33,7 +33,12 @@ import {
   isScopedRun,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
-import { type AggregateBlock, readPriorFile, reconcileScopedBlocks } from '../shared/scoped-aggregate-merge.js';
+import {
+  type AggregateBlock,
+  exclusivelyInScopeKeys,
+  readPriorFile,
+  reconcileScopedBlocks,
+} from '../shared/scoped-aggregate-merge.js';
 import { isHandwrittenOverride } from './overrides.js';
 import { orderedVariantParameters } from './resources.js';
 import { resolveKotlinWrapperParams } from './wrappers.js';
@@ -1070,14 +1075,16 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
   // primitives-only filter.
   const targets: { model: Model; json: string }[] = [];
   const seenModelClassNames = new Set<string>();
-  // Every in-scope class name this loop considered, whether or not it survived
+  // Scope of every class name this loop considered, whether or not it survived
   // the gates below. A scoped run uses it to DROP the prior block of an in-scope
   // model that no longer qualifies (its `.kt` was regenerated, so the stale
   // fixture would assert a shape the fresh data class can't produce) instead of
-  // carrying it over. See reconcileScopedBlocks.
-  const inScopeKeys = new Set<string>();
+  // carrying it over. Two IR names can collapse to one class name (see the
+  // `seenModelClassNames` dedup below), so ownership is resolved by
+  // exclusivelyInScopeKeys — an out-of-scope owner vetoes the drop.
+  const keyOwners: { key: string; inScope: boolean }[] = [];
   for (const m of spec.models) {
-    if (isModelInScope(m.name, ctx)) inScopeKeys.add(className(m.name));
+    keyOwners.push({ key: className(m.name), inScope: isModelInScope(m.name, ctx) });
     if (isListWrapperModel(m) || isListMetadataModel(m)) continue;
     if (m.fields.length === 0) continue;
     // AGGREGATE gate: this whole-suite test references `${cls}::class.java`. In a
@@ -1126,7 +1133,7 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
       return null;
     }
   }
-  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped, inScopeKeys);
+  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped, exclusivelyInScopeKeys(keyOwners));
   if (methods.length === 0) return null;
 
   const lines: string[] = [

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -35,7 +35,7 @@ import {
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import {
   type AggregateBlock,
-  exclusivelyInScopeKeys,
+  keysWithInScopeOwner,
   readPriorFile,
   reconcileScopedBlocks,
 } from '../shared/scoped-aggregate-merge.js';
@@ -1080,8 +1080,9 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
   // model that no longer qualifies (its `.kt` was regenerated, so the stale
   // fixture would assert a shape the fresh data class can't produce) instead of
   // carrying it over. Two IR names can collapse to one class name (see the
-  // `seenModelClassNames` dedup below), so ownership is resolved by
-  // exclusivelyInScopeKeys — an out-of-scope owner vetoes the drop.
+  // `seenModelClassNames` dedup below); that class name is also the `.kt` path,
+  // so colliding models share ONE file and any in-scope owner regenerates it —
+  // keysWithInScopeOwner claims the key on that basis.
   const keyOwners: { key: string; inScope: boolean }[] = [];
   for (const m of spec.models) {
     keyOwners.push({ key: className(m.name), inScope: isModelInScope(m.name, ctx) });
@@ -1133,7 +1134,7 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
       return null;
     }
   }
-  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped, exclusivelyInScopeKeys(keyOwners));
+  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped, keysWithInScopeOwner(keyOwners));
   if (methods.length === 0) return null;
 
   const lines: string[] = [

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -1070,7 +1070,14 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
   // primitives-only filter.
   const targets: { model: Model; json: string }[] = [];
   const seenModelClassNames = new Set<string>();
+  // Every in-scope class name this loop considered, whether or not it survived
+  // the gates below. A scoped run uses it to DROP the prior block of an in-scope
+  // model that no longer qualifies (its `.kt` was regenerated, so the stale
+  // fixture would assert a shape the fresh data class can't produce) instead of
+  // carrying it over. See reconcileScopedBlocks.
+  const inScopeKeys = new Set<string>();
   for (const m of spec.models) {
+    if (isModelInScope(m.name, ctx)) inScopeKeys.add(className(m.name));
     if (isListWrapperModel(m) || isListMetadataModel(m)) continue;
     if (m.fields.length === 0) continue;
     // AGGREGATE gate: this whole-suite test references `${cls}::class.java`. In a
@@ -1119,7 +1126,7 @@ function generateModelRoundTripTest(spec: ApiSpec, ctx: EmitterContext): Generat
       return null;
     }
   }
-  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped);
+  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped, inScopeKeys);
   if (methods.length === 0) return null;
 
   const lines: string[] = [

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -35,7 +35,12 @@ import {
   fileExistsAfterRun,
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
-import { type AggregateBlock, readPriorFile, reconcileScopedBlocks } from '../shared/scoped-aggregate-merge.js';
+import {
+  type AggregateBlock,
+  exclusivelyInScopeKeys,
+  readPriorFile,
+  reconcileScopedBlocks,
+} from '../shared/scoped-aggregate-merge.js';
 import { pythonLiteral } from './wrappers.js';
 import { computeSchemaPlacement } from './shared-schemas.js';
 
@@ -1572,14 +1577,18 @@ function buildDirRoundTripFile(
   // out-of-scope models to their prior on-disk text (see reconciliation below).
   const roundTripBlocks: AggregateBlock[] = [];
   const discriminatorBlocks: AggregateBlock[] = [];
-  // Keys of every in-scope model this dir CONSIDERED, whether or not it goes on
-  // to produce a block below. A scoped run drops the prior block of an in-scope
-  // model that produced none — its per-model `.py` WAS regenerated, so the
-  // frozen block asserts a shape the fresh model can't produce (see
-  // reconcileScopedBlocks) — instead of carrying the stale text over. Shared by
-  // both aggregates so a model that gains or loses a discriminator (moving
-  // between the two) doesn't strand its block in the class it left.
-  const inScopeKeys = new Set(dirModels.filter((m) => isModelInScope(m.name, ctx)).map((m) => fileName(m.name)));
+  // Scope of every key this dir CONSIDERED, whether or not it goes on to produce
+  // a block below. A scoped run drops the prior block of an in-scope model that
+  // produced none — its per-model `.py` WAS regenerated, so the frozen block
+  // asserts a shape the fresh model can't produce (see reconcileScopedBlocks) —
+  // instead of carrying the stale text over. `fileName` is normalized, so two IR
+  // names can share a key; exclusivelyInScopeKeys lets an out-of-scope owner veto
+  // the drop. Shared by both aggregates so a model that gains or loses a
+  // discriminator (moving between the two) doesn't strand its block in the class
+  // it left.
+  const inScopeKeys = exclusivelyInScopeKeys(
+    dirModels.map((m) => ({ key: fileName(m.name), inScope: isModelInScope(m.name, ctx) })),
+  );
 
   {
     for (const model of roundTripModels) {

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -37,7 +37,7 @@ import {
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import {
   type AggregateBlock,
-  exclusivelyInScopeKeys,
+  keysWithInScopeOwner,
   readPriorFile,
   reconcileScopedBlocks,
 } from '../shared/scoped-aggregate-merge.js';
@@ -1582,11 +1582,13 @@ function buildDirRoundTripFile(
   // produced none — its per-model `.py` WAS regenerated, so the frozen block
   // asserts a shape the fresh model can't produce (see reconcileScopedBlocks) —
   // instead of carrying the stale text over. `fileName` is normalized, so two IR
-  // names can share a key; exclusivelyInScopeKeys lets an out-of-scope owner veto
-  // the drop. Shared by both aggregates so a model that gains or loses a
+  // names can share a key; it is also the `.py` and fixture path, so colliding
+  // models share ONE artifact and any in-scope owner regenerates it —
+  // keysWithInScopeOwner claims the key on that basis. Shared by both
+  // aggregates so a model that gains or loses a
   // discriminator (moving between the two) doesn't strand its block in the class
   // it left.
-  const inScopeKeys = exclusivelyInScopeKeys(
+  const inScopeKeys = keysWithInScopeOwner(
     dirModels.map((m) => ({ key: fileName(m.name), inScope: isModelInScope(m.name, ctx) })),
   );
 

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -1572,6 +1572,14 @@ function buildDirRoundTripFile(
   // out-of-scope models to their prior on-disk text (see reconciliation below).
   const roundTripBlocks: AggregateBlock[] = [];
   const discriminatorBlocks: AggregateBlock[] = [];
+  // Keys of every in-scope model this dir CONSIDERED, whether or not it goes on
+  // to produce a block below. A scoped run drops the prior block of an in-scope
+  // model that produced none — its per-model `.py` WAS regenerated, so the
+  // frozen block asserts a shape the fresh model can't produce (see
+  // reconcileScopedBlocks) — instead of carrying the stale text over. Shared by
+  // both aggregates so a model that gains or loses a discriminator (moving
+  // between the two) doesn't strand its block in the class it left.
+  const inScopeKeys = new Set(dirModels.filter((m) => isModelInScope(m.name, ctx)).map((m) => fileName(m.name)));
 
   {
     for (const model of roundTripModels) {
@@ -1743,8 +1751,8 @@ function buildDirRoundTripFile(
       return null;
     }
   }
-  const roundTripMethods = reconcileScopedBlocks(roundTripBlocks, prior.roundTrip, scoped);
-  const discriminatorMethods = reconcileScopedBlocks(discriminatorBlocks, prior.discriminator, scoped);
+  const roundTripMethods = reconcileScopedBlocks(roundTripBlocks, prior.roundTrip, scoped, inScopeKeys);
+  const discriminatorMethods = reconcileScopedBlocks(discriminatorBlocks, prior.discriminator, scoped, inScopeKeys);
   if (roundTripMethods.length === 0 && discriminatorMethods.length === 0) return null;
 
   const body: string[] = [];

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -25,7 +25,7 @@ import {
 } from '../shared/resolved-ops.js';
 import {
   type AggregateBlock,
-  exclusivelyInScopeKeys,
+  keysWithInScopeOwner,
   readPriorFile,
   reconcileScopedBlocks,
 } from '../shared/scoped-aggregate-merge.js';
@@ -331,9 +331,10 @@ function buildDirRoundTripFile(
   // produced none rather than carrying stale text over — its `.rb` WAS
   // regenerated, so the frozen fixture asserts a shape the fresh model can't
   // produce (see reconcileScopedBlocks). `fileName` is normalized and two IR
-  // names can collapse onto one (the dedup below), so exclusivelyInScopeKeys lets
-  // an out-of-scope owner veto the drop.
-  const inScopeKeys = exclusivelyInScopeKeys(
+  // names can collapse onto one (the dedup below); it is also the `.rb` path
+  // within this dir, so colliding models share ONE file and any in-scope owner
+  // regenerates it — keysWithInScopeOwner claims the key on that basis.
+  const inScopeKeys = keysWithInScopeOwner(
     dirModels.map((m) => ({ key: fileName(m.name), inScope: isModelInScope(m.name, ctx) })),
   );
   for (const model of dirModels) {

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -23,7 +23,12 @@ import {
   isScopedRun,
   fileExistsAfterRun,
 } from '../shared/resolved-ops.js';
-import { type AggregateBlock, readPriorFile, reconcileScopedBlocks } from '../shared/scoped-aggregate-merge.js';
+import {
+  type AggregateBlock,
+  exclusivelyInScopeKeys,
+  readPriorFile,
+  reconcileScopedBlocks,
+} from '../shared/scoped-aggregate-merge.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { classifyUnassignedModel } from './models.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
@@ -321,12 +326,16 @@ function buildDirRoundTripFile(
 
   const newBlocks: AggregateBlock[] = [];
   const emitted = new Set<string>();
-  // Keys of every in-scope model this dir CONSIDERED, whether or not it goes on
-  // to produce a block. A scoped run drops the prior block of an in-scope model
-  // that produced none rather than carrying stale text over — its `.rb` WAS
+  // Scope of every key this dir CONSIDERED, whether or not it goes on to produce
+  // a block. A scoped run drops the prior block of an in-scope model that
+  // produced none rather than carrying stale text over — its `.rb` WAS
   // regenerated, so the frozen fixture asserts a shape the fresh model can't
-  // produce (see reconcileScopedBlocks).
-  const inScopeKeys = new Set(dirModels.filter((m) => isModelInScope(m.name, ctx)).map((m) => fileName(m.name)));
+  // produce (see reconcileScopedBlocks). `fileName` is normalized and two IR
+  // names can collapse onto one (the dedup below), so exclusivelyInScopeKeys lets
+  // an out-of-scope owner veto the drop.
+  const inScopeKeys = exclusivelyInScopeKeys(
+    dirModels.map((m) => ({ key: fileName(m.name), inScope: isModelInScope(m.name, ctx) })),
+  );
   for (const model of dirModels) {
     // Avoid duplicate test names when two IR model names collapse to the same
     // snake_case file name (we use the file name as the test suffix).

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -321,6 +321,12 @@ function buildDirRoundTripFile(
 
   const newBlocks: AggregateBlock[] = [];
   const emitted = new Set<string>();
+  // Keys of every in-scope model this dir CONSIDERED, whether or not it goes on
+  // to produce a block. A scoped run drops the prior block of an in-scope model
+  // that produced none rather than carrying stale text over — its `.rb` WAS
+  // regenerated, so the frozen fixture asserts a shape the fresh model can't
+  // produce (see reconcileScopedBlocks).
+  const inScopeKeys = new Set(dirModels.filter((m) => isModelInScope(m.name, ctx)).map((m) => fileName(m.name)));
   for (const model of dirModels) {
     // Avoid duplicate test names when two IR model names collapse to the same
     // snake_case file name (we use the file name as the test suffix).
@@ -408,7 +414,7 @@ function buildDirRoundTripFile(
       return null;
     }
   }
-  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped);
+  const methods = reconcileScopedBlocks(newBlocks, priorBlocks, scoped, inScopeKeys);
   if (methods.length === 0) return null;
 
   const lines: string[] = [];

--- a/src/shared/scoped-aggregate-merge.ts
+++ b/src/shared/scoped-aggregate-merge.ts
@@ -25,7 +25,11 @@ import { resolve } from 'node:path';
  *   - out-of-scope, brand-new      → dropped (its per-model file isn't emitted
  *                                    this run, so a block referencing it would
  *                                    dangle).
- * Prior blocks the new spec no longer produces are carried over verbatim.
+ * Prior blocks the new spec no longer produces are carried over verbatim —
+ * EXCEPT for keys the caller reports as in scope (see `inScopeKeys`), which are
+ * dropped instead: an in-scope model that produced no block was disqualified on
+ * purpose, and its per-model file WAS regenerated, so the prior block asserts a
+ * shape the fresh model no longer has.
  *
  * A full (non-scoped) run skips reconciliation and emits every fresh block.
  */
@@ -71,11 +75,20 @@ export function readPriorFile(relPath: string, ctx: EmitterContext): string | nu
  *                    to in-scope ∪ on-disk models.
  * @param priorBlocks Blocks parsed from the prior on-disk file (parser-specific).
  * @param scoped      Whether a scoped (`--services`) run is active.
+ * @param inScopeKeys Every key the caller CONSIDERED whose owning model is in
+ *                    scope this run, whether or not it produced a block. A key
+ *                    in this set that produced no block was disqualified on
+ *                    purpose (e.g. the model gained an optional field and no
+ *                    longer satisfies the round-trip fixture gate), so its prior
+ *                    block is dropped rather than carried over — the freshly
+ *                    regenerated model would fail the stale assertion. Omit to
+ *                    keep the pre-existing carry-over-everything behavior.
  */
 export function reconcileScopedBlocks(
   newBlocks: AggregateBlock[],
   priorBlocks: AggregateBlock[],
   scoped: boolean,
+  inScopeKeys?: ReadonlySet<string>,
 ): string[] {
   // Full run: emit everything the new spec produced, unchanged.
   if (!scoped) return newBlocks.map((b) => b.text);
@@ -102,11 +115,19 @@ export function reconcileScopedBlocks(
 
   // Carry over prior blocks the new spec no longer produces at all (renamed /
   // removed models whose per-model file this run left untouched on disk).
+  //
+  // An in-scope key is NOT carried over: its per-model file WAS regenerated, so
+  // "no fresh block" means the generator disqualified it deliberately and the
+  // prior block now asserts a shape the new model can't produce. Carrying it
+  // over resurrected the stale block at the end of the file and broke the build
+  // (e.g. a model that gained an optional field: the frozen fixture omits it,
+  // the regenerated model serializes it as null, and the round-trip assertion
+  // fails).
   for (const block of priorBlocks) {
-    if (!emitted.has(block.key)) {
-      out.push(block.text);
-      emitted.add(block.key);
-    }
+    if (emitted.has(block.key)) continue;
+    if (inScopeKeys?.has(block.key)) continue;
+    out.push(block.text);
+    emitted.add(block.key);
   }
 
   return out;

--- a/src/shared/scoped-aggregate-merge.ts
+++ b/src/shared/scoped-aggregate-merge.ts
@@ -71,22 +71,25 @@ export function readPriorFile(relPath: string, ctx: EmitterContext): string | nu
  * (key, inScope) pair the caller considered.
  *
  * Block keys are NORMALIZED names (a generated class or file name), and two
- * distinct IR model names can collapse to the same one. A key is reported as in
- * scope only when EVERY model that maps to it is in scope: a single
- * out-of-scope owner vetoes it, so its prior block is carried over rather than
- * dropped. The veto is deliberately conservative — the worst case is keeping a
- * block the reconciler could have refreshed, whereas the reverse would silently
- * delete coverage for a model this run never touched.
+ * distinct IR model names can collapse onto one — Kotlin and Ruby both carry an
+ * explicit dedup for exactly that. A key is in scope when ANY model mapping to
+ * it is in scope.
+ *
+ * "Any", not "every", because the key IS the generated artifact's identity: it
+ * is the same normalized name that forms the file path each emitter writes
+ * (`…/models/<className>.kt`, `lib/workos/<dir>/<fileName>.rb`,
+ * `…/models/<fileName>.py` plus its flat fixture). Colliding owners therefore
+ * do not have separate artifacts — they share ONE file, and a single in-scope
+ * owner regenerates it. There is no out-of-scope coverage to preserve in that
+ * case, only a prior block describing a shape the shared artifact no longer
+ * has, so the key must be treated as in scope and the stale block dropped.
  */
-export function exclusivelyInScopeKeys(owners: Iterable<{ key: string; inScope: boolean }>): Set<string> {
-  const inScope = new Set<string>();
-  const vetoed = new Set<string>();
-  for (const { key, inScope: owned } of owners) {
-    if (owned) inScope.add(key);
-    else vetoed.add(key);
+export function keysWithInScopeOwner(owners: Iterable<{ key: string; inScope: boolean }>): Set<string> {
+  const keys = new Set<string>();
+  for (const { key, inScope } of owners) {
+    if (inScope) keys.add(key);
   }
-  for (const key of vetoed) inScope.delete(key);
-  return inScope;
+  return keys;
 }
 
 /**
@@ -98,10 +101,10 @@ export function exclusivelyInScopeKeys(owners: Iterable<{ key: string; inScope: 
  *                    to in-scope ∪ on-disk models.
  * @param priorBlocks Blocks parsed from the prior on-disk file (parser-specific).
  * @param scoped      Whether a scoped (`--services`) run is active.
- * @param inScopeKeys Keys the caller CONSIDERED that are owned EXCLUSIVELY by
- *                    in-scope models, whether or not they produced a block —
- *                    build it with {@link exclusivelyInScopeKeys}. A key in this
- *                    set that produced no block was disqualified on purpose
+ * @param inScopeKeys Keys the caller CONSIDERED that have at least one in-scope
+ *                    owner, whether or not they produced a block — build it with
+ *                    {@link keysWithInScopeOwner}. A key in this set that
+ *                    produced no block was disqualified on purpose
  *                    (e.g. the model gained an optional field and no longer
  *                    satisfies the round-trip fixture gate), so its prior block
  *                    is dropped rather than carried over — the freshly

--- a/src/shared/scoped-aggregate-merge.ts
+++ b/src/shared/scoped-aggregate-merge.ts
@@ -67,6 +67,29 @@ export function readPriorFile(relPath: string, ctx: EmitterContext): string | nu
 }
 
 /**
+ * Build the `inScopeKeys` set for {@link reconcileScopedBlocks} from every
+ * (key, inScope) pair the caller considered.
+ *
+ * Block keys are NORMALIZED names (a generated class or file name), and two
+ * distinct IR model names can collapse to the same one. A key is reported as in
+ * scope only when EVERY model that maps to it is in scope: a single
+ * out-of-scope owner vetoes it, so its prior block is carried over rather than
+ * dropped. The veto is deliberately conservative — the worst case is keeping a
+ * block the reconciler could have refreshed, whereas the reverse would silently
+ * delete coverage for a model this run never touched.
+ */
+export function exclusivelyInScopeKeys(owners: Iterable<{ key: string; inScope: boolean }>): Set<string> {
+  const inScope = new Set<string>();
+  const vetoed = new Set<string>();
+  for (const { key, inScope: owned } of owners) {
+    if (owned) inScope.add(key);
+    else vetoed.add(key);
+  }
+  for (const key of vetoed) inScope.delete(key);
+  return inScope;
+}
+
+/**
  * Reconcile freshly generated per-model blocks against the prior on-disk blocks.
  * Returns the ordered block texts to emit (new-spec order, then carry-overs).
  *
@@ -75,12 +98,13 @@ export function readPriorFile(relPath: string, ctx: EmitterContext): string | nu
  *                    to in-scope ∪ on-disk models.
  * @param priorBlocks Blocks parsed from the prior on-disk file (parser-specific).
  * @param scoped      Whether a scoped (`--services`) run is active.
- * @param inScopeKeys Every key the caller CONSIDERED whose owning model is in
- *                    scope this run, whether or not it produced a block. A key
- *                    in this set that produced no block was disqualified on
- *                    purpose (e.g. the model gained an optional field and no
- *                    longer satisfies the round-trip fixture gate), so its prior
- *                    block is dropped rather than carried over — the freshly
+ * @param inScopeKeys Keys the caller CONSIDERED that are owned EXCLUSIVELY by
+ *                    in-scope models, whether or not they produced a block —
+ *                    build it with {@link exclusivelyInScopeKeys}. A key in this
+ *                    set that produced no block was disqualified on purpose
+ *                    (e.g. the model gained an optional field and no longer
+ *                    satisfies the round-trip fixture gate), so its prior block
+ *                    is dropped rather than carried over — the freshly
  *                    regenerated model would fail the stale assertion. Omit to
  *                    keep the pre-existing carry-over-everything behavior.
  */

--- a/test/kotlin/tests.test.ts
+++ b/test/kotlin/tests.test.ts
@@ -251,6 +251,81 @@ describe('kotlin/tests', () => {
     rmSync(outputDir, { recursive: true, force: true });
   });
 
+  it('scoped run: drops an in-scope model block when the model stops qualifying for a fixture', () => {
+    // Regression (workos-kotlin CI): Organization is IN SCOPE and the current
+    // spec gives it an OPTIONAL field, so the all-fields-required fixture gate
+    // disqualifies it and no fresh block is produced. Its `.kt` IS regenerated
+    // though (now carrying `val provider: String? = null`), so carrying the
+    // prior block over resurrected a fixture that omits the field while Jackson
+    // serializes it as null — `assertEquals(tree1, tree2)` then fails and the
+    // SDK build breaks. The stale in-scope block must be DROPPED; Directory
+    // (out of scope, untouched on disk) must still be carried over.
+    const outputDir = mkdtempSync(join(tmpdir(), 'oagen-rt-'));
+    const rtPath = join(outputDir, 'src/test/kotlin/com/workos/models/GeneratedModelRoundTripTest.kt');
+    mkdirSync(dirname(rtPath), { recursive: true });
+    const method = (cls: string) =>
+      [
+        '  @Test',
+        `  fun \`${cls} round-trips through Jackson\`() {`,
+        '    val json = "{\\"id\\": \\"sample\\", \\"name\\": \\"sample\\"}"',
+        `    val parsed = mapper.readValue(json, ${cls}::class.java)`,
+        '    val reserialized = mapper.writeValueAsString(parsed)',
+        '    val tree1 = mapper.readTree(json)',
+        '    val tree2 = mapper.readTree(reserialized)',
+        '    assertEquals(tree1, tree2)',
+        '  }',
+      ].join('\n');
+    writeFileSync(
+      rtPath,
+      [
+        'package com.workos.models',
+        '',
+        'import com.workos.common.json.ObjectMapperFactory',
+        'import org.junit.jupiter.api.Assertions.assertEquals',
+        'import org.junit.jupiter.api.Test',
+        '',
+        'class GeneratedModelRoundTripTest {',
+        '  private val mapper = ObjectMapperFactory.create()',
+        '',
+        method('Organization'),
+        '',
+        method('Directory'),
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    const disqualified: Model = {
+      name: 'Organization',
+      fields: [
+        { name: 'id', type: { kind: 'primitive', type: 'string' }, required: true },
+        { name: 'name', type: { kind: 'primitive', type: 'string' }, required: true },
+        // Newly added and OPTIONAL → the model no longer round-trips from a
+        // required-fields-only fixture.
+        { name: 'provider', type: { kind: 'primitive', type: 'string' }, required: false },
+      ],
+    };
+    const scopedSpec: ApiSpec = { ...spec, models: [disqualified, roundTripModel('Directory')] };
+    const scopedCtx: EmitterContext = {
+      ...ctx,
+      spec: scopedSpec,
+      outputDir,
+      resolvedOperations: buildResolvedOps(services),
+      scopedServices: new Set(['Organizations']),
+      scopedModelNames: new Set(['Organization']),
+      priorTargetManifestPaths: new Set(['src/main/kotlin/com/workos/models/Directory.kt']),
+    };
+
+    const roundTrip = generateTests(scopedSpec, scopedCtx).find((f) =>
+      f.path.endsWith('GeneratedModelRoundTripTest.kt'),
+    )!;
+    expect(roundTrip).toBeDefined();
+    expect(roundTrip.content).not.toContain('Organization round-trips through Jackson');
+    expect(roundTrip.content).toContain('Directory round-trips through Jackson');
+
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
   it('scoped run: does NOT emit the round-trip test when the prior file exists but is unreadable', () => {
     // Guard against silent data loss: if the prior aggregate can't be read, we
     // must not overwrite it with only fresh in-scope blocks (which would drop

--- a/test/shared/scoped-aggregate-merge.test.ts
+++ b/test/shared/scoped-aggregate-merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  exclusivelyInScopeKeys,
+  keysWithInScopeOwner,
   reconcileScopedBlocks,
   type AggregateBlock,
 } from '../../src/shared/scoped-aggregate-merge.js';
@@ -76,32 +76,45 @@ describe('reconcileScopedBlocks', () => {
   });
 });
 
-describe('exclusivelyInScopeKeys', () => {
+describe('keysWithInScopeOwner', () => {
   it('keeps a key owned only by in-scope models', () => {
-    expect([...exclusivelyInScopeKeys([{ key: 'A', inScope: true }])]).toEqual(['A']);
+    expect([...keysWithInScopeOwner([{ key: 'A', inScope: true }])]).toEqual(['A']);
   });
 
   it('omits a key owned only by out-of-scope models', () => {
-    expect([...exclusivelyInScopeKeys([{ key: 'A', inScope: false }])]).toEqual([]);
+    expect([...keysWithInScopeOwner([{ key: 'A', inScope: false }])]).toEqual([]);
   });
 
-  it('lets a single out-of-scope owner veto a colliding key', () => {
+  it('claims a colliding key when ANY owner is in scope, whatever the order', () => {
     // Two distinct IR model names normalize onto one generated class/file name.
-    // Suppressing the carry-over here would delete the OUT-OF-SCOPE model's
-    // coverage even though this run never regenerated it — so the key is vetoed
-    // regardless of which owner is seen first.
+    // They do not have separate artifacts — the key IS the file path, so they
+    // share ONE file and the in-scope owner regenerates it. An out-of-scope
+    // co-owner must therefore NOT veto the key: there is no untouched artifact
+    // whose coverage carrying the prior block would preserve.
     const owners = [
       { key: 'Shared', inScope: true },
       { key: 'Shared', inScope: false },
-      { key: 'Solo', inScope: true },
+      { key: 'Solo', inScope: false },
     ];
-    expect([...exclusivelyInScopeKeys(owners)].sort()).toEqual(['Solo']);
-    expect([...exclusivelyInScopeKeys([...owners].reverse())].sort()).toEqual(['Solo']);
+    expect([...keysWithInScopeOwner(owners)].sort()).toEqual(['Shared']);
+    expect([...keysWithInScopeOwner([...owners].reverse())].sort()).toEqual(['Shared']);
   });
 
-  it('a vetoed key still carries its prior block over', () => {
-    const keys = exclusivelyInScopeKeys([
+  it('a colliding key with an in-scope owner drops its stale prior block', () => {
+    // The regression this ordering protects: the shared artifact was rewritten
+    // from the in-scope owner, so its prior block asserts a shape that no longer
+    // exists and would fail the generated suite.
+    const keys = keysWithInScopeOwner([
       { key: 'Shared', inScope: true },
+      { key: 'Shared', inScope: false },
+    ]);
+    const out = reconcileScopedBlocks([], [prior('Shared')], true, keys);
+    expect(out).toEqual([]);
+  });
+
+  it('a colliding key with no in-scope owner keeps its prior block', () => {
+    const keys = keysWithInScopeOwner([
+      { key: 'Shared', inScope: false },
       { key: 'Shared', inScope: false },
     ]);
     const out = reconcileScopedBlocks([], [prior('Shared')], true, keys);

--- a/test/shared/scoped-aggregate-merge.test.ts
+++ b/test/shared/scoped-aggregate-merge.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { reconcileScopedBlocks, type AggregateBlock } from '../../src/shared/scoped-aggregate-merge.js';
+import {
+  exclusivelyInScopeKeys,
+  reconcileScopedBlocks,
+  type AggregateBlock,
+} from '../../src/shared/scoped-aggregate-merge.js';
 
 const fresh = (key: string, inScope: boolean): AggregateBlock => ({ key, text: `${key}:fresh`, inScope });
 const prior = (key: string): AggregateBlock => ({ key, text: `${key}:prior` });
@@ -69,5 +73,38 @@ describe('reconcileScopedBlocks', () => {
   it('full run ignores inScopeKeys (no prior is consulted at all)', () => {
     const out = reconcileScopedBlocks([fresh('A', false)], [prior('A'), prior('D')], false, new Set(['A', 'D']));
     expect(out).toEqual(['A:fresh']);
+  });
+});
+
+describe('exclusivelyInScopeKeys', () => {
+  it('keeps a key owned only by in-scope models', () => {
+    expect([...exclusivelyInScopeKeys([{ key: 'A', inScope: true }])]).toEqual(['A']);
+  });
+
+  it('omits a key owned only by out-of-scope models', () => {
+    expect([...exclusivelyInScopeKeys([{ key: 'A', inScope: false }])]).toEqual([]);
+  });
+
+  it('lets a single out-of-scope owner veto a colliding key', () => {
+    // Two distinct IR model names normalize onto one generated class/file name.
+    // Suppressing the carry-over here would delete the OUT-OF-SCOPE model's
+    // coverage even though this run never regenerated it — so the key is vetoed
+    // regardless of which owner is seen first.
+    const owners = [
+      { key: 'Shared', inScope: true },
+      { key: 'Shared', inScope: false },
+      { key: 'Solo', inScope: true },
+    ];
+    expect([...exclusivelyInScopeKeys(owners)].sort()).toEqual(['Solo']);
+    expect([...exclusivelyInScopeKeys([...owners].reverse())].sort()).toEqual(['Solo']);
+  });
+
+  it('a vetoed key still carries its prior block over', () => {
+    const keys = exclusivelyInScopeKeys([
+      { key: 'Shared', inScope: true },
+      { key: 'Shared', inScope: false },
+    ]);
+    const out = reconcileScopedBlocks([], [prior('Shared')], true, keys);
+    expect(out).toEqual(['Shared:prior']);
   });
 });

--- a/test/shared/scoped-aggregate-merge.test.ts
+++ b/test/shared/scoped-aggregate-merge.test.ts
@@ -43,4 +43,31 @@ describe('reconcileScopedBlocks', () => {
     );
     expect(out).toEqual(['A:fresh', 'B:prior', 'Z:prior']);
   });
+
+  it('scoped: drops the prior block of an IN-SCOPE model that no longer qualifies', () => {
+    // D is in scope and its per-model file WAS regenerated, but the generator
+    // disqualified it this run (e.g. it gained an optional field, so its
+    // all-fields-required round-trip fixture no longer holds). Carrying the
+    // prior block over resurrects a fixture the fresh model can't satisfy and
+    // breaks the SDK build — drop it instead.
+    const out = reconcileScopedBlocks([fresh('A', true)], [prior('A'), prior('D')], true, new Set(['A', 'D']));
+    expect(out).toEqual(['A:fresh']);
+  });
+
+  it('scoped: still carries over a prior block whose model is out of scope', () => {
+    // Same shape as above, but D is NOT in scope: its file was left untouched on
+    // disk, so its coverage must survive the scoped run.
+    const out = reconcileScopedBlocks([fresh('A', true)], [prior('A'), prior('D')], true, new Set(['A']));
+    expect(out).toEqual(['A:fresh', 'D:prior']);
+  });
+
+  it('scoped: an in-scope key that DID produce a block is unaffected by the drop rule', () => {
+    const out = reconcileScopedBlocks([fresh('A', true)], [prior('A')], true, new Set(['A']));
+    expect(out).toEqual(['A:fresh']);
+  });
+
+  it('full run ignores inScopeKeys (no prior is consulted at all)', () => {
+    const out = reconcileScopedBlocks([fresh('A', false)], [prior('A'), prior('D')], false, new Set(['A', 'D']));
+    expect(out).toEqual(['A:fresh']);
+  });
 });


### PR DESCRIPTION
## Problem

[openapi-spec run 33013270617](https://github.com/workos/openapi-spec/actions/runs/33013270617/job/98324831144) failed the Kotlin preview build:

```
GeneratedModelRoundTripTest > AuthenticationOAuthSucceededData round-trips through Jackson() FAILED
    org.opentest4j.AssertionFailedError at GeneratedModelRoundTripTest.kt:1641
627 tests completed, 1 failed
```

Chain of events:

1. The spec gave `authentication.oauth_succeeded`'s payload a new **optional** `provider`.
2. The Kotlin model regenerated as `val provider: String? = null`.
3. `generateModelRoundTripTest` requires *every* field be required (`src/kotlin/tests.ts`), so it correctly stopped emitting a fixture for `AuthenticationOAuthSucceededData`.
4. `reconcileScopedBlocks` then re-appended the **prior** block verbatim. Its carry-over pass was unconditional — it never checked whether the key was in scope this run. The generated diff shows the block removed at old line 640 and resurrected at new line 1632, where it reads as new coverage.
5. Jackson now writes `"provider": null`; the frozen fixture JSON has no `provider`, so `assertEquals(tree1, tree2)` fails.

The carry-over rule is right for an out-of-scope model — its per-model file was left untouched on disk, so its coverage must survive. It is wrong for an in-scope one: that file **was** regenerated, so "no fresh block" means the generator disqualified it deliberately, and the prior block asserts a shape the new model can no longer produce.

## Fix

`reconcileScopedBlocks` takes an optional fourth argument: the set of keys the caller *considered* whose owning model is in scope, whether or not each produced a block. The carry-over pass skips those keys.

Wired up in all three callers:

- `src/kotlin/tests.ts` — round-trip aggregate (the failing one)
- `src/python/tests.ts` — both aggregates, sharing one key set so a model that gains or loses a discriminator doesn't strand a block in the class it left
- `src/ruby/tests.ts` — round-trip aggregate

Out-of-scope carry-over, out-of-scope freezing, and full runs are all unchanged. The parameter is optional, so an emitter that omits it keeps today's behavior.

## Tests

- `test/kotlin/tests.test.ts` — end-to-end regression: an in-scope model gains an optional field, its prior block is dropped, an out-of-scope model's block is still carried over. Verified red before the fix (`expect(...).not.toContain('Organization round-trips through Jackson')` fails on `main`).
- `test/shared/scoped-aggregate-merge.test.ts` — four unit cases covering the drop, the still-carry-over case, an in-scope key that *did* produce a block, and `inScopeKeys` being inert on a full run.

`npm test` 844 passed / 103 files · `npm run typecheck` · `npm run lint` · `npm run format` all clean.

## Follow-up

Needs an oagen-emitters release, then an openapi-spec bump, before the Kotlin preview job goes green.