### PR TITLE
fix(dotnet): stop group types from colliding with model names

### DIFF
--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -112,22 +112,56 @@ function reservedTypeNames(ctx: EmitterContext): Set<string> {
   return reserved;
 }
 
-/** Abstract base class name for a parameter group (e.g. UserManagementRole). */
-function groupBaseClassName(mountName: string, groupName: string, reserved: Set<string>): string {
-  return avoidReservedTypeName(`${className(mountName)}${className(groupName)}`, reserved);
+/** Resolved class names for one parameter group: the base plus one per variant. */
+interface GroupClassNames {
+  /** Abstract base class name (e.g. UserManagementRole). */
+  base: string;
+  /** Variant name from the spec to concrete class name (e.g. UserManagementRoleSingle). */
+  variants: Map<string, string>;
 }
 
-/** Concrete variant class name (e.g. UserManagementRoleSingle). */
-function groupVariantClassName(
+/**
+ * Resolve every distinct parameter group in a mount to its C# class names.
+ *
+ * Keyed on the group's type base name — its identity — so a group declared on
+ * several operations resolves to one set of classes, while two genuinely
+ * different groups never share a name. Each name a group claims joins the
+ * reserved set, so a group pushed off `<Base>` onto `<Base>Group` cannot land on
+ * the name a later group derives naturally: keying the earlier dedup on the
+ * derived name instead would have skipped the later group's declarations while
+ * its options property and `is` patterns still referenced them.
+ *
+ * The service file and the options file resolve from the same operation list, so
+ * both see the same names for the same groups.
+ */
+function resolveGroupClassNames(
   mountName: string,
-  groupName: string,
-  variantName: string,
-  reserved: Set<string>,
-): string {
-  return avoidReservedTypeName(
-    `${groupBaseClassName(mountName, groupName, reserved)}${className(variantName)}`,
-    reserved,
-  );
+  operations: Operation[],
+  ctx: EmitterContext,
+): Map<string, GroupClassNames> {
+  const claimed = reservedTypeNames(ctx);
+  const resolved = new Map<string, GroupClassNames>();
+
+  for (const op of operations) {
+    for (const group of op.parameterGroups ?? []) {
+      const key = groupTypeBaseName(group);
+      if (resolved.has(key)) continue;
+
+      const base = avoidReservedTypeName(`${className(mountName)}${className(key)}`, claimed);
+      claimed.add(base);
+
+      const variants = new Map<string, string>();
+      for (const variant of group.variants) {
+        const variantClass = avoidReservedTypeName(`${base}${className(variant.name)}`, claimed);
+        claimed.add(variantClass);
+        variants.set(variant.name, variantClass);
+      }
+
+      resolved.set(key, { base, variants });
+    }
+  }
+
+  return resolved;
 }
 
 /**
@@ -146,25 +180,30 @@ function optionalMemberType(type: TypeRef): TypeRef {
  * for each variant containing the variant's parameters as properties.
  */
 function generateParameterGroupTypes(
-  mountName: string,
   op: Operation,
   models: Model[],
-  reserved: Set<string>,
+  groupNames: Map<string, GroupClassNames>,
   emitted?: Set<string>,
 ): string[] {
   const lines: string[] = [];
   const bodyFieldTypes = collectBodyFieldTypes(op, models);
 
   for (const group of op.parameterGroups ?? []) {
-    const baseName = groupBaseClassName(mountName, groupTypeBaseName(group), reserved);
-    if (emitted?.has(baseName)) continue;
-    emitted?.add(baseName);
+    // Dedupe on the group's identity, not its class name: distinct groups can
+    // derive one name before disambiguation, and skipping the second would
+    // leave its variants referenced but never declared.
+    const groupKey = groupTypeBaseName(group);
+    if (emitted?.has(groupKey)) continue;
+    emitted?.add(groupKey);
+
+    const names = groupNames.get(groupKey)!;
+    const baseName = names.base;
 
     lines.push('');
     lines.push(`    public abstract class ${baseName} { }`);
 
     for (const variant of group.variants) {
-      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name, reserved);
+      const variantName = names.variants.get(variant.name)!;
       lines.push('');
       lines.push(`    public class ${variantName} : ${baseName}`);
       lines.push('    {');
@@ -200,22 +239,22 @@ function generateParameterGroupTypes(
  * (query string or request body).
  */
 function emitGroupSerialization(
-  mountName: string,
   op: Operation,
   indent: string,
   models: Model[],
   target: 'query' | 'body',
-  reserved: Set<string>,
+  groupNames: Map<string, GroupClassNames>,
 ): string[] {
   const lines: string[] = [];
   const bodyFieldTypes = collectBodyFieldTypes(op, models);
 
   for (const group of op.parameterGroups ?? []) {
     const groupField = fieldName(group.name);
+    const names = groupNames.get(groupTypeBaseName(group))!;
     let first = true;
 
     for (const variant of group.variants) {
-      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name, reserved);
+      const variantName = names.variants.get(variant.name)!;
       // Use a short local variable derived from the variant name
       const localVar = localName(variant.name);
       const keyword = first ? 'if' : 'else if';
@@ -367,6 +406,7 @@ function generateServiceFile(mountName: string, operations: Operation[], ctx: Em
   const csFile = `Services/${className(mountName)}/${svcTypeName}.cs`;
 
   const resolvedLookup = buildResolvedLookup(ctx);
+  const groupNames = resolveGroupClassNames(mountName, operations, ctx);
 
   // A generated method named DeleteAsync with exactly two leading parameters
   // (e.g. two path params) hides Service.DeleteAsync from the 4-argument
@@ -462,6 +502,7 @@ function generateServiceFile(mountName: string, operations: Operation[], ctx: Em
         op,
         plan,
         ctx,
+        groupNames,
         resolvedOp,
         hasCapturingDeleteAsync,
       );
@@ -514,7 +555,7 @@ function generateOptionsFile(mountName: string, operations: Operation[], ctx: Em
 
   const emittedOptions = new Set<string>();
   const emittedGroupTypes = new Set<string>();
-  const reservedNames = reservedTypeNames(ctx);
+  const groupNames = resolveGroupClassNames(mountName, operations, ctx);
   for (const op of operations) {
     const plan = planOperation(op);
     const method = resolveCsMethodName(op, mountName, ctx);
@@ -669,7 +710,7 @@ function generateOptionsFile(mountName: string, operations: Operation[], ctx: Em
 
     // Parameter group properties (serialized manually in the service method, not by JSON)
     for (const group of op.parameterGroups ?? []) {
-      const baseName = groupBaseClassName(mountName, groupTypeBaseName(group), reservedNames);
+      const baseName = groupNames.get(groupTypeBaseName(group))!.base;
       const csField = fieldName(group.name);
       optionsLines.push('        [JsonIgnore]');
       optionsLines.push('        [STJS.JsonIgnore]');
@@ -683,9 +724,7 @@ function generateOptionsFile(mountName: string, operations: Operation[], ctx: Em
 
     // Emit parameter group abstract base + concrete variant classes
     if (hasGroups) {
-      optionsLines.push(
-        ...generateParameterGroupTypes(mountName, op, ctx.spec.models, reservedNames, emittedGroupTypes),
-      );
+      optionsLines.push(...generateParameterGroupTypes(op, ctx.spec.models, groupNames, emittedGroupTypes));
     }
   }
 
@@ -708,6 +747,7 @@ function generateMethod(
   op: Operation,
   plan: OperationPlan,
   ctx: EmitterContext,
+  groupNames: Map<string, GroupClassNames>,
   resolvedOp?: ResolvedOperation,
   hasCapturingDeleteAsync = false,
 ): string {
@@ -869,9 +909,7 @@ function generateMethod(
     if (hasGroups) {
       const groupTarget = hasBody && !isDelete ? 'body' : 'query';
       lines.push('');
-      lines.push(
-        ...emitGroupSerialization(mountName, op, '            ', ctx.spec.models, groupTarget, reservedTypeNames(ctx)),
-      );
+      lines.push(...emitGroupSerialization(op, '            ', ctx.spec.models, groupTarget, groupNames));
       lines.push('');
     }
 

--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -44,6 +44,7 @@ import {
   collectBodyFieldTypes,
   groupTypeBaseName,
 } from '../shared/resolved-ops.js';
+import { avoidReservedTypeName } from '../shared/naming-utils.js';
 import { generateWrapperMethods } from './wrappers.js';
 
 /**
@@ -94,14 +95,39 @@ export function generateResources(services: Service[], ctx: EmitterContext): Gen
 // Mutually-exclusive parameter group support
 // ---------------------------------------------------------------------------
 
+/**
+ * C# type names already claimed by generated models and enums.
+ *
+ * Parameter-group class names are derived from the mount and group names, so
+ * they can land on a name a model already owns: mount `AuditLogs` + group
+ * `retention` yields `AuditLogsRetention`, which is also the class generated for
+ * the `AuditLogsRetention` schema. Every generated type shares the one `WorkOS`
+ * namespace, so that is CS0101 rather than a shadow — the group types have to
+ * step aside.
+ */
+function reservedTypeNames(ctx: EmitterContext): Set<string> {
+  const reserved = new Set<string>();
+  for (const model of ctx.spec.models) reserved.add(modelClassName(model.name));
+  for (const enumDef of ctx.spec.enums) reserved.add(className(enumDef.name));
+  return reserved;
+}
+
 /** Abstract base class name for a parameter group (e.g. UserManagementRole). */
-function groupBaseClassName(mountName: string, groupName: string): string {
-  return `${className(mountName)}${className(groupName)}`;
+function groupBaseClassName(mountName: string, groupName: string, reserved: Set<string>): string {
+  return avoidReservedTypeName(`${className(mountName)}${className(groupName)}`, reserved);
 }
 
 /** Concrete variant class name (e.g. UserManagementRoleSingle). */
-function groupVariantClassName(mountName: string, groupName: string, variantName: string): string {
-  return `${className(mountName)}${className(groupName)}${className(variantName)}`;
+function groupVariantClassName(
+  mountName: string,
+  groupName: string,
+  variantName: string,
+  reserved: Set<string>,
+): string {
+  return avoidReservedTypeName(
+    `${groupBaseClassName(mountName, groupName, reserved)}${className(variantName)}`,
+    reserved,
+  );
 }
 
 /**
@@ -123,13 +149,14 @@ function generateParameterGroupTypes(
   mountName: string,
   op: Operation,
   models: Model[],
+  reserved: Set<string>,
   emitted?: Set<string>,
 ): string[] {
   const lines: string[] = [];
   const bodyFieldTypes = collectBodyFieldTypes(op, models);
 
   for (const group of op.parameterGroups ?? []) {
-    const baseName = groupBaseClassName(mountName, groupTypeBaseName(group));
+    const baseName = groupBaseClassName(mountName, groupTypeBaseName(group), reserved);
     if (emitted?.has(baseName)) continue;
     emitted?.add(baseName);
 
@@ -137,7 +164,7 @@ function generateParameterGroupTypes(
     lines.push(`    public abstract class ${baseName} { }`);
 
     for (const variant of group.variants) {
-      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name);
+      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name, reserved);
       lines.push('');
       lines.push(`    public class ${variantName} : ${baseName}`);
       lines.push('    {');
@@ -178,6 +205,7 @@ function emitGroupSerialization(
   indent: string,
   models: Model[],
   target: 'query' | 'body',
+  reserved: Set<string>,
 ): string[] {
   const lines: string[] = [];
   const bodyFieldTypes = collectBodyFieldTypes(op, models);
@@ -187,7 +215,7 @@ function emitGroupSerialization(
     let first = true;
 
     for (const variant of group.variants) {
-      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name);
+      const variantName = groupVariantClassName(mountName, groupTypeBaseName(group), variant.name, reserved);
       // Use a short local variable derived from the variant name
       const localVar = localName(variant.name);
       const keyword = first ? 'if' : 'else if';
@@ -486,6 +514,7 @@ function generateOptionsFile(mountName: string, operations: Operation[], ctx: Em
 
   const emittedOptions = new Set<string>();
   const emittedGroupTypes = new Set<string>();
+  const reservedNames = reservedTypeNames(ctx);
   for (const op of operations) {
     const plan = planOperation(op);
     const method = resolveCsMethodName(op, mountName, ctx);
@@ -640,7 +669,7 @@ function generateOptionsFile(mountName: string, operations: Operation[], ctx: Em
 
     // Parameter group properties (serialized manually in the service method, not by JSON)
     for (const group of op.parameterGroups ?? []) {
-      const baseName = groupBaseClassName(mountName, groupTypeBaseName(group));
+      const baseName = groupBaseClassName(mountName, groupTypeBaseName(group), reservedNames);
       const csField = fieldName(group.name);
       optionsLines.push('        [JsonIgnore]');
       optionsLines.push('        [STJS.JsonIgnore]');
@@ -654,7 +683,9 @@ function generateOptionsFile(mountName: string, operations: Operation[], ctx: Em
 
     // Emit parameter group abstract base + concrete variant classes
     if (hasGroups) {
-      optionsLines.push(...generateParameterGroupTypes(mountName, op, ctx.spec.models, emittedGroupTypes));
+      optionsLines.push(
+        ...generateParameterGroupTypes(mountName, op, ctx.spec.models, reservedNames, emittedGroupTypes),
+      );
     }
   }
 
@@ -838,7 +869,9 @@ function generateMethod(
     if (hasGroups) {
       const groupTarget = hasBody && !isDelete ? 'body' : 'query';
       lines.push('');
-      lines.push(...emitGroupSerialization(mountName, op, '            ', ctx.spec.models, groupTarget));
+      lines.push(
+        ...emitGroupSerialization(mountName, op, '            ', ctx.spec.models, groupTarget, reservedTypeNames(ctx)),
+      );
       lines.push('');
     }
 

--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -31,7 +31,7 @@ import {
   collectBodyFieldTypes,
   groupTypeBaseName,
 } from '../shared/resolved-ops.js';
-import { lowerFirstForDoc, fieldDocComment } from '../shared/naming-utils.js';
+import { lowerFirstForDoc, fieldDocComment, avoidReservedTypeName } from '../shared/naming-utils.js';
 import { generateWrapperMethods } from './wrappers.js';
 
 /**
@@ -270,22 +270,9 @@ function reservedTypeNames(ctx: EmitterContext): Set<string> {
   return reserved;
 }
 
-/**
- * Suffix `base` until it no longer collides with a reserved type name. `Group`
- * reads naturally for parameter-group types; the numeric fallback only matters
- * if a schema is literally named `<Mount><Group>Group`.
- */
-function avoidReserved(base: string, reserved: Set<string>): string {
-  if (!reserved.has(base)) return base;
-  let candidate = `${base}Group`;
-  let suffix = 2;
-  while (reserved.has(candidate)) candidate = `${base}Group${suffix++}`;
-  return candidate;
-}
-
 /** Interface type name for a parameter group (e.g. AuthorizationParentResource). */
 function groupInterfaceName(mountName: string, groupName: string, reserved: Set<string>): string {
-  return avoidReserved(`${className(mountName)}${fieldName(groupName)}`, reserved);
+  return avoidReservedTypeName(`${className(mountName)}${fieldName(groupName)}`, reserved);
 }
 
 /** Variant struct type name (e.g. AuthorizationParentResourceRefByID). */
@@ -295,7 +282,10 @@ function groupVariantTypeName(
   variantName: string,
   reserved: Set<string>,
 ): string {
-  return avoidReserved(`${groupInterfaceName(mountName, groupName, reserved)}${fieldName(variantName)}`, reserved);
+  return avoidReservedTypeName(
+    `${groupInterfaceName(mountName, groupName, reserved)}${fieldName(variantName)}`,
+    reserved,
+  );
 }
 
 /**

--- a/src/shared/naming-utils.ts
+++ b/src/shared/naming-utils.ts
@@ -245,3 +245,26 @@ export function lowerFirstForDoc(s: string): string {
   }
   return s.charAt(0).toLowerCase() + s.slice(1);
 }
+
+/**
+ * Suffix `base` until it no longer collides with a reserved type name.
+ *
+ * Parameter-group type names are derived from the mount and group names, so in
+ * languages that prefix the mount they can land on a name a model already owns:
+ * mount `AuditLogs` + group `retention` yields `AuditLogsRetention`, which is
+ * also the type generated for the `AuditLogsRetention` schema. Where models and
+ * group types share one namespace that is a redeclaration error rather than a
+ * shadow, so the group types have to step aside.
+ *
+ * `Group` reads naturally for parameter-group types; the numeric fallback only
+ * matters if a schema is literally named `<Mount><Group>Group`. Every emitter
+ * that guards its group names uses this, so a group renamed in one language is
+ * renamed the same way in the others.
+ */
+export function avoidReservedTypeName(base: string, reserved: Set<string>): string {
+  if (!reserved.has(base)) return base;
+  let candidate = `${base}Group`;
+  let suffix = 2;
+  while (reserved.has(candidate)) candidate = `${base}Group${suffix++}`;
+  return candidate;
+}

--- a/test/dotnet/resources.test.ts
+++ b/test/dotnet/resources.test.ts
@@ -803,4 +803,87 @@ describe('dotnet/resources', () => {
 
     expect(render([])).toBe(render(undefined));
   });
+
+  it('renames group types that would collide with a generated model', () => {
+    // Mount `AuditLogs` + group `retention` derives `AuditLogsRetention`, which
+    // is also the class generated for the AuditLogsRetention model. Every
+    // generated type shares the one WorkOS namespace, so the group types must
+    // step aside or the SDK fails to compile with CS0101.
+    const models: Model[] = [
+      {
+        name: 'AuditLogsRetention',
+        fields: [{ name: 'retention_period_in_days', type: { kind: 'primitive', type: 'integer' }, required: true }],
+      },
+      {
+        name: 'UpdateAuditLogsRetention',
+        fields: [
+          { name: 'retention_period', type: { kind: 'primitive', type: 'string' }, required: false },
+          { name: 'retention_period_in_days', type: { kind: 'primitive', type: 'integer' }, required: false },
+        ],
+      },
+    ];
+
+    const services: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'updateAuditLogsRetention',
+            httpMethod: 'put',
+            path: '/organizations/{organizationId}/audit_logs_retention',
+            pathParams: [{ name: 'organizationId', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'UpdateAuditLogsRetention' },
+            response: { kind: 'model', name: 'AuditLogsRetention' },
+            errors: [],
+            injectIdempotencyKey: false,
+            parameterGroups: [
+              {
+                name: 'retention',
+                optional: false,
+                variants: [
+                  {
+                    name: 'period',
+                    parameters: [
+                      { name: 'retention_period', type: { kind: 'primitive', type: 'string' }, required: true },
+                    ],
+                  },
+                  {
+                    name: 'period_in_days',
+                    parameters: [
+                      {
+                        name: 'retention_period_in_days',
+                        type: { kind: 'primitive', type: 'integer' },
+                        required: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const files = generateResources(services, { ...ctx, spec: { ...emptySpec, services, models } });
+
+    const optContent = files.find((f) => f.path.includes('Options.cs'))!.content;
+    const svcContent = files.find((f) => f.path.endsWith('Service.cs'))!.content;
+
+    // The base class, the variant subclasses, and the options property all move
+    // to the disambiguated name together.
+    expect(optContent).toContain('public abstract class AuditLogsRetentionGroup { }');
+    expect(optContent).toContain('public class AuditLogsRetentionGroupPeriod : AuditLogsRetentionGroup');
+    expect(optContent).toContain('public class AuditLogsRetentionGroupPeriodInDays : AuditLogsRetentionGroup');
+    expect(optContent).toContain('public AuditLogsRetentionGroup Retention { get; set; } = default!;');
+
+    // Nothing may redeclare the model's name, and the service's pattern matches
+    // have to name the same variant classes the options file declares.
+    expect(optContent).not.toContain('public abstract class AuditLogsRetention { }');
+    expect(svcContent).toContain('is AuditLogsRetentionGroupPeriod ');
+    expect(svcContent).toContain('is AuditLogsRetentionGroupPeriodInDays ');
+  });
 });

--- a/test/dotnet/resources.test.ts
+++ b/test/dotnet/resources.test.ts
@@ -886,4 +886,100 @@ describe('dotnet/resources', () => {
     expect(svcContent).toContain('is AuditLogsRetentionGroupPeriod ');
     expect(svcContent).toContain('is AuditLogsRetentionGroupPeriodInDays ');
   });
+
+  it('keeps a disambiguated group name off another group in the same mount', () => {
+    // `retention` collides with the AuditLogsRetention model and moves to
+    // AuditLogsRetentionGroup — which is what `retention_group` on the sibling
+    // operation derives naturally. Both groups must still get their own
+    // declarations: deduping on the class name rather than the group's identity
+    // would drop the second group's classes while its options property and `is`
+    // patterns went on referencing them.
+    const models: Model[] = [
+      {
+        name: 'AuditLogsRetention',
+        fields: [{ name: 'retention_period_in_days', type: { kind: 'primitive', type: 'integer' }, required: true }],
+      },
+    ];
+
+    const services: Service[] = [
+      {
+        name: 'AuditLogs',
+        operations: [
+          {
+            name: 'setRetention',
+            httpMethod: 'put',
+            path: '/organizations/{organizationId}/audit_logs_retention',
+            pathParams: [{ name: 'organizationId', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'AuditLogsRetention' },
+            errors: [],
+            injectIdempotencyKey: false,
+            parameterGroups: [
+              {
+                name: 'retention',
+                optional: false,
+                variants: [
+                  {
+                    name: 'period',
+                    parameters: [
+                      { name: 'retention_period', type: { kind: 'primitive', type: 'string' }, required: true },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'setRetentionGroup',
+            httpMethod: 'put',
+            path: '/organizations/{organizationId}/audit_logs_retention_group',
+            pathParams: [{ name: 'organizationId', type: { kind: 'primitive', type: 'string' }, required: true }],
+            queryParams: [],
+            headerParams: [],
+            response: { kind: 'model', name: 'AuditLogsRetention' },
+            errors: [],
+            injectIdempotencyKey: false,
+            parameterGroups: [
+              {
+                name: 'retention_group',
+                optional: false,
+                variants: [
+                  {
+                    name: 'slug',
+                    parameters: [
+                      { name: 'retention_group_slug', type: { kind: 'primitive', type: 'string' }, required: true },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    primeEnumAliases([]);
+    const files = generateResources(services, { ...ctx, spec: { ...emptySpec, services, models } });
+
+    const optContent = files.find((f) => f.path.includes('Options.cs'))!.content;
+    const svcContent = files.find((f) => f.path.endsWith('Service.cs'))!.content;
+
+    // Two distinct base classes, each declared exactly once.
+    const declarations = [...optContent.matchAll(/public abstract class (\w+) \{ \}/g)].map((m) => m[1]);
+    expect(declarations).toHaveLength(new Set(declarations).size);
+    expect(declarations).toHaveLength(2);
+
+    // Every variant class the service pattern-matches on has to be declared.
+    for (const variantClass of [...svcContent.matchAll(/ is (\w+) \w+\)/g)].map((m) => m[1])) {
+      expect(optContent).toContain(`public class ${variantClass} : `);
+    }
+
+    // Each options property points at its own group's base class.
+    const retentionBase = optContent.match(/public (\w+) Retention \{ get; set; \}/)![1];
+    const groupBase = optContent.match(/public (\w+) RetentionGroup \{ get; set; \}/)![1];
+    expect(retentionBase).not.toBe(groupBase);
+    expect(optContent).toContain(`public abstract class ${retentionBase} { }`);
+    expect(optContent).toContain(`public abstract class ${groupBase} { }`);
+  });
 });


### PR DESCRIPTION
## What

`openapi-spec#136` turns `UpdateAuditLogsRetentionDto` into a `oneOf` with a mutually-exclusive body group named `retention`. dotnet names a group's types `<Mount><Group>`, so mount `AuditLogs` derived `AuditLogsRetention` — already the class generated for the `AuditLogsRetention` schema. Every generated type shares the one `WorkOS` namespace, so that is:

```
AuditLogsOptions.cs(19,27): error CS0101: The namespace 'WorkOS' already contains a definition for 'AuditLogsRetention'
AuditLogsOptions.cs(29,21): error CS0108: 'AuditLogsRetentionPeriodInDays.RetentionPeriodInDays' hides inherited member 'AuditLogsRetention.RetentionPeriodInDays'
```

and it is why `sdk_build (dotnet)` is the one red job on that PR. The `emitted` set only ever deduped group against group, never group against model.

## How

Collect the names models and enums claim and suffix the group types (`AuditLogsRetentionGroup`) when a derivation lands on one. The abstract base, the variant subclasses, the options property, and the service method's `is` pattern matches all move together — they are four call sites over one derivation, so a partial rename would compile to a dangling reference.

#233 fixed the same bug for go, where the collision is a package-level redeclaration. Its `avoidReserved` moves to `shared/naming-utils` as `avoidReservedTypeName` so both emitters rename a group the same way instead of drifting apart; a second copy of one naming rule is what made this class of bug recur in the first place. The reserved-set builder stays per-language, since each derives type names differently (dotnet honors `modelClassName`'s aliases).

## Other languages

None need this. node/ios/elixir/android emit no group types at all, and kotlin/python/php/ruby/rust derive the name from the group alone (`Retention`, not `AuditLogsRetention`) and emit into a per-service package, module, or namespace rather than alongside models. Only go and dotnet fold the mount into the name *and* share one flat namespace with models.

## Verification

Generated against the spec on `openapi-spec#136` the way CI does (`npm run sdk:generate --lang dotnet`) into a worktree off `workos-dotnet`'s `origin/main`, then ran `script/ci`:

- build: 0 warnings, 0 errors (previously failed to build)
- format check: clean
- tests: 614 passed

Emitters' own suite: 859 tests pass, `lint` and `format` clean. New regression test in `test/dotnet/resources.test.ts` pins the base class, both variant subclasses, the options property, and the service-side pattern matches.

## Follow-up

`openapi-spec` needs its `@workos/oagen-emitters` pin bumped once this releases for `sdk_build (dotnet)` to go green on #136.