### PR TITLE
docs(kotlin): record that the client accessor KDoc is load-bearing

### DIFF
--- a/src/kotlin/client.ts
+++ b/src/kotlin/client.ts
@@ -13,9 +13,17 @@ const KOTLIN_SRC_PREFIX = 'src/main/kotlin/';
  * merger deep-merges them into the existing hand-written `WorkOS.kt`.
  *
  * Each referenced service class is hoisted into a top-level `import` so the
- * accessor bodies use the short class name. The live `WorkOS.kt` is marked
- * `@oagen-ignore-file` and won't be regenerated, but the emitter still emits
- * the cleaner shape so future regenerations don't reintroduce the FQN noise.
+ * accessor bodies use the short class name.
+ *
+ * The accessor KDoc ("Lazily-constructed [X] accessor…") is load-bearing: it is
+ * how the merger tells a generated accessor from a hand-written one, so an
+ * accessor whose service leaves the spec — a renamed or resplit tag — gets
+ * pruned along with its import instead of dangling as a reference to a class
+ * that is no longer emitted. Don't reword it here without updating
+ * `KOTLIN_MANAGED_ACCESSOR_DOC` in oagen's Kotlin merge adapter.
+ *
+ * Never scope this on `ctx.scopedServices`: pruning assumes the emitted set is
+ * every service, so a partial client would delete the accessors it left out.
  */
 export function generateClient(spec: ApiSpec, ctx: EmitterContext): GeneratedFile[] {
   const targets = deduplicateByMount(spec.services, ctx);


### PR DESCRIPTION
## What

Comment-only change to `src/kotlin/client.ts`. No generated output changes.

## Why

The accessor KDoc this emitter writes — `/** Lazily-constructed [X] accessor for this [WorkOS] client. */` — is not decoration. It's how oagen's Kotlin merge adapter tells a generated accessor from a hand-written one (`KOTLIN_MANAGED_ACCESSOR_DOC`), which is what lets deep merge prune an accessor whose service has left the spec. Reword it here and pruning silently stops: an accessor whose service class is no longer emitted dangles, and the SDK stops compiling. That coupling was invisible from this side, so this records it and names the constant to grep for.

Two more notes added:

- **Never gate this emitter on `ctx.scopedServices`.** Pruning assumes the emitted accessor set is every service; a scoped client would delete the accessors it left out. It doesn't scope today — this keeps it that way.
- Dropped the stale claim that the live `WorkOS.kt` is marked `@oagen-ignore-file` and won't be regenerated. It carries a symbol-level `@oagen-ignore` in its class KDoc and is deep-merged on every run.

## Context

Companion to workos/oagen#159, which fixes the pruning that this comment describes — the KDoc was being excluded from the member text the adapter matched against, so it never fired. That surfaced as a red `sdk_build (kotlin)` on workos/openapi-spec#134 when the `agents` tag was split into sub-services.