### PR TITLE
fix: prefix enum members whose wire value starts with a digit

### DIFF
--- a/src/dotnet/enums.ts
+++ b/src/dotnet/enums.ts
@@ -106,6 +106,9 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       if (usedWireValues.has(String(v.value))) continue;
       usedWireValues.add(String(v.value));
       let memberName = className(String(v.value));
+      // C# identifiers cannot start with a digit (e.g. wire value "1_MONTH"
+      // pascal-cases to "1Month"); EnumMember keeps the wire value intact.
+      if (/^[0-9]/.test(memberName)) memberName = `Value${memberName}`;
       // Avoid collision with the type itself or previously used names
       if (memberName === typeName || usedNames.has(memberName)) {
         let suffix = 2;

--- a/src/php/enums.ts
+++ b/src/php/enums.ts
@@ -1,6 +1,6 @@
 import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { toPascalCase } from '@workos/oagen';
-import { className, resolveEnumName } from './naming.js';
+import { className, guardEnumCaseName, resolveEnumName } from './naming.js';
 import { phpDocComment } from './utils.js';
 import { isEnumInScope } from '../shared/resolved-ops.js';
 
@@ -43,10 +43,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
     // Deduplicate case names
     const usedNames = new Map<string, number>();
     for (const val of e.values) {
-      let caseName = toPascalCase(val.name.toLowerCase());
-      // PHP enum case names cannot start with a digit (e.g. wire value
-      // "1_MONTH" pascal-cases to "1Month").
-      if (/^[0-9]/.test(caseName)) caseName = `Value${caseName}`;
+      let caseName = guardEnumCaseName(toPascalCase(val.name.toLowerCase()));
       const baseName = caseName;
       const count = usedNames.get(baseName) ?? 0;
       if (count > 0) {

--- a/src/php/enums.ts
+++ b/src/php/enums.ts
@@ -44,6 +44,9 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
     const usedNames = new Map<string, number>();
     for (const val of e.values) {
       let caseName = toPascalCase(val.name.toLowerCase());
+      // PHP enum case names cannot start with a digit (e.g. wire value
+      // "1_MONTH" pascal-cases to "1Month").
+      if (/^[0-9]/.test(caseName)) caseName = `Value${caseName}`;
       const baseName = caseName;
       const count = usedNames.get(baseName) ?? 0;
       if (count > 0) {

--- a/src/php/naming.ts
+++ b/src/php/naming.ts
@@ -309,3 +309,13 @@ export function buildServiceDirMap(grouping: NamespaceGrouping): Map<string, str
   }
   return map;
 }
+
+/**
+ * PHP enum case names cannot start with a digit (e.g. wire value "1_MONTH"
+ * pascal-cases to "1Month"); prefix those with "Value". Every emitter that
+ * writes a case declaration or an `Enum::Case` reference must route the
+ * pascal-cased name through this guard so the two stay in sync.
+ */
+export function guardEnumCaseName(caseName: string): string {
+  return /^[0-9]/.test(caseName) ? `Value${caseName}` : caseName;
+}

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -10,7 +10,14 @@ import type {
 } from '@workos/oagen';
 import { planOperation, toCamelCase, toPascalCase } from '@workos/oagen';
 import { mapTypeRef, mapTypeRefForPHPDoc } from './type-map.js';
-import { className, fieldName, resolveMethodName, buildExportedClassNameSet, resolveServiceTarget } from './naming.js';
+import {
+  className,
+  fieldName,
+  guardEnumCaseName,
+  resolveMethodName,
+  buildExportedClassNameSet,
+  resolveServiceTarget,
+} from './naming.js';
 import { isListWrapperModel } from './models.js';
 import {
   scopedMountGroups,
@@ -758,7 +765,7 @@ function buildMethodParams(
       // Only enums are safe to default this way — primitives stay nullable so
       // callers can distinguish "unset" from "explicit value".
       const enumType = mapTypeRef(q.type, { qualified: true });
-      const caseName = toPascalCase(String(q.default));
+      const caseName = guardEnumCaseName(toPascalCase(String(q.default)));
       optional.push(`${enumType} $${phpName} = ${enumType}::${caseName}`);
     } else {
       const nullableType = phpType.startsWith('?') ? phpType : `?${phpType}`;

--- a/src/php/tests.ts
+++ b/src/php/tests.ts
@@ -11,6 +11,7 @@ import { planOperation, toCamelCase, toPascalCase } from '@workos/oagen';
 import {
   className,
   enumClassName,
+  guardEnumCaseName,
   resolveMethodName,
   snakeName,
   servicePropertyName,
@@ -433,7 +434,7 @@ function generateTestValue(
         if (e && e.values.length > 0) {
           const enumClass = enumClassName(ref.name);
           // Must match the case-name logic in enums.ts
-          const caseName = toPascalCase(String(e.values[0].name).toLowerCase());
+          const caseName = guardEnumCaseName(toPascalCase(String(e.values[0].name).toLowerCase()));
           return `\\WorkOS\\Resource\\${enumClass}::${caseName}`;
         }
       }

--- a/src/python/enums.ts
+++ b/src/python/enums.ts
@@ -201,6 +201,10 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       const usedNames = new Set<string>();
       for (const v of uniqueValues) {
         let memberName = toUpperSnakeCase(String(v.value));
+        // Python identifiers cannot start with a digit (e.g. wire value
+        // "1_MONTH"); a leading underscore would make the member private to
+        // the Enum machinery, so prefix those too.
+        if (!/^[A-Z]/i.test(memberName)) memberName = `VALUE_${memberName}`;
         if (usedNames.has(memberName)) {
           let suffix = 2;
           while (usedNames.has(`${memberName}_${suffix}`)) suffix++;

--- a/test/dotnet/enums.test.ts
+++ b/test/dotnet/enums.test.ts
@@ -336,4 +336,42 @@ describe('dotnet/enums', () => {
     expect(content).toContain('[System.Obsolete');
     expect(content).toContain('OldStatus');
   });
+  it('prefixes members whose wire value starts with a digit', () => {
+    const enums: Enum[] = [
+      {
+        name: 'RetentionPeriod',
+        values: [
+          { name: '1_MONTH', value: '1_MONTH' },
+          { name: '10_YEARS', value: '10_YEARS' },
+        ],
+      },
+    ];
+
+    const service: Service = {
+      name: 'AuditLogs',
+      operations: [
+        {
+          name: 'setRetention',
+          httpMethod: 'put',
+          path: '/organizations/{id}/audit_logs_retention',
+          pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+          queryParams: [{ name: 'retention_period', type: { kind: 'enum', name: 'RetentionPeriod' }, required: false }],
+          headerParams: [],
+          response: { kind: 'model', name: 'AuditLogsRetention' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+
+    const files = generateEnums(enums, {
+      ...ctx,
+      spec: { ...emptySpec, services: [service] },
+    });
+    expect(files.length).toBe(1);
+    expect(files[0].content).toContain('[EnumMember(Value = "1_MONTH")]');
+    expect(files[0].content).toContain('Value1Month,');
+    expect(files[0].content).toContain('[EnumMember(Value = "10_YEARS")]');
+    expect(files[0].content).toContain('Value10Years,');
+  });
 });

--- a/test/php/enums.test.ts
+++ b/test/php/enums.test.ts
@@ -170,4 +170,21 @@ describe('generateEnums', () => {
     expect(result[0].content).toContain('case FooBar =');
     expect(result[0].content).toContain('case FooBar2 =');
   });
+  it('prefixes case names that would start with a digit', () => {
+    const enums: Enum[] = [
+      {
+        name: 'RetentionPeriod',
+        values: [
+          { name: '1_MONTH', value: '1_MONTH' },
+          { name: '10_YEARS', value: '10_YEARS' },
+        ],
+      },
+    ];
+
+    const result = generateEnums(enums, ctx);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toContain("case Value1Month = '1_MONTH';");
+    expect(result[0].content).toContain("case Value10Years = '10_YEARS';");
+  });
 });

--- a/test/python/enums.test.ts
+++ b/test/python/enums.test.ts
@@ -316,4 +316,20 @@ describe('generateEnums', () => {
     const nextLine = content.slice(activeIdx).split('\n')[1];
     expect(nextLine).not.toContain('"""');
   });
+  it('prefixes members whose wire value starts with a digit', () => {
+    const enums: Enum[] = [
+      {
+        name: 'RetentionPeriod',
+        values: [
+          { name: '1_MONTH', value: '1_MONTH' },
+          { name: '10_YEARS', value: '10_YEARS' },
+        ],
+      },
+    ];
+
+    const files = generateEnums(enums, ctx);
+    expect(files.length).toBe(1);
+    expect(files[0].content).toContain('    VALUE_1_MONTH = "1_MONTH"');
+    expect(files[0].content).toContain('    VALUE_10_YEARS = "10_YEARS"');
+  });
 });


### PR DESCRIPTION
## Summary

Enum wire values that start with a digit (e.g. `1_MONTH` … `10_YEARS`, introduced to the spec by workos/workos#70210 for the Audit Logs Set Retention API) generate identifiers that are illegal in Python, PHP, and C#:

- Python: `1_MONTH = "1_MONTH"` — `SyntaxError`, seen as the `ruff format` parse failure on workos/openapi-spec#137's `sdk_build (python)`
- PHP: `case 1Month = '1_MONTH';` — parse error (`sdk_build (php)`)
- C#: `1Month,` — CS1001/CS1003 in `UpdateAuditLogsRetentionRetentionPeriod.cs` (`sdk_build (dotnet)`)

The ruby emitter already guards against this (`VALUE_` prefix, `src/ruby/enums.ts`) and kotlin gained a `Value` prefix guard recently (`src/kotlin/enums.ts:144`). This PR mirrors those guards in the three emitters that lack them; wire values are untouched:

| Emitter | Member for `1_MONTH` | Wire value |
|---|---|---|
| python | `VALUE_1_MONTH` | `"1_MONTH"` |
| php | `Value1Month` | `'1_MONTH'` |
| dotnet | `Value1Month` + `[EnumMember(Value = "1_MONTH")]` | `"1_MONTH"` |

Note: this does **not** fix `sdk_build (go)` on openapi-spec#137 — that failure is a different bug (`AuditLogsRetention redeclared`, a type-name collision with an existing declaration in workos-go's `audit_logs.go`), which needs a naming-policy decision rather than an identifier guard.

## Test plan

- Added leading-digit cases to `test/{python,php,dotnet}/enums.test.ts` asserting the prefixed member names and preserved wire values
- Full suite: 853 tests pass (`npm test`); `npm run lint` and `npm run build` clean