### PR TITLE
fix: give diverging parameter-group wrappers distinct types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
       "version": "0.24.6",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.29.0"
+        "@workos/oagen": "^0.29.3"
       },
       "devDependencies": {
-        "@commitlint/cli": "^21.2.1",
-        "@commitlint/config-conventional": "^21.2.0",
-        "@types/node": "^26.1.2",
+        "@commitlint/cli": "^21.2.2",
+        "@commitlint/config-conventional": "^21.2.2",
+        "@types/node": "^26.4.0",
         "husky": "^9.1.7",
-        "oxfmt": "^0.62.0",
-        "oxlint": "^1.77.0",
+        "oxfmt": "^0.65.0",
+        "oxlint": "^1.80.0",
         "prettier": "^3.9.6",
         "tsdown": "^0.22.14",
-        "tsx": "^4.23.8",
+        "tsx": "^4.23.13",
         "typescript": "^7.0.2",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.11"
       },
       "engines": {
         "node": ">=24.10.0"
@@ -63,16 +63,16 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "21.2.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.1.tgz",
-      "integrity": "sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.2.tgz",
+      "integrity": "sha512-a+6hQxIxnpdvSvS2apvttPNbEliYsVC3PqFYDiiB2kjbwIsQsj1urvQ4Tkf70pKYozPalKAuRQmm/GHwndduqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-conventional": "^21.2.0",
-        "@commitlint/format": "^21.2.0",
-        "@commitlint/lint": "^21.2.0",
-        "@commitlint/load": "^21.2.0",
+        "@commitlint/config-conventional": "^21.2.2",
+        "@commitlint/format": "^21.2.2",
+        "@commitlint/lint": "^21.2.2",
+        "@commitlint/load": "^21.2.2",
         "@commitlint/read": "^21.2.1",
         "@commitlint/types": "^21.2.0",
         "tinyexec": "^1.0.0",
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
-      "integrity": "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.2.tgz",
+      "integrity": "sha512-NxA37SZviusFUEYOQZ5hNnZ1h7O/KiemPkxjOlpzKJNnWxThiwc6/SaZhaPa8fyLvfRBAywhQhJJk8XESHWlpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.0.tgz",
-      "integrity": "sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.2.tgz",
+      "integrity": "sha512-v6fvxZSc/AvVMROlr3H34+1766bZSYApRUSCAMjWamStPjKMvZ8GdvVA5YW/VQNgbFTmcMz6OYmSTJEvIjPrfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.0.tgz",
-      "integrity": "sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.2.tgz",
+      "integrity": "sha512-9UoKNgfFE3LU7FrzierCvk3CdDfMDeVGC86qZiT/n0TIjfq/dmZ9MHuXd45OTNRa26ZanmJRxEtmiXk/lEJihg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -166,15 +166,15 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.0.tgz",
-      "integrity": "sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.2.tgz",
+      "integrity": "sha512-Fy8JxEBzdmsYWFude/61GxXu5O+wEymwiRK2z9GL9R8mCsXphCoGxAFc5iHn5mjlfcSrhiiONE+ksf4KOjnaPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^21.2.0",
-        "@commitlint/parse": "^21.2.0",
-        "@commitlint/rules": "^21.2.0",
+        "@commitlint/is-ignored": "^21.2.2",
+        "@commitlint/parse": "^21.2.2",
+        "@commitlint/rules": "^21.2.2",
         "@commitlint/types": "^21.2.0"
       },
       "engines": {
@@ -182,15 +182,15 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.0.tgz",
-      "integrity": "sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.2.tgz",
+      "integrity": "sha512-0Tt6wDPX167cjKC5D4zhm0+20wJJG+TN/TKovMOspfSe78rOnKX+MNzlVNiu6HyQPZChPJ8QBH31MVt6Bb8fCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^21.2.0",
         "@commitlint/execute-rule": "^21.0.1",
-        "@commitlint/resolve-extends": "^21.2.0",
+        "@commitlint/resolve-extends": "^21.2.2",
         "@commitlint/types": "^21.2.0",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
@@ -213,9 +213,9 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.0.tgz",
-      "integrity": "sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.2.tgz",
+      "integrity": "sha512-MEkobPfvRp+z06Wro8HMG1BDGHzZmj82A1LH1nWeG3ipHpg/x4m6v3wEDvMBIKjRFUnfR3nBeFs3MVCr7UdAmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -225,36 +225,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@commitlint/parse/node_modules/conventional-commits-parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.0.1.tgz",
-      "integrity": "sha512-6VtskFpPsNkGVk/TY2RnV/MEdKfvCPBtQZN9x8jh9+k5RWBQ+tiaWn5UFCzTr0Dd88iKx7xghxbjBRp5uIzp3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/stream-utils": "^2.0.0",
-        "meow": "^14.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@commitlint/parse/node_modules/meow": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@commitlint/read": {
@@ -274,9 +244,9 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
-      "integrity": "sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.2.tgz",
+      "integrity": "sha512-RPkJ/IFi7sMUUVbZLqwWFtWw/zRDcfFsmrPSiTMrt5wb7AdxOr86EGQFvmGzef5QKV5IPBWWCujqVTw1RWX44A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -291,9 +261,9 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.0.tgz",
-      "integrity": "sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==",
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.2.tgz",
+      "integrity": "sha512-eplQzyYkBjYB1HyyRj8hkcK11Y9DU9nuBz7uOKEd6NpE9NGDytLFCAnlRE+OoiK/5sHEJsaz2RGhuWBvYzIbNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -343,36 +313,6 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/@commitlint/types/node_modules/conventional-commits-parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.0.1.tgz",
-      "integrity": "sha512-6VtskFpPsNkGVk/TY2RnV/MEdKfvCPBtQZN9x8jh9+k5RWBQ+tiaWn5UFCzTr0Dd88iKx7xghxbjBRp5uIzp3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/stream-utils": "^2.0.0",
-        "meow": "^14.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/meow": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@conventional-changelog/git-client": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.0.tgz",
@@ -401,47 +341,13 @@
       }
     },
     "node_modules/@conventional-changelog/template": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
-      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
+      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -861,35 +767,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
-      "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -897,9 +784,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.62.0.tgz",
-      "integrity": "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.65.0.tgz",
+      "integrity": "sha512-M10Gs1SSpTNI6ahGx3M/OlIdUF4hkaP6OgUb+MS79t/Pgflk3r1nW5gPFqsZGUAXg0H1AfANT9AvLdBSTIhZKg==",
       "cpu": [
         "arm"
       ],
@@ -914,9 +801,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.62.0.tgz",
-      "integrity": "sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.65.0.tgz",
+      "integrity": "sha512-6DXH5sftNlaHpWJG50hFMF+Qxtq5D2TmahvcDPxWNcGIf8qrC9Y0YgHYcYZ2hlWzaccKXh/f3GcssH8vtkl4JA==",
       "cpu": [
         "arm64"
       ],
@@ -931,9 +818,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.62.0.tgz",
-      "integrity": "sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.65.0.tgz",
+      "integrity": "sha512-K9m7lr53pcOLETNsC88sWes/GWHUGjZyHx95UhYcSXy0r30haLdeXlSufSenEAtoLaW753WN8/l4M7GYcRt6cg==",
       "cpu": [
         "arm64"
       ],
@@ -948,9 +835,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.62.0.tgz",
-      "integrity": "sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.65.0.tgz",
+      "integrity": "sha512-sTNwIx1gre3MyiHOPLu7IGW4UyMScYL4DTmJT01p4vzB0En+OJUQz6KuH8t0PpsClRSaMuY3b0QmtoPItfO8Lg==",
       "cpu": [
         "x64"
       ],
@@ -965,9 +852,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.62.0.tgz",
-      "integrity": "sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.65.0.tgz",
+      "integrity": "sha512-lYZMVIiIpnjGu5hJb2jxA8NYQ/e0OTGuaiAf4dqlGPNnPmUTu23FZRMltmjro/KkQm1uE4NT4n5yJ2zWmKcpfA==",
       "cpu": [
         "x64"
       ],
@@ -982,9 +869,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.62.0.tgz",
-      "integrity": "sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.65.0.tgz",
+      "integrity": "sha512-gIdXFAt/bURnjxuoedDEWdZ0PEWEmdDcm8qdpoFYYvW3QMk/5D4vUaH4mlMeRpeTdST4izUgHVO6RawQ4QulJw==",
       "cpu": [
         "arm"
       ],
@@ -999,9 +886,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.62.0.tgz",
-      "integrity": "sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.65.0.tgz",
+      "integrity": "sha512-jJVyADto7gA2AaX5qAjAexrxx9PJQaKWOe8PICE7yKMbjBRyOHcmj9TtVJ+MZYDUQ3hodU0AcoTj0jFQ1W4C6Q==",
       "cpu": [
         "arm"
       ],
@@ -1016,9 +903,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.62.0.tgz",
-      "integrity": "sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.65.0.tgz",
+      "integrity": "sha512-p3RFkB+u7u+8up99b/NEcI1hdpLDiGgJYNwDorB60n7eH+eKposAKuMBxx+NqB3b+sJP4CZmYDh9G7X62tUsKg==",
       "cpu": [
         "arm64"
       ],
@@ -1036,9 +923,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.62.0.tgz",
-      "integrity": "sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.65.0.tgz",
+      "integrity": "sha512-5Prb0uFzJHr+OUD/qS/TmU526wD+PaHDsm3KoRiUXbMIDpTSErjeQYkK3OQeshAvD/PuLa9WGEi9WPajjdOZJg==",
       "cpu": [
         "arm64"
       ],
@@ -1056,9 +943,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.62.0.tgz",
-      "integrity": "sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.65.0.tgz",
+      "integrity": "sha512-S8svxTp81obnF3admN9yd+u2rOYXtyzThLGBTg1PY6TPtGcC09BaaXLQD+TBSMa7yvqhCDZ8DFri+S/yG60qCg==",
       "cpu": [
         "ppc64"
       ],
@@ -1076,9 +963,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.62.0.tgz",
-      "integrity": "sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.65.0.tgz",
+      "integrity": "sha512-WtXBr75G/h2qOHy8SiGtC1R6aS3jt4mE52v1D8AtwMXIgoOmSNP9lKvbSaTRoL0e5wsMPoi6T72QWDYPu+S+nA==",
       "cpu": [
         "riscv64"
       ],
@@ -1096,9 +983,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.62.0.tgz",
-      "integrity": "sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.65.0.tgz",
+      "integrity": "sha512-YwSLVvpaz4o/nv/miiPEBJz+eJ+VmbgNIrao6RccK9ce+L5EA8wP+ZD0uFeq6wKOza6zoWv/dR0sj6lip6R3EA==",
       "cpu": [
         "riscv64"
       ],
@@ -1116,9 +1003,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.62.0.tgz",
-      "integrity": "sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.65.0.tgz",
+      "integrity": "sha512-XQTPqgvyrgkKcFq+Tp2eK6JS7sqqJ+nRmy2Fav4j3I+i4dJoPJm7YwEdoeSDX9xkqj9jZ/lWfF3bXUWztIrn6A==",
       "cpu": [
         "s390x"
       ],
@@ -1136,9 +1023,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.62.0.tgz",
-      "integrity": "sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.65.0.tgz",
+      "integrity": "sha512-cjZlx6S/VkeCNWCbwZriTnLnZeTcV3DEyeRGSw/2wwLP9viq+C0bJ4bC1k/ZLkFxDcB1lUgSasPkYGP1bdraOg==",
       "cpu": [
         "x64"
       ],
@@ -1156,9 +1043,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.62.0.tgz",
-      "integrity": "sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.65.0.tgz",
+      "integrity": "sha512-2azCjxdLtK4zCcIOU1dlXlU0xxfbPi6EjwWx7Ac7teWPidIIDOcIhudup83xNCKYhtqeVd/gaVDOxbUq4syXWA==",
       "cpu": [
         "x64"
       ],
@@ -1176,9 +1063,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.62.0.tgz",
-      "integrity": "sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.65.0.tgz",
+      "integrity": "sha512-KXQ7xi1e/voP0IQaw6fG6XY4Z5+Llf1XmRSZS1t7pVFCecFJ0iXaboKmVwjFtp5MLlT5iWQrJ2U1C3GJdZ2u+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1193,9 +1080,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.62.0.tgz",
-      "integrity": "sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.65.0.tgz",
+      "integrity": "sha512-2FbbjG5jEqLSLKVJwBap84uJfpn5Y5A53KEO0aUNr+zeiRB9nyPUIFMcSbZVMFLitfBytFWRNngozXYjb6Rsbw==",
       "cpu": [
         "arm64"
       ],
@@ -1210,9 +1097,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.62.0.tgz",
-      "integrity": "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.65.0.tgz",
+      "integrity": "sha512-LJ+ZacAPSjegDOnSLyA1TMWAhdDrsK4el3REdr1oL2UtVBCMhO2II/Sb3cEW6mF2MfLhl8hDNCSvc7KSbgk3LQ==",
       "cpu": [
         "ia32"
       ],
@@ -1227,9 +1114,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.62.0.tgz",
-      "integrity": "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.65.0.tgz",
+      "integrity": "sha512-higu9cWEO6XXFzATD1jf0mCK34rNfN2H9JrJie7QB1IhleVpTh0QlLH9Ip2C1H/Nd5n0v5pvRtC+5R0uE4HpVg==",
       "cpu": [
         "x64"
       ],
@@ -1244,9 +1131,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
-      "integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.80.0.tgz",
+      "integrity": "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA==",
       "cpu": [
         "arm"
       ],
@@ -1261,9 +1148,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
-      "integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.80.0.tgz",
+      "integrity": "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw==",
       "cpu": [
         "arm64"
       ],
@@ -1278,9 +1165,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
-      "integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.80.0.tgz",
+      "integrity": "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA==",
       "cpu": [
         "arm64"
       ],
@@ -1295,9 +1182,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
-      "integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.80.0.tgz",
+      "integrity": "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA==",
       "cpu": [
         "x64"
       ],
@@ -1312,9 +1199,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
-      "integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.80.0.tgz",
+      "integrity": "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg==",
       "cpu": [
         "x64"
       ],
@@ -1329,9 +1216,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
-      "integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.80.0.tgz",
+      "integrity": "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA==",
       "cpu": [
         "arm"
       ],
@@ -1346,9 +1233,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
-      "integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.80.0.tgz",
+      "integrity": "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ==",
       "cpu": [
         "arm"
       ],
@@ -1363,9 +1250,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
-      "integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.80.0.tgz",
+      "integrity": "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A==",
       "cpu": [
         "arm64"
       ],
@@ -1383,9 +1270,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
-      "integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.80.0.tgz",
+      "integrity": "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ==",
       "cpu": [
         "arm64"
       ],
@@ -1403,9 +1290,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
-      "integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.80.0.tgz",
+      "integrity": "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A==",
       "cpu": [
         "ppc64"
       ],
@@ -1423,9 +1310,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
-      "integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.80.0.tgz",
+      "integrity": "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA==",
       "cpu": [
         "riscv64"
       ],
@@ -1443,9 +1330,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
-      "integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.80.0.tgz",
+      "integrity": "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1463,9 +1350,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
-      "integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.80.0.tgz",
+      "integrity": "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw==",
       "cpu": [
         "s390x"
       ],
@@ -1483,9 +1370,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
-      "integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.80.0.tgz",
+      "integrity": "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A==",
       "cpu": [
         "x64"
       ],
@@ -1503,9 +1390,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
-      "integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.80.0.tgz",
+      "integrity": "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ==",
       "cpu": [
         "x64"
       ],
@@ -1523,9 +1410,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
-      "integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.80.0.tgz",
+      "integrity": "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA==",
       "cpu": [
         "arm64"
       ],
@@ -1540,9 +1427,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
-      "integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.80.0.tgz",
+      "integrity": "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ==",
       "cpu": [
         "arm64"
       ],
@@ -1557,9 +1444,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
-      "integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.80.0.tgz",
+      "integrity": "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw==",
       "cpu": [
         "ia32"
       ],
@@ -1574,9 +1461,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
-      "integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.80.0.tgz",
+      "integrity": "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q==",
       "cpu": [
         "x64"
       ],
@@ -1690,10 +1577,27 @@
         "js-yaml": "bin/js-yaml.mjs"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.0.tgz",
-      "integrity": "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1708,9 +1612,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.0.tgz",
-      "integrity": "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
       "cpu": [
         "arm64"
       ],
@@ -1725,9 +1629,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.0.tgz",
-      "integrity": "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
       "cpu": [
         "x64"
       ],
@@ -1742,9 +1646,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.0.tgz",
-      "integrity": "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
       "cpu": [
         "x64"
       ],
@@ -1759,9 +1663,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.0.tgz",
-      "integrity": "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
       "cpu": [
         "arm"
       ],
@@ -1776,9 +1680,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.0.tgz",
-      "integrity": "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
       "cpu": [
         "arm64"
       ],
@@ -1796,9 +1700,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.0.tgz",
-      "integrity": "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
       "cpu": [
         "arm64"
       ],
@@ -1816,9 +1720,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.0.tgz",
-      "integrity": "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1836,9 +1740,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.0.tgz",
-      "integrity": "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
       "cpu": [
         "s390x"
       ],
@@ -1856,9 +1760,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.0.tgz",
-      "integrity": "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
       "cpu": [
         "x64"
       ],
@@ -1876,9 +1780,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.0.tgz",
-      "integrity": "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
       "cpu": [
         "x64"
       ],
@@ -1896,9 +1800,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.0.tgz",
-      "integrity": "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
       "cpu": [
         "arm64"
       ],
@@ -1912,29 +1816,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.0.tgz",
-      "integrity": "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.2",
-        "@emnapi/runtime": "1.11.2",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.0.tgz",
-      "integrity": "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
       "cpu": [
         "arm64"
       ],
@@ -1949,9 +1834,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.0.tgz",
-      "integrity": "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
       "cpu": [
         "x64"
       ],
@@ -2008,17 +1893,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2051,9 +1925,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2401,16 +2275,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2419,13 +2293,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2446,9 +2320,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2459,13 +2333,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2473,14 +2347,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2489,9 +2363,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2499,13 +2373,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2514,9 +2388,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.29.2.tgz",
-      "integrity": "sha512-jS71kyo9WaZx3IFzZ3+/3BLTVNDo7r19kd4AWOHS3inxp4AoY2EmTSmbz+pMwO16G/IZv2/CCaAID4oDqQqapA==",
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.29.3.tgz",
+      "integrity": "sha512-HH3ASAG+lgwcTP3O1gVlW9XKp5RLUmXg9b5qFLxCHJBYYv+fIQ1mMgtTD9JnfZOFrYqLo7ZNG+pMPPjIkz5vkA==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.40.0",
@@ -2981,6 +2855,19 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3052,26 +2939,43 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
-      "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.4.0.tgz",
+      "integrity": "sha512-HdxRxuS8bBXVIuo4V82gvSwAXT0vYQUizrjs/izmPg5JdDstr8v8I5hduGL3iQbG+o310dUDxC4+LetuS5hu9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "@conventional-changelog/template": "^1.4.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
+      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
         "node": ">=22"
@@ -3085,9 +2989,9 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3224,14 +3128,16 @@
       "license": "MIT"
     },
     "node_modules/es-toolkit": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
-      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
-        "benchmarks"
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/esbuild": {
@@ -3543,9 +3449,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3593,9 +3499,9 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -3609,23 +3515,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -3644,9 +3550,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -3665,9 +3571,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -3686,9 +3592,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -3707,9 +3613,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -3728,9 +3634,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -3752,9 +3658,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -3776,9 +3682,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -3800,9 +3706,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -3824,9 +3730,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -3845,9 +3751,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -3883,9 +3789,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3936,9 +3842,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.62.0.tgz",
-      "integrity": "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.65.0.tgz",
+      "integrity": "sha512-SgS5VgnP42T0zl3zWD+xoH8FCqg1SAFnSRoOT/qeoa6gxcYIqrDMOmcXIg/EWSN92Du4ogB4riuKhKd6Y4CGhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3954,25 +3860,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.62.0",
-        "@oxfmt/binding-android-arm64": "0.62.0",
-        "@oxfmt/binding-darwin-arm64": "0.62.0",
-        "@oxfmt/binding-darwin-x64": "0.62.0",
-        "@oxfmt/binding-freebsd-x64": "0.62.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.62.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.62.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.62.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.62.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.62.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.62.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.62.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.62.0",
-        "@oxfmt/binding-linux-x64-musl": "0.62.0",
-        "@oxfmt/binding-openharmony-arm64": "0.62.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.62.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.62.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.62.0"
+        "@oxfmt/binding-android-arm-eabi": "0.65.0",
+        "@oxfmt/binding-android-arm64": "0.65.0",
+        "@oxfmt/binding-darwin-arm64": "0.65.0",
+        "@oxfmt/binding-darwin-x64": "0.65.0",
+        "@oxfmt/binding-freebsd-x64": "0.65.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.65.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.65.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.65.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.65.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.65.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.65.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.65.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.65.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.65.0",
+        "@oxfmt/binding-linux-x64-musl": "0.65.0",
+        "@oxfmt/binding-openharmony-arm64": "0.65.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.65.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.65.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.65.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -3988,9 +3894,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
-      "integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.80.0.tgz",
+      "integrity": "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4003,25 +3909,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.77.0",
-        "@oxlint/binding-android-arm64": "1.77.0",
-        "@oxlint/binding-darwin-arm64": "1.77.0",
-        "@oxlint/binding-darwin-x64": "1.77.0",
-        "@oxlint/binding-freebsd-x64": "1.77.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.77.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.77.0",
-        "@oxlint/binding-linux-arm64-musl": "1.77.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.77.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.77.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.77.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.77.0",
-        "@oxlint/binding-linux-x64-gnu": "1.77.0",
-        "@oxlint/binding-linux-x64-musl": "1.77.0",
-        "@oxlint/binding-openharmony-arm64": "1.77.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.77.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.77.0",
-        "@oxlint/binding-win32-x64-msvc": "1.77.0"
+        "@oxlint/binding-android-arm-eabi": "1.80.0",
+        "@oxlint/binding-android-arm64": "1.80.0",
+        "@oxlint/binding-darwin-arm64": "1.80.0",
+        "@oxlint/binding-darwin-x64": "1.80.0",
+        "@oxlint/binding-freebsd-x64": "1.80.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.80.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.80.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.80.0",
+        "@oxlint/binding-linux-arm64-musl": "1.80.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.80.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.80.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.80.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.80.0",
+        "@oxlint/binding-linux-x64-gnu": "1.80.0",
+        "@oxlint/binding-linux-x64-musl": "1.80.0",
+        "@oxlint/binding-openharmony-arm64": "1.80.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.80.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.80.0",
+        "@oxlint/binding-win32-x64-msvc": "1.80.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -4104,9 +4010,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4124,7 +4030,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4195,13 +4101,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.0.tgz",
-      "integrity": "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.140.0",
+        "@oxc-project/types": "=0.147.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -4211,21 +4117,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.0",
-        "@rolldown/binding-darwin-arm64": "1.2.0",
-        "@rolldown/binding-darwin-x64": "1.2.0",
-        "@rolldown/binding-freebsd-x64": "1.2.0",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.0",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.0",
-        "@rolldown/binding-linux-arm64-musl": "1.2.0",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.0",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.0",
-        "@rolldown/binding-linux-x64-gnu": "1.2.0",
-        "@rolldown/binding-linux-x64-musl": "1.2.0",
-        "@rolldown/binding-openharmony-arm64": "1.2.0",
-        "@rolldown/binding-wasm32-wasi": "1.2.0",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.0",
-        "@rolldown/binding-win32-x64-msvc": "1.2.0"
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
       }
     },
     "node_modules/rolldown-plugin-dts": {
@@ -4393,9 +4299,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4706,18 +4612,10 @@
         }
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/tsx": {
-      "version": "4.23.11",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
-      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -4802,16 +4700,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4828,7 +4726,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4879,373 +4777,20 @@
         }
       }
     },
-    "node_modules/vite/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/vite/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/vite/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/vite/node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/vite/node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.133.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
-      }
-    },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5273,12 +4818,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -38,22 +38,22 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@commitlint/cli": "^21.2.1",
-    "@commitlint/config-conventional": "^21.2.0",
-    "@types/node": "^26.1.2",
+    "@commitlint/cli": "^21.2.2",
+    "@commitlint/config-conventional": "^21.2.2",
+    "@types/node": "^26.4.0",
     "husky": "^9.1.7",
-    "oxfmt": "^0.62.0",
-    "oxlint": "^1.77.0",
+    "oxfmt": "^0.65.0",
+    "oxlint": "^1.80.0",
     "prettier": "^3.9.6",
     "tsdown": "^0.22.14",
-    "tsx": "^4.23.8",
+    "tsx": "^4.23.13",
     "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   },
   "engines": {
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.29.0"
+    "@workos/oagen": "^0.29.3"
   }
 }

--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -42,6 +42,7 @@ import {
   hasHiddenParams,
   collectGroupedParamNames,
   collectBodyFieldTypes,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { generateWrapperMethods } from './wrappers.js';
 
@@ -128,7 +129,7 @@ function generateParameterGroupTypes(
   const bodyFieldTypes = collectBodyFieldTypes(op, models);
 
   for (const group of op.parameterGroups ?? []) {
-    const baseName = groupBaseClassName(mountName, group.name);
+    const baseName = groupBaseClassName(mountName, groupTypeBaseName(group));
     if (emitted?.has(baseName)) continue;
     emitted?.add(baseName);
 
@@ -136,7 +137,7 @@ function generateParameterGroupTypes(
     lines.push(`    public abstract class ${baseName} { }`);
 
     for (const variant of group.variants) {
-      const variantName = groupVariantClassName(mountName, group.name, variant.name);
+      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name);
       lines.push('');
       lines.push(`    public class ${variantName} : ${baseName}`);
       lines.push('    {');
@@ -186,7 +187,7 @@ function emitGroupSerialization(
     let first = true;
 
     for (const variant of group.variants) {
-      const variantName = groupVariantClassName(mountName, group.name, variant.name);
+      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name);
       // Use a short local variable derived from the variant name
       const localVar = localName(variant.name);
       const keyword = first ? 'if' : 'else if';
@@ -639,7 +640,7 @@ function generateOptionsFile(mountName: string, operations: Operation[], ctx: Em
 
     // Parameter group properties (serialized manually in the service method, not by JSON)
     for (const group of op.parameterGroups ?? []) {
-      const baseName = groupBaseClassName(mountName, group.name);
+      const baseName = groupBaseClassName(mountName, groupTypeBaseName(group));
       const csField = fieldName(group.name);
       optionsLines.push('        [JsonIgnore]');
       optionsLines.push('        [STJS.JsonIgnore]');

--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -5,6 +5,7 @@ import type {
   EmitterContext,
   GeneratedFile,
   ResolvedOperation,
+  Model,
 } from '@workos/oagen';
 import { planOperation, toSnakeCase } from '@workos/oagen';
 import { isListWrapperModel } from './models.js';
@@ -28,6 +29,7 @@ import {
   hasHiddenParams,
   collectGroupedParamNames,
   collectBodyFieldTypes,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { lowerFirstForDoc, fieldDocComment } from '../shared/naming-utils.js';
 import { generateWrapperMethods } from './wrappers.js';
@@ -139,17 +141,9 @@ function generateServiceFile(mountName: string, operations: Operation[], ctx: Em
   // type definitions. A group with the same name may appear in both query-param
   // and body-param contexts; the interface then carries both applyToQuery and
   // applyToBody methods.
-  const groupTypes = collectFileGroups(mountName, operations);
+  const groupTypes = collectFileGroups(mountName, operations, ctx.spec.models);
   if (groupTypes.length > 0) {
-    // Collect body field types from all operations so variant structs use the
-    // correct IR types (the parser's group-level types can fall back to string).
-    const mergedBodyFieldTypes = new Map<string, import('@workos/oagen').TypeRef>();
-    for (const op of operations) {
-      for (const [k, v] of collectBodyFieldTypes(op, ctx.spec.models)) {
-        mergedBodyFieldTypes.set(k, v);
-      }
-    }
-    lines.push(emitCollectedGroupTypes(mountName, groupTypes, mergedBodyFieldTypes));
+    lines.push(emitCollectedGroupTypes(mountName, groupTypes));
   }
 
   // Generate params structs and methods for each operation.
@@ -282,33 +276,53 @@ function deriveVariantFieldName(paramName: string, groupName: string): string {
 
 /** Collected group metadata, merged across all operations in a file. */
 interface CollectedGroup {
+  /** Group name from the spec. Strips member field prefixes; not a type name. */
   name: string;
+  /**
+   * Base name for this group's generated interface and variant structs. Equals
+   * `name` unless two operations' declarations of the group diverge, in which
+   * case oagen qualifies it so each gets its own Go types instead of both
+   * collapsing onto one that fits only one of the operations.
+   */
+  typeBaseName: string;
   needsQuery: boolean;
   needsBody: boolean;
   /** Use the first variant set encountered (they should be identical). */
   variants: import('@workos/oagen').ParameterGroupVariant[];
+  /**
+   * Body field types from the operation that contributed this group. Captured
+   * per group rather than merged across the file: the map is keyed by wire
+   * field name, and two operations can type one field differently, so a merged
+   * map would let whichever operation is visited last decide for all of them.
+   */
+  bodyFieldTypes: Map<string, import('@workos/oagen').TypeRef>;
 }
 
 /**
  * Pre-collect all parameter groups across operations in a mount group,
- * deduplicating by group name and merging query/body usage flags.
+ * deduplicating by generated type name and merging query/body usage flags.
  */
-function collectFileGroups(mountName: string, operations: Operation[]): CollectedGroup[] {
+function collectFileGroups(mountName: string, operations: Operation[], models: Model[]): CollectedGroup[] {
   const byName = new Map<string, CollectedGroup>();
 
   for (const op of operations) {
     for (const group of op.parameterGroups ?? []) {
-      const existing = byName.get(group.name);
+      // Key on the type base name, not the group name: two operations whose
+      // declarations diverge must NOT be merged into one set of Go types.
+      const typeBaseName = groupTypeBaseName(group);
+      const existing = byName.get(typeBaseName);
       const isBody = isBodyGroup(group, op);
       if (existing) {
         if (isBody) existing.needsBody = true;
         else existing.needsQuery = true;
       } else {
-        byName.set(group.name, {
+        byName.set(typeBaseName, {
           name: group.name,
+          typeBaseName,
           needsQuery: !isBody,
           needsBody: isBody,
           variants: group.variants,
+          bodyFieldTypes: collectBodyFieldTypes(op, models),
         });
       }
     }
@@ -322,18 +336,14 @@ function collectFileGroups(mountName: string, operations: Operation[]): Collecte
  * collected parameter groups in a file. Groups used in query contexts get
  * applyToQuery; body contexts get applyToBody; groups used in both get both.
  */
-function emitCollectedGroupTypes(
-  mountName: string,
-  groups: CollectedGroup[],
-  bodyFieldTypes: Map<string, import('@workos/oagen').TypeRef>,
-): string {
+function emitCollectedGroupTypes(mountName: string, groups: CollectedGroup[]): string {
   const lines: string[] = [];
 
   for (const group of groups) {
-    const ifaceName = groupInterfaceName(mountName, group.name);
+    const ifaceName = groupInterfaceName(mountName, group.typeBaseName);
     const markerMethod = `is${ifaceName}`;
 
-    const variantNames = group.variants.map((v) => groupVariantTypeName(mountName, group.name, v.name));
+    const variantNames = group.variants.map((v) => groupVariantTypeName(mountName, group.typeBaseName, v.name));
     lines.push(`// ${ifaceName} is one of:`);
     for (const vn of variantNames) {
       lines.push(`//   - ${vn}`);
@@ -350,7 +360,7 @@ function emitCollectedGroupTypes(
     lines.push('');
 
     for (const variant of group.variants) {
-      const typeName = groupVariantTypeName(mountName, group.name, variant.name);
+      const typeName = groupVariantTypeName(mountName, group.typeBaseName, variant.name);
 
       // Members named in optionalParameters may be omitted when this variant is
       // used: they become pointer fields (Go's optional convention) and trail
@@ -362,7 +372,7 @@ function emitCollectedGroupTypes(
       ];
       const members = orderedParams.map((param) => {
         const goField = deriveVariantFieldName(param.name, group.name);
-        const baseType = mapTypeRefValue(bodyFieldTypes.get(param.name) ?? param.type);
+        const baseType = mapTypeRefValue(group.bodyFieldTypes.get(param.name) ?? param.type);
         const isOptional = optionalNames.has(param.name);
         const goType = isOptional ? makeOptional(baseType) : baseType;
         // makeOptional leaves already-nil-able types (slices, maps, model
@@ -543,7 +553,7 @@ function generateParamsStruct(
   // Parameter group fields (sum-type interfaces, serialized via applyToQuery)
   for (const group of op.parameterGroups ?? []) {
     const goField = fieldName(group.name);
-    const goType = groupInterfaceName(mountName, group.name);
+    const goType = groupInterfaceName(mountName, groupTypeBaseName(group));
     if (group.optional) {
       lines.push(`\t// ${goField} optionally identifies the ${group.name.replace(/_/g, ' ')}.`);
     } else {

--- a/src/kotlin/resources.ts
+++ b/src/kotlin/resources.ts
@@ -41,6 +41,7 @@ import {
   getOpInferFromClient,
   collectGroupedParamNames,
   collectBodyFieldTypes,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { generateWrapperMethods } from './wrappers.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
@@ -192,16 +193,16 @@ function generateApiClass(
   // Emit sealed classes for parameter groups before the API class.
   // Parameter-group IR can lose body field type fidelity; prefer the request
   // body model's field type when available.
-  const bodyFieldTypes = new Map<string, TypeRef>();
-  for (const op of operations) {
-    for (const [name, type] of collectBodyFieldTypes(op, ctx.spec.models)) {
-      bodyFieldTypes.set(name, type);
-    }
-  }
   const sealedLines: string[] = [];
   const emittedSealedClasses = new Set<string>();
   for (const op of operations) {
     if ((op.parameterGroups?.length ?? 0) > 0) {
+      // Resolved per operation, never merged across the file. The map is keyed
+      // by wire field name and two operations can type one field differently —
+      // `saml_options` is a CreateConnectionSAMLOptions on create and a
+      // PatchConnectionSAMLOptions on update — so a file-wide map lets whichever
+      // operation happens to be visited last decide the type for all of them.
+      const bodyFieldTypes = collectBodyFieldTypes(op, ctx.spec.models);
       for (const group of op.parameterGroups ?? []) {
         // Register imports for types used in parameter group sealed classes.
         // The body field type override may introduce enum/model types that
@@ -212,8 +213,12 @@ function generateApiClass(
             registerTypeImports(effectiveType, imports, ctx);
           }
         }
-        if (emittedSealedClasses.has(group.name)) continue;
-        emittedSealedClasses.add(group.name);
+        // Keyed on the type base name: where two operations' declarations of a
+        // group diverge oagen gives them distinct base names, and both sealed
+        // classes have to be emitted rather than the first one winning.
+        const sealedKey = groupTypeBaseName(group);
+        if (emittedSealedClasses.has(sealedKey)) continue;
+        emittedSealedClasses.add(sealedKey);
         for (const line of generateSealedClass(group, bodyFieldTypes)) sealedLines.push(line);
       }
     }
@@ -390,7 +395,7 @@ function renderMethod(
 
   // Parameter group params (sealed class types)
   for (const group of op.parameterGroups ?? []) {
-    const sealedName = sealedGroupName(group.name);
+    const sealedName = sealedGroupName(group);
     const prop = groupParamNames.get(group.name)!;
     if (group.optional) {
       pushParam(`    ${prop}: ${sealedName}? = null`, prop);
@@ -707,7 +712,7 @@ function emitOneJavaOverload(
   variant: import('@workos/oagen').ParameterGroup['variants'][number],
   overloadMethodName: string,
 ): void {
-  const sealedName = sealedGroupName(group.name);
+  const sealedName = sealedGroupName(group);
   const variantClass = className(variant.name);
   const targetGroupProp = ctx.groupParamNames.get(group.name)!;
 
@@ -1229,7 +1234,7 @@ function generateSealedClass(
   bodyFieldTypes?: Map<string, TypeRef>,
 ): string[] {
   const lines: string[] = [];
-  const sealedName = sealedGroupName(group.name);
+  const sealedName = sealedGroupName(group);
 
   // KDoc with Kotlin + Java construction examples. Pick the first variant as
   // a worked example so callers see the variant constructor in both languages
@@ -1302,7 +1307,7 @@ function emitGroupQueryDispatch(
   indent: string,
   receiverMode = false,
 ): string[] {
-  const sealedName = sealedGroupName(group.name);
+  const sealedName = sealedGroupName(group);
   const lines: string[] = [];
 
   if (group.optional) {
@@ -1318,7 +1323,7 @@ function emitGroupQueryDispatch(
 function assignGroupParameterNames(op: Operation, occupiedNames: Set<string>): Map<string, string> {
   const names = new Map<string, string>();
   for (const group of op.parameterGroups ?? []) {
-    const natural = propertyName(sealedGroupName(group.name));
+    const natural = propertyName(sealedGroupName(group));
     const assigned = reserveUniqueGroupParameterName(natural, occupiedNames);
     names.set(group.name, assigned);
   }
@@ -1382,7 +1387,7 @@ function emitWhenBlock(
 
 /** Emit `when` dispatch that serializes a parameter group into the request body map. */
 function emitGroupBodyDispatch(group: import('@workos/oagen').ParameterGroup, prop: string, indent: string): string[] {
-  const sealedName = sealedGroupName(group.name);
+  const sealedName = sealedGroupName(group);
   const lines: string[] = [];
 
   if (group.optional) {
@@ -1395,8 +1400,11 @@ function emitGroupBodyDispatch(group: import('@workos/oagen').ParameterGroup, pr
   return lines;
 }
 
-function sealedGroupName(name: string): string {
-  const resolved = className(name);
+function sealedGroupName(group: import('@workos/oagen').ParameterGroup): string {
+  // groupTypeBaseName, not group.name: where two operations' declarations of one
+  // group diverge, oagen qualifies the base name so each gets its own sealed
+  // type instead of both collapsing onto one that fits only one of them.
+  const resolved = className(groupTypeBaseName(group));
   if (resolved === 'Password') return 'CreateUserPassword';
   if (resolved === 'Role') return 'CreateUserRole';
   return resolved;

--- a/src/kotlin/tests.ts
+++ b/src/kotlin/tests.ts
@@ -31,6 +31,7 @@ import {
   isEnumInScope,
   fileExistsAfterRun,
   isScopedRun,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import {
@@ -347,14 +348,18 @@ function buildOperationTest(
   const groupParamNames = assignGroupParameterNames(op, hidden, queryFields, bodyModel, groupedParamNames);
   for (const group of op.parameterGroups ?? []) {
     const variant = group.variants[0];
-    const sealedName = sealedGroupName(group.name);
+    const sealedName = sealedGroupName(group);
     const variantName = className(variant.name);
     // Positional construction, so walk the variant's parameters in the same
     // order [generateSealedClass] declares them — optional members trail the
     // required ones. Every member gets a value, including the optional ones.
-    const variantArgs = orderedVariantParameters(variant)
-      .parameters.map((_p) => ktStringLiteral('sample-arg'))
-      .join(', ');
+    //
+    // A member is not always a string: it can be a model, an enum, or a list
+    // (a connection's `saml_options`, a membership's `role_slugs`). Route
+    // through synthValue so the stub matches the declared member type.
+    const variantValues = orderedVariantParameters(variant).parameters.map((p) => synthValue(p.type, ctx, imports));
+    if (variantValues.some((v) => v === null)) return null;
+    const variantArgs = variantValues.join(', ');
     imports.add(`com.workos.${mountPackage}.${sealedName}`);
     argParts.push(`${groupParamNames.get(group.name)!} = ${sealedName}.${variantName}(${variantArgs})`);
   }
@@ -456,15 +461,18 @@ function assignGroupParameterNames(
 
   const names = new Map<string, string>();
   for (const group of op.parameterGroups ?? []) {
-    const natural = propertyName(sealedGroupName(group.name));
+    const natural = propertyName(sealedGroupName(group));
     const assigned = reserveUniqueGroupParameterName(natural, occupiedNames);
     names.set(group.name, assigned);
   }
   return names;
 }
 
-function sealedGroupName(name: string): string {
-  const resolved = className(name);
+function sealedGroupName(group: import('@workos/oagen').ParameterGroup): string {
+  // groupTypeBaseName, not group.name: where two operations' declarations of one
+  // group diverge, oagen qualifies the base name so each gets its own sealed
+  // type instead of both collapsing onto one that fits only one of them.
+  const resolved = className(groupTypeBaseName(group));
   if (resolved === 'Password') return 'CreateUserPassword';
   if (resolved === 'Role') return 'CreateUserRole';
   return resolved;

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -20,6 +20,7 @@ import {
   getOpInferFromClient,
   collectGroupedParamNames,
   collectBodyFieldTypes,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { generateWrapperMethods } from './wrappers.js';
 import { phpDocComment } from './utils.js';
@@ -206,7 +207,7 @@ function generateParameterGroupFiles(
 
   for (const group of op.parameterGroups ?? []) {
     for (const variant of group.variants) {
-      const variantClass = groupVariantClassName(group.name, variant.name);
+      const variantClass = groupVariantClassName(groupTypeBaseName(group), variant.name);
       const lines: string[] = [];
 
       lines.push(`namespace ${ctx.namespacePascal}\\Service;`);
@@ -254,7 +255,7 @@ function generateGroupDispatch(op: Operation, indent: string, target: '$query' |
 
     for (let vi = 0; vi < group.variants.length; vi++) {
       const variant = group.variants[vi];
-      const variantClass = groupVariantClassName(group.name, variant.name);
+      const variantClass = groupVariantClassName(groupTypeBaseName(group), variant.name);
       const keyword = vi === 0 ? 'if' : 'elseif';
 
       lines.push(`${indent}${keyword} ($${phpParamName} instanceof ${variantClass}) {`);
@@ -345,7 +346,7 @@ function generateMethod(
     const phpName = fieldName(group.name);
     if (seenDocParams.has(phpName)) continue;
     seenDocParams.add(phpName);
-    const variantTypes = group.variants.map((v) => groupVariantClassName(group.name, v.name));
+    const variantTypes = group.variants.map((v) => groupVariantClassName(groupTypeBaseName(group), v.name));
     const unionDocType = variantTypes.join('|');
     const nullPrefix = group.optional ? 'null|' : '';
     docParts.push(`@param ${nullPrefix}${unionDocType} $${phpName}`);
@@ -732,7 +733,7 @@ function buildMethodParams(
     if (usedNames.has(phpName)) continue;
     usedNames.add(phpName);
     // PHP 8.0+ union syntax: VariantA|VariantB $paramName
-    const variantTypes = group.variants.map((v) => groupVariantClassName(group.name, v.name));
+    const variantTypes = group.variants.map((v) => groupVariantClassName(groupTypeBaseName(group), v.name));
     const unionType = variantTypes.join('|');
     if (group.optional) {
       optional.push(`null|${unionType} $${phpName} = null`);

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -25,6 +25,7 @@ import {
   getOpDefaults,
   getOpInferFromClient,
   collectGroupedParamNames,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { isRedirectEndpoint, deriveVariantFieldName } from './resources.js';
@@ -379,9 +380,12 @@ function buildTestArgs(
   for (const group of op.parameterGroups ?? []) {
     if (!group.optional || includeOptional) {
       const variant = group.variants[0];
-      const variantClass = `${className(group.name)}${className(variant.name)}`;
+      const variantClass = `${className(groupTypeBaseName(group))}${className(variant.name)}`;
+      // A group member is not always a string — it can be a model, an enum, or
+      // an array (a connection's `saml_options`, a membership's `role_slugs`).
+      // Route through generateTestValue so the stub matches the member type.
       const variantArgs = variant.parameters
-        .map((p) => `${deriveVariantFieldName(p.name, group.name)}: 'test_value'`)
+        .map((p) => `${deriveVariantFieldName(p.name, group.name)}: ${generateTestValue(p.type, ctx)}`)
         .join(', ');
       args.push(`${toCamelCase(group.name)}: new \\${ctx.namespacePascal}\\Service\\${variantClass}(${variantArgs})`);
     }

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -37,6 +37,7 @@ import {
   buildHiddenParams as buildHiddenParamsShared,
   collectGroupedParamNames,
   collectBodyFieldTypes,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import {
   generateSyncWrapperMethods,
@@ -103,7 +104,7 @@ function generateParameterGroupDataclasses(
     const bodyFieldTypes = collectBodyFieldTypes(op, models);
     for (const group of op.parameterGroups ?? []) {
       for (const variant of group.variants) {
-        const variantClass = groupVariantClassName(group.name, variant.name);
+        const variantClass = groupVariantClassName(groupTypeBaseName(group), variant.name);
         if (emitted.has(variantClass)) continue;
         emitted.add(variantClass);
 
@@ -156,7 +157,7 @@ export function collectParameterGroupClassNames(operations: Operation[]): string
   for (const op of operations) {
     for (const group of op.parameterGroups ?? []) {
       for (const variant of group.variants) {
-        const cls = groupVariantClassName(group.name, variant.name);
+        const cls = groupVariantClassName(groupTypeBaseName(group), variant.name);
         if (!seen.has(cls)) {
           seen.add(cls);
           names.push(cls);
@@ -351,7 +352,7 @@ function emitMethodSignature(
 
   // Parameter group union kwargs
   for (const group of op.parameterGroups ?? []) {
-    const variantClasses = group.variants.map((v) => groupVariantClassName(group.name, v.name));
+    const variantClasses = group.variants.map((v) => groupVariantClassName(groupTypeBaseName(group), v.name));
     const unionType = `Union[${variantClasses.join(', ')}]`;
     const paramName = fieldName(group.name);
     if (group.optional) {
@@ -538,7 +539,7 @@ function emitMethodDocstring(
 
   // Add parameter group docs
   for (const group of op.parameterGroups ?? []) {
-    const variantClasses = group.variants.map((v) => groupVariantClassName(group.name, v.name));
+    const variantClasses = group.variants.map((v) => groupVariantClassName(groupTypeBaseName(group), v.name));
     const readableGroup = group.name.replace(/_/g, ' ');
     const desc = `Identifies the ${readableGroup}. One of: ${variantClasses.join(', ')}.`;
     allParams.push({ name: fieldName(group.name), desc });
@@ -1042,7 +1043,7 @@ function emitGroupDispatch(
     const indent = group.optional ? '    ' : '';
     let first = true;
     for (const variant of group.variants) {
-      const variantClass = groupVariantClassName(group.name, variant.name);
+      const variantClass = groupVariantClassName(groupTypeBaseName(group), variant.name);
       const keyword = first ? 'if' : 'elif';
       first = false;
       lines.push(`        ${indent}${keyword} isinstance(${groupParam}, ${variantClass}):`);
@@ -1050,9 +1051,13 @@ function emitGroupDispatch(
       for (const param of variant.parameters) {
         const pyField = fieldName(param.name);
         const resolvedType = bodyFieldTypes?.get(param.name) ?? param.type;
-        const effectiveType = resolvedType.kind === 'nullable' ? resolvedType.inner : resolvedType;
-        const isEnum = effectiveType.kind === 'enum';
-        const value = isEnum ? `enum_value(${groupParam}.${pyField})` : `${groupParam}.${pyField}`;
+        // Members are not always scalars: a member can be a model or a list of
+        // models (a connection's `saml_options`), which must reach the wire as a
+        // dict rather than as the dataclass instance. serializeBodyFieldValue is
+        // the same routine flat body fields use, so the two stay consistent.
+        // Passing isRequired=true keeps the expression free of an inline None
+        // check — the optional-member branch below already guards on None.
+        const value = serializeBodyFieldValue(resolvedType, `${groupParam}.${pyField}`, true);
         if (optionalNames.has(param.name)) {
           // Optional variant members are omitted from the wire format when
           // unset rather than sent as null.

--- a/src/python/tests.ts
+++ b/src/python/tests.ts
@@ -33,6 +33,7 @@ import {
   isScopedRun,
   isModelInScope,
   fileExistsAfterRun,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import {
@@ -243,6 +244,22 @@ function generateServiceTest(
         }
       }
     }
+    // Collect model- and enum-typed parameter group members. The body-field
+    // loop above deliberately skips grouped params — they are passed inside the
+    // group's wrapper rather than as flat arguments — but the wrapper's
+    // constructor still names their types in the generated test, so a member
+    // typed `CreateConnectionSAMLOptions` needs that class imported.
+    for (const group of op.parameterGroups ?? []) {
+      for (const variant of group.variants) {
+        for (const p of variant.parameters) {
+          const t = p.type.kind === 'nullable' ? p.type.inner : p.type;
+          if (t.kind === 'model') modelImports.add(t.name);
+          else if (t.kind === 'enum') enumImports.add(t.name);
+          else if (t.kind === 'array' && t.items.kind === 'model') modelImports.add(t.items.name);
+          else if (t.kind === 'array' && t.items.kind === 'enum') enumImports.add(t.items.name);
+        }
+      }
+    }
     // Collect enum-typed query params
     for (const param of op.queryParams) {
       if (param.type.kind === 'enum') enumImports.add(param.type.name);
@@ -304,7 +321,7 @@ function generateServiceTest(
   for (const op of service.operations) {
     for (const group of op.parameterGroups ?? []) {
       for (const variant of group.variants) {
-        groupVariantImports.add(className(`${group.name}_${variant.name}`));
+        groupVariantImports.add(className(`${groupTypeBaseName(group)}_${variant.name}`));
       }
     }
   }
@@ -1120,8 +1137,13 @@ function buildTestArgs(op: Operation, spec: ApiSpec, hiddenParams?: Set<string>)
   const groupedParamNames = collectGroupedParamNames(op);
   for (const group of op.parameterGroups ?? []) {
     const variant = group.variants[0];
-    const variantClass = className(`${group.name}_${variant.name}`);
-    const variantArgs = variant.parameters.map((p) => `${fieldName(p.name)}="test_value"`).join(', ');
+    const variantClass = className(`${groupTypeBaseName(group)}_${variant.name}`);
+    // A group member is not always a string — it can be a model, an enum, or a
+    // list (a connection's `saml_options`, a membership's `role_slugs`). Route
+    // through generateTestValue so the stub matches the declared member type.
+    const variantArgs = variant.parameters
+      .map((p) => `${fieldName(p.name)}=${generateTestValue(p.type, p.name)}`)
+      .join(', ');
     args.push(`${fieldName(group.name)}=${variantClass}(${variantArgs})`);
   }
 
@@ -1177,7 +1199,7 @@ function buildQueryEncodingTestArgs(op: Operation, spec: ApiSpec): string {
   // Parameter group args — emit first variant constructor
   for (const group of op.parameterGroups ?? []) {
     const variant = group.variants[0];
-    const variantClass = className(`${group.name}_${variant.name}`);
+    const variantClass = className(`${groupTypeBaseName(group)}_${variant.name}`);
     const variantArgs = variant.parameters
       .map((p) => `${fieldName(p.name)}=${generateQueryEncodingValue(p.type, p.name)}`)
       .join(', ');

--- a/src/ruby/parameter-groups.ts
+++ b/src/ruby/parameter-groups.ts
@@ -1,7 +1,7 @@
 import type { EmitterContext, TypeRef, Model } from '@workos/oagen';
 import { className, fieldName, groupVariantClassName } from './naming.js';
 import { mapTypeRefForYard } from './type-map.js';
-import { collectBodyFieldTypes, groupByMount } from '../shared/resolved-ops.js';
+import { collectBodyFieldTypes, groupByMount, groupTypeBaseName } from '../shared/resolved-ops.js';
 
 /**
  * Sorbet type string for a TypeRef. Mirrors `mapSorbetType` in rbi.ts but
@@ -128,7 +128,7 @@ export function collectVariantsForMountTarget(
     for (const group of op.parameterGroups ?? []) {
       if (owner.get(group.name) !== mountTarget) continue;
       for (const variant of group.variants) {
-        const cls = groupVariantClassName(group.name, variant.name);
+        const cls = groupVariantClassName(groupTypeBaseName(group), variant.name);
         if (seen.has(cls)) continue;
         seen.add(cls);
         // Optional members carry a `nil` default, so they trail the required

--- a/src/ruby/rbi.ts
+++ b/src/ruby/rbi.ts
@@ -22,6 +22,7 @@ import {
   buildHiddenParams,
   getUrlBuilderClientOverrides,
   collectGroupedParamNames,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel, isListMetadataModel } from '../shared/model-utils.js';
 import { buildGroupOwnerMap, collectVariantsForMountTarget, emitInlineVariantRbi } from './parameter-groups.js';
@@ -252,7 +253,9 @@ export function generateRbiFiles(spec: ApiSpec, ctx: EmitterContext): GeneratedF
           throw new Error(`No owner mount target found for parameter group '${group.name}'`);
         }
         const resolvedOwner = resolveServiceTarget(owner, exportedClasses);
-        const variants = group.variants.map((v) => scopedGroupVariantClassName(resolvedOwner, group.name, v.name));
+        const variants = group.variants.map((v) =>
+          scopedGroupVariantClassName(resolvedOwner, groupTypeBaseName(group), v.name),
+        );
         if (variants.length === 1) return variants[0];
         return `T.any(${variants.join(', ')})`;
       };

--- a/src/ruby/resources.ts
+++ b/src/ruby/resources.ts
@@ -1,4 +1,13 @@
-import type { Service, EmitterContext, GeneratedFile, Operation, TypeRef, Parameter, Model } from '@workos/oagen';
+import type {
+  Service,
+  EmitterContext,
+  GeneratedFile,
+  Operation,
+  TypeRef,
+  Parameter,
+  ParameterGroup,
+  Model,
+} from '@workos/oagen';
 import { planOperation } from '@workos/oagen';
 import {
   className,
@@ -21,6 +30,7 @@ import {
   getUrlBuilderClientOverrides,
   buildHiddenParams,
   collectGroupedParamNames,
+  groupTypeBaseName,
 } from '../shared/resolved-ops.js';
 import { isListWrapperModel } from '../shared/model-utils.js';
 import { generateWrapperMethods, collectWrapperResponseModels } from './wrappers.js';
@@ -363,12 +373,13 @@ function emitMethod(args: {
   void enumNames;
 
   /** Fully-qualified Ruby constant for a variant (e.g. WorkOS::UserManagement::PasswordPlaintext). */
-  const variantClassRef = (group: { name: string }, variantName: string): string => {
+  const variantClassRef = (group: ParameterGroup, variantName: string): string => {
     const owner = groupOwners.get(group.name);
     if (!owner) {
       throw new Error(`No owner mount target found for parameter group '${group.name}'`);
     }
-    return scopedGroupVariantClassName(resolveServiceTarget(owner, exportedClasses), group.name, variantName);
+    const base = groupTypeBaseName(group);
+    return scopedGroupVariantClassName(resolveServiceTarget(owner, exportedClasses), base, variantName);
   };
 
   const plan = planOperation(op);
@@ -997,7 +1008,7 @@ function buildYardDoc(
   hiddenParams: Set<string>,
   bodyFieldRenames: Map<string, string> | undefined,
   listWrapperModels: Map<string, Model> | undefined,
-  variantClassRef: (group: { name: string }, variantName: string) => string,
+  variantClassRef: (group: ParameterGroup, variantName: string) => string,
 ): string[] {
   const lines: string[] = [];
   const summary = op.description ?? `${op.httpMethod.toUpperCase()} ${op.path}`;
@@ -1100,9 +1111,9 @@ function rubyDefaultLiteral(value: unknown): string {
  * interpolates the actual class of the value the caller passed.
  */
 function dispatchErrorLiteral(
-  group: { name: string; variants: { name: string }[] },
+  group: ParameterGroup,
   prop: string,
-  variantClassRef: (group: { name: string }, variantName: string) => string,
+  variantClassRef: (group: ParameterGroup, variantName: string) => string,
 ): string {
   const expected = group.variants.map((v) => variantClassRef(group, v.name)).join(', ');
   return `"expected ${prop} to be one of: ${expected}, got #{${prop}.class}"`;

--- a/src/ruby/tests.ts
+++ b/src/ruby/tests.ts
@@ -19,6 +19,7 @@ import {
   lookupResolved,
   buildHiddenParams,
   collectBodyFieldTypes,
+  groupTypeBaseName,
   isModelInScope,
   isScopedRun,
   fileExistsAfterRun,
@@ -615,7 +616,7 @@ function buildCallArgsStub(
       }
       const variantClass = scopedGroupVariantClassName(
         resolveServiceTarget(owner, exportedClasses),
-        group.name,
+        groupTypeBaseName(group),
         variant.name,
       );
       const fieldStubs = variant.parameters

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -14,7 +14,13 @@ import { fieldName, domainFieldName, methodName, typeName, moduleName, variantNa
 import { mapTypeRef, makeOptional, UnionRegistry } from './type-map.js';
 import { applySecretRedaction } from './secret.js';
 import { parsePathTemplate } from '../shared/path-template.js';
-import { groupByMount, buildResolvedLookup, isMountInScope, getMountTarget } from '../shared/resolved-ops.js';
+import {
+  groupByMount,
+  buildResolvedLookup,
+  isMountInScope,
+  getMountTarget,
+  groupTypeBaseName,
+} from '../shared/resolved-ops.js';
 import { resolveWrapperParams, type ResolvedWrapperParam } from '../shared/wrapper-utils.js';
 
 /**
@@ -215,7 +221,7 @@ class GroupEmitter {
 
   /** Register a parameter-group enum, returning the PascalCase Rust name. */
   registerEnum(group: ParameterGroup): string {
-    const name = typeName(group.name);
+    const name = typeName(groupTypeBaseName(group));
     const variants = group.variants.map((v) => {
       const optionalNames = new Set(v.optionalParameters ?? []);
       // Optional members trail the required ones, matching every other

--- a/src/rust/tests.ts
+++ b/src/rust/tests.ts
@@ -11,7 +11,7 @@ import type {
   TypeRef,
 } from '@workos/oagen';
 import { methodName, moduleName, typeName } from './naming.js';
-import { scopedMountGroups } from '../shared/resolved-ops.js';
+import { scopedMountGroups, groupTypeBaseName } from '../shared/resolved-ops.js';
 import { exampleFor, generateFixtures } from './fixtures.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { isInlineEnvelopeList } from './resources.js';
@@ -299,12 +299,12 @@ function buildCallArgs(
         ctorArgs.push(stubExpr(p.type, p.name, modelMap, enumMap));
       }
       for (const g of requiredQueryGroups) {
-        ctorArgs.push(parameterGroupStubExpr(g, crate, accessor));
+        ctorArgs.push(parameterGroupStubExpr(g, crate, accessor, modelMap, enumMap));
       }
       if (hasBody && bodyRequired) {
         const hasBodyGroup = hasBodyParameterGroup(op);
         if (hasBodyGroup) {
-          ctorArgs.push(syntheticBodyStubExpr(op, resolved, crate, accessor, modelMap));
+          ctorArgs.push(syntheticBodyStubExpr(op, resolved, crate, accessor, modelMap, enumMap));
         } else {
           ctorArgs.push(stubExpr(op.requestBody!, 'body', modelMap, enumMap));
         }
@@ -635,6 +635,7 @@ function syntheticBodyStubExpr(
   crate: string,
   accessor: string,
   modelMap: Map<string, Model>,
+  enumMap: Map<string, Enum>,
 ): string {
   const bodyRef = op.requestBody!;
   const bodyName = `${typeName(resolved.methodName)}ParamsBody`;
@@ -655,14 +656,14 @@ function syntheticBodyStubExpr(
       if (bodyGroupNames.has(f.name)) continue;
       const isRequired = !!f.required && f.type.kind !== 'nullable';
       if (!isRequired) continue;
-      args.push(`${JSON.stringify(`stub_${f.name}`)}.to_string()`);
+      args.push(stubExpr(f.type, f.name, modelMap, enumMap));
     }
   }
   for (const g of op.parameterGroups ?? []) {
     const isBodyGroup = g.variants.every((v) => v.parameters.every((p) => !queryNames.has(p.name)));
     if (!isBodyGroup) continue;
     if (g.optional) continue;
-    args.push(parameterGroupStubExpr(g, crate, accessor));
+    args.push(parameterGroupStubExpr(g, crate, accessor, modelMap, enumMap));
   }
   return `${fqn}::new(${args.join(', ')})`;
 }
@@ -672,16 +673,16 @@ function parameterGroupStubExpr(
   group: import('@workos/oagen').ParameterGroup,
   crate: string,
   accessor: string,
+  modelMap: Map<string, Model>,
+  enumMap: Map<string, Enum>,
 ): string {
-  const enumName = group.name
-    .split('_')
-    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-    .join('');
+  // Both names must be spelled the way the definition site in resources.ts
+  // spells them, which is `typeName`. Hand-rolling PascalCase here diverges on
+  // acronyms — "saml" becomes `Saml` rather than `SAML` — and the fixture stops
+  // compiling against the very enum it is meant to construct.
+  const enumName = typeName(groupTypeBaseName(group));
   const firstVariant = group.variants[0];
-  const variantName = firstVariant.name
-    .split('_')
-    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-    .join('');
+  const variantName = typeName(firstVariant.name);
   const fqn = `${crate}::${accessor}::${enumName}`;
   if (firstVariant.parameters.length === 0) return `${fqn}::${variantName}`;
   // Members the IR marks optional are `Option<T>` on the generated variant, so
@@ -691,7 +692,10 @@ function parameterGroupStubExpr(
   const optionalNames = new Set(firstVariant.optionalParameters ?? []);
   const fields = firstVariant.parameters
     .map((p) => {
-      const value = `${JSON.stringify(`stub_${p.name}`)}.to_string()`;
+      // A group member is not always a string: it can be a model, an enum, or
+      // an array (a connection's `saml_options`, a membership's `role_slugs`).
+      // Route through stubExpr so the stub matches the declared member type.
+      const value = stubExpr(p.type, p.name, modelMap, enumMap);
       return `${p.name}: ${optionalNames.has(p.name) ? `Some(${value})` : value}`;
     })
     .join(', ');

--- a/src/shared/resolved-ops.ts
+++ b/src/shared/resolved-ops.ts
@@ -1,4 +1,12 @@
-import type { Operation, EmitterContext, Service, ResolvedOperation, Model, TypeRef } from '@workos/oagen';
+import type {
+  Operation,
+  EmitterContext,
+  Service,
+  ResolvedOperation,
+  Model,
+  ParameterGroup,
+  TypeRef,
+} from '@workos/oagen';
 import { toPascalCase } from '@workos/oagen';
 
 /**
@@ -264,6 +272,25 @@ export function getUrlBuilderClientOverrides(op: Operation, resolvedOp?: Resolve
 // ---------------------------------------------------------------------------
 // Parameter group helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Base name to build a parameter group's generated *type* names from.
+ *
+ * Use this everywhere a group contributes to a type name (wrapper class,
+ * sealed/interface name, enum name, generated file name) and keep `group.name`
+ * for anything caller-facing: the method's parameter name, doc prose, and the
+ * prefix stripped from member field names.
+ *
+ * Two operations sharing a group name normally share one generated wrapper.
+ * When their members genuinely diverge — connection create takes a
+ * `CreateConnectionSAMLOptions`, update takes a `PatchConnectionSAMLOptions` —
+ * oagen qualifies `wrapperName` with the operation name so the two get separate
+ * types instead of one silently mistyping an operation. Groups that agree keep
+ * the bare group name, so published wrapper names never move.
+ */
+export function groupTypeBaseName(group: ParameterGroup): string {
+  return group.wrapperName ?? group.name;
+}
 
 /**
  * Collect all parameter names that belong to any mutually-exclusive parameter group.


### PR DESCRIPTION
Emitter half of the mutually-exclusive body group fix. Consumes `ParameterGroup.wrapperName` from **workos/oagen#158** and fixes three further breaks that only surface once group members carry their real types.

Found while investigating why [openapi-spec#131](https://github.com/workos/openapi-spec/pull/131) failed to build in 4 of 8 languages: python, php, kotlin and rust.

## 1. One wrapper type for two diverging operations

Every emitter named a group's wrapper from `group.name`, so two operations declaring the same group collapsed onto one generated type. `protocol_options` is the first group whose declarations genuinely differ — create's `saml_options` is a `CreateConnectionSAMLOptions`, update's a `PatchConnectionSAMLOptions`, and the latter lacks `idp_signing_certs`, `sp_signing_key_pair` and `sp_encryption_key_pairs`.

The collapse was silent and each emitter resolved it differently:

| Emitter | Shared wrapper's `saml_options` |
| --- | --- |
| python | `CreateConnectionSAMLOptions` |
| php | `PatchConnectionSAMLOptions` — create callers could not send signing certs |
| rust | `String`, and `PatchConnectionSAMLOptions` generated but unreachable from `update_connection` |

Type names now come from `groupTypeBaseName(group)`. `group.name` is retained for everything caller-facing — the method's parameter name, doc prose, and the prefix stripped from member field names — so only type names move, and only for groups oagen reports as divergent. `Password`, `Role`, `ParentResource` and `ResourceTarget` keep the names they ship under today.

Two dedupe keys had the same defect and are fixed alongside:

- Kotlin's emitted-sealed-class set and Go's `collectFileGroups` map both keyed on `group.name`, dropping the second of two diverging groups entirely.
- Both also merged body-field-type maps across every operation in a file while keying them by wire field name, letting whichever operation was visited last decide `saml_options`' type for all of them. Now resolved per operation. python, php, dotnet and ruby already did this correctly.

## 2. Group fixtures ignored the member's type

A separate break, and the one that actually turned CI red. python, php, rust and kotlin hardcoded a scalar placeholder for every group member instead of consulting `p.type`:

```ts
variant.parameters.map((p) => `${fieldName(p.name)}="test_value"`)   // python
```

Harmless while members were always scalars; stopped compiling the moment one became an object. They now route through each emitter's existing type-aware value generator — the same one flat body fields use. **Ruby's path already did**, which is exactly why ruby/go/dotnet/ios stayed green while the other four went red.

## 3. Rust acronym casing

The group enum and variant names were hand-rolled PascalCase at the fixture site rather than `typeName()`:

```rust
pub enum ProtocolOptions { SAML { .. }, Oidc { .. } }   // definition, via typeName()
workos::sso::ProtocolOptions::Saml { .. }               // fixture, hand-rolled
```

7× `E0599 no variant named Saml`. `Oidc` agrees under both rules, which is what kept this hidden until a group variant was named after an acronym.

## 4. python, object-valued members

Two further fixes needed once `saml_options` became a model:

- the test emitter skipped grouped params when collecting model/enum imports (correct when they were strings, so `F821 Undefined name`);
- the group body serializer passed the member through raw, so `PatchConnectionSAMLOptions is not JSON serializable` at runtime. It now uses `serializeBodyFieldValue`, the same routine flat body fields use.

## Testing

850 existing tests pass. Verified end-to-end by generating every SDK against openapi-spec#131's spec and running its own CI:

| SDK | Result |
| --- | --- |
| python | 2,663 passed (ruff + pyright + pytest) |
| php | 333 tests, 1,594 assertions, all checks passed |
| ruby | 1,201 runs, 6,071 assertions, 0 failures |
| rust | 32 suites ok, 0 failures (110 SSO) |
| kotlin | `BUILD SUCCESSFUL` |
| go | fmt/build/vet/test pass |
| ios | 358 tests, 35 suites |
| dotnet | **not run** — no .NET SDK available locally. Generated output inspected: `SSOCreateProtocolOptionsSAML`/`SSOPatchProtocolOptionsSAML` carry the correct DTOs. Worth a second look in CI. |

## Merge order

Needs **workos/oagen#158** released first — this depends on `ParameterGroup.wrapperName`.