### PR TITLE
fix(kotlin): spell `number` round-trip fixtures with a decimal point

### DIFF
--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -702,8 +702,13 @@ function synthJsonValue(type: TypeRef, ctx: EmitterContext, visited: Set<string>
       case 'string':
         return '"sample"';
       case 'integer':
-      case 'number':
         return '0';
+      // `number` maps to Kotlin `Double`, which Jackson reserializes as `0.0`.
+      // The round-trip test compares parsed JsonNode trees, and Jackson's
+      // numeric nodes are type-strict (`IntNode(0) != DoubleNode(0.0)`), so an
+      // integer literal here fails the round trip. Carry the decimal point.
+      case 'number':
+        return '0.0';
       case 'boolean':
         return 'false';
     }

--- a/test/kotlin/tests.test.ts
+++ b/test/kotlin/tests.test.ts
@@ -134,6 +134,33 @@ describe('kotlin/tests', () => {
     expect(content).toContain('assertEquals(tree1, tree2)');
   });
 
+  it('round-trip fixture spells `number` fields with a decimal point', () => {
+    // `number` maps to Kotlin `Double`, so Jackson reserializes it as `0.0`.
+    // The round-trip test compares parsed JsonNode trees and Jackson's numeric
+    // nodes are type-strict, so an integer literal in the fixture would make
+    // `IntNode(0)` face `DoubleNode(0.0)` and fail. `integer` stays `0`.
+    const numericSpec: ApiSpec = {
+      ...spec,
+      models: [
+        {
+          name: 'SessionSetting',
+          fields: [
+            { name: 'max_age_seconds', type: { kind: 'primitive', type: 'number' }, required: true },
+            { name: 'retry_count', type: { kind: 'primitive', type: 'integer' }, required: true },
+          ],
+        },
+      ],
+    };
+    const numericCtx: EmitterContext = { ...ctx, spec: numericSpec };
+
+    generateEnums([], numericCtx);
+    const files = generateTests(numericSpec, numericCtx);
+    const roundTrip = files.find((f) => f.path.includes('GeneratedModelRoundTripTest.kt'))!;
+
+    expect(roundTrip.content).toContain('\\"max_age_seconds\\": 0.0');
+    expect(roundTrip.content).toContain('\\"retry_count\\": 0');
+  });
+
   it('generates forward-compat test with OffsetDateTime round-trip', () => {
     generateEnums([], ctx);
     const files = generateTests(spec, ctx);


### PR DESCRIPTION
## Summary

- `synthJsonValue` collapsed `integer` and `number` into the literal `0`, but `number` maps to Kotlin `Double`, so Jackson reserializes the parsed value as `0.0`. `GeneratedModelRoundTripTest` compares parsed `JsonNode` trees and Jackson's numeric nodes are type-strict, so `IntNode(0)` faced `DoubleNode(0.0)` and the assertion failed.
- Split the two cases: `integer` keeps `0`, `number` becomes `0.0`. The sibling synthesizers in the same file — `synthValue` (Kotlin expressions, `:600`) and `queryValueRegexFor` (`:516`) — already drew this distinction; only the JSON fixture didn't.
- Nothing exercised this until the spec added an inline `session_settings` object to the `agent.blueprint.created` / `agent.blueprint.updated` webhook payloads — the first round-tripped model with a `number` field. It failed `sdk_build (kotlin)` on workos/openapi-spec#128 with two `AssertionFailedError`s.
- Added a regression test asserting the fixture emits `"max_age_seconds": 0.0` next to `"retry_count": 0`, so the integer/number split stays pinned in both directions.
- Verified end to end: built the emitter, regenerated `workos-kotlin` against the openapi-spec#128 spec, and `script/ci` passes — lint, format, 628 tests / 0 failures, including both `AgentBlueprint{Created,Updated}DataSessionSetting round-trips through Jackson`.
