### PR TITLE
fix: stop generated group types from colliding with model names

### DIFF
--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -143,7 +143,7 @@ function generateServiceFile(mountName: string, operations: Operation[], ctx: Em
   // applyToBody methods.
   const groupTypes = collectFileGroups(mountName, operations, ctx.spec.models);
   if (groupTypes.length > 0) {
-    lines.push(emitCollectedGroupTypes(mountName, groupTypes));
+    lines.push(emitCollectedGroupTypes(mountName, groupTypes, reservedTypeNames(ctx)));
   }
 
   // Generate params structs and methods for each operation.
@@ -253,14 +253,49 @@ function isBodyGroup(group: import('@workos/oagen').ParameterGroup, op: Operatio
   return group.variants.every((v) => v.parameters.every((p) => !queryNames.has(p.name)));
 }
 
+/**
+ * Go type names already claimed by generated models and enums.
+ *
+ * Parameter-group type names are derived from the mount and group names, so
+ * they can land on a name a model already owns: mount `AuditLogs` + group
+ * `retention` yields `AuditLogsRetention`, which is also the struct generated
+ * for the `AuditLogsRetention` schema. Everything lands in one Go package, so
+ * that is a redeclaration error rather than a shadow — the group types have to
+ * step aside.
+ */
+function reservedTypeNames(ctx: EmitterContext): Set<string> {
+  const reserved = new Set<string>();
+  for (const model of ctx.spec.models) reserved.add(className(model.name));
+  for (const enumDef of ctx.spec.enums) reserved.add(className(enumDef.name));
+  return reserved;
+}
+
+/**
+ * Suffix `base` until it no longer collides with a reserved type name. `Group`
+ * reads naturally for parameter-group types; the numeric fallback only matters
+ * if a schema is literally named `<Mount><Group>Group`.
+ */
+function avoidReserved(base: string, reserved: Set<string>): string {
+  if (!reserved.has(base)) return base;
+  let candidate = `${base}Group`;
+  let suffix = 2;
+  while (reserved.has(candidate)) candidate = `${base}Group${suffix++}`;
+  return candidate;
+}
+
 /** Interface type name for a parameter group (e.g. AuthorizationParentResource). */
-function groupInterfaceName(mountName: string, groupName: string): string {
-  return `${className(mountName)}${fieldName(groupName)}`;
+function groupInterfaceName(mountName: string, groupName: string, reserved: Set<string>): string {
+  return avoidReserved(`${className(mountName)}${fieldName(groupName)}`, reserved);
 }
 
 /** Variant struct type name (e.g. AuthorizationParentResourceRefByID). */
-function groupVariantTypeName(mountName: string, groupName: string, variantName: string): string {
-  return `${groupInterfaceName(mountName, groupName)}${fieldName(variantName)}`;
+function groupVariantTypeName(
+  mountName: string,
+  groupName: string,
+  variantName: string,
+  reserved: Set<string>,
+): string {
+  return avoidReserved(`${groupInterfaceName(mountName, groupName, reserved)}${fieldName(variantName)}`, reserved);
 }
 
 /**
@@ -336,14 +371,16 @@ function collectFileGroups(mountName: string, operations: Operation[], models: M
  * collected parameter groups in a file. Groups used in query contexts get
  * applyToQuery; body contexts get applyToBody; groups used in both get both.
  */
-function emitCollectedGroupTypes(mountName: string, groups: CollectedGroup[]): string {
+function emitCollectedGroupTypes(mountName: string, groups: CollectedGroup[], reserved: Set<string>): string {
   const lines: string[] = [];
 
   for (const group of groups) {
-    const ifaceName = groupInterfaceName(mountName, group.typeBaseName);
+    const ifaceName = groupInterfaceName(mountName, group.typeBaseName, reserved);
     const markerMethod = `is${ifaceName}`;
 
-    const variantNames = group.variants.map((v) => groupVariantTypeName(mountName, group.typeBaseName, v.name));
+    const variantNames = group.variants.map((v) =>
+      groupVariantTypeName(mountName, group.typeBaseName, v.name, reserved),
+    );
     lines.push(`// ${ifaceName} is one of:`);
     for (const vn of variantNames) {
       lines.push(`//   - ${vn}`);
@@ -360,7 +397,7 @@ function emitCollectedGroupTypes(mountName: string, groups: CollectedGroup[]): s
     lines.push('');
 
     for (const variant of group.variants) {
-      const typeName = groupVariantTypeName(mountName, group.typeBaseName, variant.name);
+      const typeName = groupVariantTypeName(mountName, group.typeBaseName, variant.name, reserved);
 
       // Members named in optionalParameters may be omitted when this variant is
       // used: they become pointer fields (Go's optional convention) and trail
@@ -553,7 +590,7 @@ function generateParamsStruct(
   // Parameter group fields (sum-type interfaces, serialized via applyToQuery)
   for (const group of op.parameterGroups ?? []) {
     const goField = fieldName(group.name);
-    const goType = groupInterfaceName(mountName, groupTypeBaseName(group));
+    const goType = groupInterfaceName(mountName, groupTypeBaseName(group), reservedTypeNames(ctx));
     if (group.optional) {
       lines.push(`\t// ${goField} optionally identifies the ${group.name.replace(/_/g, ' ')}.`);
     } else {

--- a/src/node/enums.ts
+++ b/src/node/enums.ts
@@ -8,14 +8,26 @@ import { liveSurfaceConstEnumMembers, liveSurfaceInterfacePath } from './live-su
 import { isEnumInScope } from '../shared/resolved-ops.js';
 
 /**
- * PascalCase a wire value into a member name. Wire values may legitimately
- * start with a digit (e.g. `1_MONTH`), which `toPascalCase` preserves and
- * TypeScript rejects both as an enum member and as an unquoted object key.
- * Prefix those; the member's value carries the real wire string.
+ * PascalCase a wire value into a member name, unique within `taken`.
+ *
+ * Wire values may legitimately start with a digit (e.g. `1_MONTH`), which
+ * `toPascalCase` preserves and TypeScript rejects both as an enum member and as
+ * an unquoted object key. Prefix those; the member's value carries the real
+ * wire string.
+ *
+ * The prefix can itself collide — `1_MONTH` and a sibling `VALUE_1_MONTH` both
+ * pascal-case to `Value1Month` — so suffix until unique, as the dotnet, kotlin,
+ * and ruby emitters do. Dropping the loser instead would silently omit a wire
+ * value from the const object and the union type derived from it.
  */
-function memberNameFor(value: string): string {
+function memberNameFor(value: string, taken: Set<string>): string {
   const pascal = toPascalCase(value);
-  return !pascal || /^[0-9]/.test(pascal) ? `Value${pascal || value}` : pascal;
+  const base = !pascal || /^[0-9]/.test(pascal) ? `Value${pascal || value}` : pascal;
+  let name = base;
+  let suffix = 2;
+  while (taken.has(name)) name = `${base}${suffix++}`;
+  taken.add(name);
+  return name;
 }
 
 export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
@@ -65,12 +77,15 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       hasNewValues = missingValues.length > 0;
 
       lines.push(`export enum ${enumDef.name} {`);
+      // Seed with the baseline's own member names so an appended value cannot
+      // redeclare one of them.
+      const takenMembers = new Set(Object.keys(baselineEnum.members));
       for (const [memberName, memberValue] of Object.entries(baselineEnum.members)) {
         const valueStr = typeof memberValue === 'string' ? `'${memberValue}'` : String(memberValue);
         lines.push(`  ${memberName} = ${valueStr},`);
       }
       for (const val of missingValues) {
-        const memberName = memberNameFor(val);
+        const memberName = memberNameFor(val, takenMembers);
         lines.push(`  ${memberName} = '${val}',`);
       }
       lines.push('}');
@@ -102,9 +117,10 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       //      with a member for this exact value, reuse the existing member
       //      name. This preserves acronym casing (`DSync`, `SAML`, `JWT`)
       //      that the simpler `toPascalCase` would otherwise flatten.
-      //   2. Otherwise PascalCase the value.
-      //   3. Skip duplicate values and duplicate member names — the union
-      //      type derived from the const captures every kept value.
+      //   2. Otherwise PascalCase the value, suffixed to stay unique.
+      //   3. Skip duplicate values. A live-surface name that duplicates is
+      //      still skipped rather than suffixed — renaming a shipped member
+      //      would be the breaking change we're avoiding in (1).
       const values = enumDef.values;
       const existingMembers = liveSurfaceConstEnumMembers(enumDef.name);
       const seenMembers = new Set<string>();
@@ -114,9 +130,14 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         const valueKey = String(v.value);
         if (seenValues.has(valueKey)) continue;
         seenValues.add(valueKey);
-        const memberName = existingMembers?.get(valueKey) ?? memberNameFor(valueKey);
-        if (seenMembers.has(memberName)) continue;
-        seenMembers.add(memberName);
+        // memberNameFor reserves the name it returns; a live-surface name has
+        // to be reserved (or skipped) here.
+        const shipped = existingMembers?.get(valueKey);
+        const memberName = shipped ?? memberNameFor(valueKey, seenMembers);
+        if (shipped) {
+          if (seenMembers.has(shipped)) continue;
+          seenMembers.add(shipped);
+        }
         const valueStr = typeof v.value === 'string' ? `'${v.value}'` : String(v.value);
         if (v.description || v.deprecated) {
           const parts: string[] = [];

--- a/src/node/enums.ts
+++ b/src/node/enums.ts
@@ -117,27 +117,37 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       //      with a member for this exact value, reuse the existing member
       //      name. This preserves acronym casing (`DSync`, `SAML`, `JWT`)
       //      that the simpler `toPascalCase` would otherwise flatten.
-      //   2. Otherwise PascalCase the value, suffixed to stay unique.
-      //   3. Skip duplicate values. A live-surface name that duplicates is
-      //      still skipped rather than suffixed — renaming a shipped member
-      //      would be the breaking change we're avoiding in (1).
+      //   2. Otherwise PascalCase the value, suffixed to stay unique and never
+      //      claiming a name some other value already ships under.
+      //   3. Skip duplicate values. Two values claiming one shipped name still
+      //      yields one member — a shipped name is never suffixed, since
+      //      renaming it is the breaking change (1) exists to avoid.
       const values = enumDef.values;
       const existingMembers = liveSurfaceConstEnumMembers(enumDef.name);
-      const seenMembers = new Set<string>();
+      // Reserve every shipped member name before deriving any generated one.
+      // Values are visited in spec order, so without this pre-pass a generated
+      // name could claim a shipped name first and displace the value that
+      // already ships under it — dropping that value from the const object and
+      // the union derived from it.
+      const taken = new Set<string>();
+      for (const v of values) {
+        const shipped = existingMembers?.get(String(v.value));
+        if (shipped) taken.add(shipped);
+      }
+      const emitted = new Set<string>();
       const seenValues = new Set<string>();
       lines.push(`export const ${enumDef.name} = {`);
       for (const v of values) {
         const valueKey = String(v.value);
         if (seenValues.has(valueKey)) continue;
         seenValues.add(valueKey);
-        // memberNameFor reserves the name it returns; a live-surface name has
-        // to be reserved (or skipped) here.
+        // memberNameFor reserves the name it returns into `taken`. A shipped
+        // name is already reserved, so it is deduped against what was actually
+        // emitted — two values claiming one shipped name still yields one.
         const shipped = existingMembers?.get(valueKey);
-        const memberName = shipped ?? memberNameFor(valueKey, seenMembers);
-        if (shipped) {
-          if (seenMembers.has(shipped)) continue;
-          seenMembers.add(shipped);
-        }
+        if (shipped && emitted.has(shipped)) continue;
+        const memberName = shipped ?? memberNameFor(valueKey, taken);
+        emitted.add(memberName);
         const valueStr = typeof v.value === 'string' ? `'${v.value}'` : String(v.value);
         if (v.description || v.deprecated) {
           const parts: string[] = [];

--- a/src/node/enums.ts
+++ b/src/node/enums.ts
@@ -7,6 +7,17 @@ import { isNodeOwnedService } from './options.js';
 import { liveSurfaceConstEnumMembers, liveSurfaceInterfacePath } from './live-surface.js';
 import { isEnumInScope } from '../shared/resolved-ops.js';
 
+/**
+ * PascalCase a wire value into a member name. Wire values may legitimately
+ * start with a digit (e.g. `1_MONTH`), which `toPascalCase` preserves and
+ * TypeScript rejects both as an enum member and as an unquoted object key.
+ * Prefix those; the member's value carries the real wire string.
+ */
+function memberNameFor(value: string): string {
+  const pascal = toPascalCase(value);
+  return !pascal || /^[0-9]/.test(pascal) ? `Value${pascal || value}` : pascal;
+}
+
 export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
   if (enums.length === 0) return [];
 
@@ -59,7 +70,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         lines.push(`  ${memberName} = ${valueStr},`);
       }
       for (const val of missingValues) {
-        const memberName = toPascalCase(val);
+        const memberName = memberNameFor(val);
         lines.push(`  ${memberName} = '${val}',`);
       }
       lines.push('}');
@@ -103,7 +114,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         const valueKey = String(v.value);
         if (seenValues.has(valueKey)) continue;
         seenValues.add(valueKey);
-        const memberName = existingMembers?.get(valueKey) ?? toPascalCase(valueKey);
+        const memberName = existingMembers?.get(valueKey) ?? memberNameFor(valueKey);
         if (seenMembers.has(memberName)) continue;
         seenMembers.add(memberName);
         const valueStr = typeof v.value === 'string' ? `'${v.value}'` : String(v.value);

--- a/test/go/resources.test.ts
+++ b/test/go/resources.test.ts
@@ -818,6 +818,77 @@ describe('go/resources', () => {
       );
       expect(content).not.toContain('if p.ExternalID != nil {');
     });
+
+    it('renames group types that would collide with a generated model', () => {
+      // Mount `AuditLogs` + group `retention` derives `AuditLogsRetention`,
+      // which is also the struct generated for the AuditLogsRetention model.
+      // Go puts both in one package, so the group types must step aside.
+      const services: Service[] = [
+        {
+          name: 'AuditLogs',
+          operations: [
+            makeOp({
+              name: 'setRetention',
+              httpMethod: 'put',
+              path: '/organizations/{id}/audit_logs_retention',
+              pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+              requestBody: { kind: 'model', name: 'UpdateAuditLogsRetention' },
+              response: { kind: 'model', name: 'AuditLogsRetention' },
+              parameterGroups: [
+                {
+                  name: 'retention',
+                  optional: false,
+                  variants: [
+                    {
+                      name: 'period',
+                      parameters: [
+                        { name: 'retention_period', type: { kind: 'primitive', type: 'string' }, required: true },
+                      ],
+                    },
+                    {
+                      name: 'period_in_days',
+                      parameters: [
+                        {
+                          name: 'retention_period_in_days',
+                          type: { kind: 'primitive', type: 'integer' },
+                          required: true,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            }),
+          ],
+        },
+      ];
+      const spec = makeSpec(services, [
+        {
+          name: 'AuditLogsRetention',
+          fields: [{ name: 'retention_period_in_days', type: { kind: 'primitive', type: 'integer' }, required: true }],
+        },
+        {
+          name: 'UpdateAuditLogsRetention',
+          fields: [
+            { name: 'retention_period', type: { kind: 'primitive', type: 'string' }, required: false },
+            { name: 'retention_period_in_days', type: { kind: 'primitive', type: 'integer' }, required: false },
+          ],
+        },
+      ]);
+      const content = generateResources(services, makeCtx(spec))[0].content;
+
+      // The interface, its marker method, the variant structs, and the params
+      // field all move to the disambiguated name together.
+      expect(content).toContain('type AuditLogsRetentionGroup interface {');
+      expect(content).toContain('isAuditLogsRetentionGroup()');
+      expect(content).toContain('type AuditLogsRetentionGroupPeriod struct {');
+      expect(content).toContain('type AuditLogsRetentionGroupPeriodInDays struct {');
+      expect(content).toContain('Retention AuditLogsRetentionGroup `url:"-" json:"-"`');
+
+      // Nothing may redeclare the model's name.
+      expect(content).not.toContain('type AuditLogsRetention interface {');
+      expect(content).not.toContain('type AuditLogsRetention struct {');
+    });
   });
 
   it('adds NullFields and MarshalJSON for nullable optional body fields', () => {

--- a/test/node/enums.test.ts
+++ b/test/node/enums.test.ts
@@ -131,6 +131,26 @@ describe('generateEnums', () => {
     expect(result[0].content).toContain('No longer supported.\n   * @deprecated');
     expect(result[0].content).toContain('/** @deprecated */');
   });
+
+  it('prefixes member names derived from values that start with a digit', () => {
+    const enums: Enum[] = [
+      {
+        name: 'AuditLogsRetentionPeriod',
+        values: [
+          { name: '1_MONTH', value: '1_MONTH' },
+          { name: '10_YEARS', value: '10_YEARS' },
+        ],
+      },
+    ];
+
+    const result = generateEnums(enums, ctx);
+    const content = result[0].content;
+
+    expect(content).toContain("Value1Month: '1_MONTH',");
+    expect(content).toContain("Value10Years: '10_YEARS',");
+    // A bare `1Month:` key is not a valid unquoted identifier.
+    expect(content).not.toMatch(/^\s+\d/m);
+  });
 });
 
 describe('assignEnumsToServices owned-service dependency reassignment', () => {

--- a/test/node/enums.test.ts
+++ b/test/node/enums.test.ts
@@ -151,6 +151,28 @@ describe('generateEnums', () => {
     // A bare `1Month:` key is not a valid unquoted identifier.
     expect(content).not.toMatch(/^\s+\d/m);
   });
+
+  it('keeps every wire value when the digit prefix collides with a sibling', () => {
+    // `1_MONTH` guards to Value1Month; `VALUE_1_MONTH` pascal-cases to it
+    // directly. Dropping the loser would omit a value from the union type.
+    const enums: Enum[] = [
+      {
+        name: 'RetentionPeriod',
+        values: [
+          { name: '1_MONTH', value: '1_MONTH' },
+          { name: 'VALUE_1_MONTH', value: 'VALUE_1_MONTH' },
+        ],
+      },
+    ];
+
+    const content = generateEnums(enums, ctx)[0].content;
+
+    expect(content).toContain("Value1Month: '1_MONTH',");
+    expect(content).toContain("Value1Month2: 'VALUE_1_MONTH',");
+    // Both wire values survive into the const object, so the derived union
+    // covers both. A duplicate key would also be a TS error.
+    expect(content.match(/Value1Month2?:/g)).toHaveLength(2);
+  });
 });
 
 describe('assignEnumsToServices owned-service dependency reassignment', () => {

--- a/test/node/enums.test.ts
+++ b/test/node/enums.test.ts
@@ -173,6 +173,34 @@ describe('generateEnums', () => {
     // covers both. A duplicate key would also be a TS error.
     expect(content.match(/Value1Month2?:/g)).toHaveLength(2);
   });
+
+  it('does not let a generated member name displace a shipped one', () => {
+    // The shipped value sits AFTER the new one in spec order, so without
+    // pre-reserving shipped names the generated member claims `Value1Month`
+    // first and the shipped value is skipped out of existence.
+    const surface = emptyLiveSurface();
+    surface.constObjectEnums.set('RetentionPeriod', new Map([['1_MONTH_LEGACY', 'Value1Month']]));
+    setActiveLiveSurface(surface);
+    try {
+      const enums: Enum[] = [
+        {
+          name: 'RetentionPeriod',
+          values: [
+            { name: '1_MONTH', value: '1_MONTH' },
+            { name: '1_MONTH_LEGACY', value: '1_MONTH_LEGACY' },
+          ],
+        },
+      ];
+
+      const content = generateEnums(enums, ctx)[0].content;
+
+      // The shipped member keeps its name; the new value steps aside.
+      expect(content).toContain("Value1Month: '1_MONTH_LEGACY',");
+      expect(content).toContain("Value1Month2: '1_MONTH',");
+    } finally {
+      setActiveLiveSurface(emptyLiveSurface());
+    }
+  });
 });
 
 describe('assignEnumsToServices owned-service dependency reassignment', () => {

--- a/test/php/tests.test.ts
+++ b/test/php/tests.test.ts
@@ -419,4 +419,53 @@ describe('generateTests', () => {
     // The plain-string placeholder must NOT be used for a date-time field.
     expect(content).not.toContain("assertSame('test_value', $body['range_start'])");
   });
+
+  it('references enum cases by their guarded name when the value starts with a digit', () => {
+    const enumSpec: ApiSpec = {
+      ...spec,
+      enums: [
+        {
+          name: 'RetentionPeriod',
+          values: [
+            { name: '1_MONTH', value: '1_MONTH' },
+            { name: '10_YEARS', value: '10_YEARS' },
+          ],
+        },
+      ],
+      models: [
+        ...models,
+        {
+          name: 'SetRetention',
+          fields: [{ name: 'retention_period', type: { kind: 'enum', name: 'RetentionPeriod' }, required: true }],
+        },
+      ],
+      services: [
+        {
+          name: 'AuditLogs',
+          operations: [
+            {
+              name: 'setRetention',
+              httpMethod: 'put',
+              path: '/audit_logs/retention',
+              pathParams: [],
+              queryParams: [],
+              headerParams: [],
+              requestBody: { kind: 'model', name: 'SetRetention' },
+              response: { kind: 'model', name: 'Organization' },
+              errors: [],
+              injectIdempotencyKey: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    const content = generateTests(enumSpec, { ...ctx, spec: enumSpec }).find(
+      (f) => f.path === 'tests/Service/AuditLogsTest.php',
+    )!.content;
+
+    // Must match the case name enums.ts declares — `::1Month` is a parse error.
+    expect(content).toContain('RetentionPeriod::Value1Month');
+    expect(content).not.toContain('RetentionPeriod::1Month');
+  });
 });


### PR DESCRIPTION
Follow-on to #232. That PR guarded enum **member** names for dotnet, python, and php; these are the two remaining gaps from the same spec change on [openapi-spec#136](https://github.com/workos/openapi-spec/pull/136), where the new `retention_period` enum (`1_MONTH` … `10_YEARS`) took out four of the eight matrix jobs.

With #232 merged, `sdk_build (go)` on that PR is still red.

## Go — `AuditLogsRetention redeclared`

A parameter group's types are named `<Mount><Group>`, so the new `retention` body group on the `AuditLogs` mount produces `AuditLogsRetention` — already the struct generated for the `AuditLogsRetention` schema. Everything lands in one Go package, so this is a redeclaration error, not a shadow:

```
./models.go:762:6: AuditLogsRetention redeclared in this block
	./audit_logs.go:20:6: other declaration of AuditLogsRetention
```

Collect the type names models and enums claim (`reservedTypeNames`), and suffix the group types when a derivation lands on one (`avoidReserved`). The interface, its marker method, the variant structs, and the params field all move to `AuditLogsRetentionGroup` together, so the generated `AuditLogsRetention` model keeps its name and stays the response type.

Any emitter that synthesizes a type name from operation metadata has this same exposure; Go is just the one where a flat package makes it fatal.

## Node — latent, same root cause as #232

`toPascalCase` on the wire value feeds both an enum member name and an unquoted object key, neither of which may start with a digit. #232 didn't cover node because it's absent from openapi-spec's matrix, so the break never surfaced as a red check. The const-object path still prefers an already-shipped member name from the live surface, so no previously-generated name is renamed.

## Also: the regression test #232 didn't have

`src/php/tests.ts` re-derived enum case names from its own copy of the logic, under a `// Must match the case-name logic in enums.ts` comment — and had drifted, so generated tests referenced `UpdateAuditLogsRetentionRetentionPeriod::1Month` against a guarded declaration. #232 fixed that code but didn't pin it. This adds the test. A "must match X" comment is a bug waiting to happen, and this one already was.

## Verification

Unit suite **856 passed (103 files)**, typecheck and `oxfmt` clean. The Go test was confirmed to fail without the fix, reproducing `type AuditLogsRetention interface {`.

End to end against the spec on openapi-spec#136, generated the way CI does (`npm run sdk:generate -- --lang <L> --output <WT>`) into worktrees off each SDK's `origin/main`:

- **go** — `script/ci` fully green (fmt, build, vet, test), where it previously failed to build
- **python** — `nox -s ci` successful, 2727 passed
- **php** — both previously unparseable files lint clean

## Note for whoever releases this

A full PHP regen off this branch reports 11 php-cs-fixer-fixable files (`single_space_around_construct` in `lib/Service/*`, `braces_position` in `lib/Resource/ApiKey*`). **Not from this PR** — pristine `main` produces the identical 11. But published 0.24.7 reports 0, so those 11 will turn `sdk_build (php)` red on the next release unless fixed separately.