### PR TITLE
fix(go): suffix group union names that collide with model types

### DIFF
--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -274,7 +274,12 @@ let reservedTypeNames: ReadonlySet<string> = new Set();
  */
 function groupInterfaceName(mountName: string, groupName: string): string {
   const base = `${className(mountName)}${fieldName(groupName)}`;
-  return reservedTypeNames.has(base) ? `${base}Union` : base;
+  if (!reservedTypeNames.has(base)) return base;
+  let candidate = `${base}Union`;
+  for (let n = 2; reservedTypeNames.has(candidate); n++) {
+    candidate = `${base}Union${n}`;
+  }
+  return candidate;
 }
 
 /** Variant struct type name (e.g. AuthorizationParentResourceRefByID). */

--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -61,6 +61,11 @@ export function resolveResourceClassName(service: Service, ctx: EmitterContext):
 export function generateResources(services: Service[], ctx: EmitterContext): GeneratedFile[] {
   if (services.length === 0) return [];
 
+  reservedTypeNames = new Set([
+    ...ctx.spec.models.map((m) => className(m.name)),
+    ...ctx.spec.enums.map((e) => className(e.name)),
+  ]);
+
   const files: GeneratedFile[] = [];
   const mountGroups = scopedMountGroups(ctx);
 
@@ -253,9 +258,23 @@ function isBodyGroup(group: import('@workos/oagen').ParameterGroup, op: Operatio
   return group.variants.every((v) => v.parameters.every((p) => !queryNames.has(p.name)));
 }
 
-/** Interface type name for a parameter group (e.g. AuthorizationParentResource). */
+/**
+ * Type names already claimed by generated models and enums. Go's single flat
+ * package means a group interface named `<Mount><Group>` can collide with a
+ * model struct (e.g. the AuditLogs `retention` body group vs the
+ * `AuditLogsRetention` response model); populated per generateResources run.
+ */
+let reservedTypeNames: ReadonlySet<string> = new Set();
+
+/**
+ * Interface type name for a parameter group (e.g. AuthorizationParentResource).
+ * When the natural name is taken by a model or enum, the union interface —
+ * the artificial construct — yields and takes a `Union` suffix; variant
+ * struct names follow the resolved interface name.
+ */
 function groupInterfaceName(mountName: string, groupName: string): string {
-  return `${className(mountName)}${fieldName(groupName)}`;
+  const base = `${className(mountName)}${fieldName(groupName)}`;
+  return reservedTypeNames.has(base) ? `${base}Union` : base;
 }
 
 /** Variant struct type name (e.g. AuthorizationParentResourceRefByID). */

--- a/test/go/resources.test.ts
+++ b/test/go/resources.test.ts
@@ -599,6 +599,24 @@ describe('go/resources', () => {
       expect(content).toContain('func (p AuthorizationParentResourceByExternalID) isAuthorizationParentResource()');
     });
 
+    it('suffixes the interface with Union when a model claims the natural name', () => {
+      const services = makeGroupedServices();
+      const collidingModel: Model = {
+        name: 'AuthorizationParentResource',
+        fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+      };
+      const spec = makeSpec(services, [collidingModel]);
+      const files = generateResources(services, makeCtx(spec));
+      const content = files[0].content;
+
+      expect(content).toContain('type AuthorizationParentResourceUnion interface {');
+      expect(content).toContain('isAuthorizationParentResourceUnion()');
+      expect(content).not.toContain('type AuthorizationParentResource interface {');
+      // Variant structs follow the resolved interface name
+      expect(content).toContain('type AuthorizationParentResourceUnionByID struct {');
+      expect(content).toContain('func (p AuthorizationParentResourceUnionByID) isAuthorizationParentResourceUnion()');
+    });
+
     it('generates applyToQuery methods using original wire names', () => {
       const services = makeGroupedServices();
       const spec = makeSpec(services);

--- a/test/go/resources.test.ts
+++ b/test/go/resources.test.ts
@@ -617,6 +617,26 @@ describe('go/resources', () => {
       expect(content).toContain('func (p AuthorizationParentResourceUnionByID) isAuthorizationParentResourceUnion()');
     });
 
+    it('escalates the suffix when the Union name is reserved too', () => {
+      const services = makeGroupedServices();
+      const models: Model[] = [
+        {
+          name: 'AuthorizationParentResource',
+          fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        },
+        {
+          name: 'AuthorizationParentResourceUnion',
+          fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        },
+      ];
+      const spec = makeSpec(services, models);
+      const files = generateResources(services, makeCtx(spec));
+      const content = files[0].content;
+
+      expect(content).toContain('type AuthorizationParentResourceUnion2 interface {');
+      expect(content).not.toContain('type AuthorizationParentResourceUnion interface {');
+    });
+
     it('generates applyToQuery methods using original wire names', () => {
       const services = makeGroupedServices();
       const spec = makeSpec(services);


### PR DESCRIPTION
## Summary

Fixes the remaining `sdk_build (go)` failure on workos/openapi-spec#137: `AuditLogsRetention redeclared in this block`.

Go emits the whole SDK into one flat package, and a mutually-exclusive body group's union interface is named `<Mount><Group>` (`groupInterfaceName` in `src/go/resources.ts`). The new Set Retention API introduces a `retention` body group on the AuditLogs mount, so the union interface lands on `AuditLogsRetention` — the exact name of the endpoint's generated response model struct. Two generated declarations, one package, compile error.

**The call made here**: the response model keeps the natural public name (it's the real API resource, already shipped in workos-go's public surface as the return type of `GetOrganizationAuditLogsRetention`); the union interface — the artificial request-side construct — yields and takes a `Union` suffix, with its variant structs following:

- `AuditLogsRetentionUnion` (interface), `AuditLogsRetentionUnionPeriod`, `AuditLogsRetentionUnionPeriodInDays`
- Applied only on collision (checked against the spec's model + enum type names), so every existing group name — `AuthorizationParentResource` etc. — is untouched.

## Test plan

- New unit test: a model claiming the group's natural name flips the interface and variants to the `Union`-suffixed family; existing group-naming tests unchanged (proving non-colliding names don't move)
- Full suite: 854 tests pass; lint/format clean
- End-to-end: regenerated go from openapi-spec#137's spec with this build — the duplicate declaration is gone (`AuditLogsRetentionUnion` in `audit_logs.go`, model struct in `models.go`), and a package-wide duplicate-type scan over the generated output is clean (no go toolchain on this machine, so compile verification rides openapi-spec's `sdk_build (go)`)

Together with #232 (merged) this should turn openapi-spec#137's sdk-validation fully green.