### PR TITLE
fix(ios): stop requiredness changes from renumbering labeled arguments

### DIFF
--- a/src/ios/resources.ts
+++ b/src/ios/resources.ts
@@ -204,9 +204,31 @@ export function collectMethodParams(resolved: ResolvedOperation, ctx: EmitterCon
   return params;
 }
 
-/** Signature order: required params first, optionals after. */
+/**
+ * Signature order: exactly the collection order from `collectMethodParams`
+ * (path params in template order, then body fields, then query params).
+ *
+ * Deliberately does NOT sort by optionality. Swift permits a defaulted
+ * parameter in any position, so required-first was only cosmetic — but it made
+ * a parameter's *position* a function of its requiredness, and the backend
+ * flips required ↔ optional routinely. Every flip then moved the parameter
+ * across the bucket boundary and renumbered everything after it, which for
+ * Swift's order-sensitive labeled arguments is a source break: making `code`
+ * optional on `SSO.getProfileAndToken` moved it from position 1 to 4 and
+ * dragged `requestOptions` from 2 to 5, turning a purely additive API change
+ * into a major version bump.
+ *
+ * Collection order is derived from spec structure instead, so requiredness
+ * changes are invisible here. Adding a parameter mid-spec still shifts the
+ * ones after it — that is inherent without a record of the previously emitted
+ * signature — but it is now the only thing that can.
+ *
+ * Kept as a named function (rather than inlining the identity) because it is
+ * the single definition of signature order, shared with the smoke runner and
+ * test emitter, which must reconstruct call sites exactly.
+ */
 export function orderMethodParams(params: RenderedParam[]): RenderedParam[] {
-  return [...params].sort((a, b) => Number(a.optional) - Number(b.optional));
+  return [...params];
 }
 
 function renderMethod(resolved: ResolvedOperation, mountName: string, method: string, ctx: EmitterContext): string {

--- a/test/ios/resources.test.ts
+++ b/test/ios/resources.test.ts
@@ -212,3 +212,54 @@ describe('ios/resources', () => {
     expect(content).not.toContain('public func listAutoPaging(\n        after:');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Signature stability across requiredness changes (issue #240)
+// ---------------------------------------------------------------------------
+
+/**
+ * `beta` is declared before `alpha` but `alpha` is required, so the old
+ * optionality sort hoisted `alpha` ahead of it. Flipping `alpha` to optional
+ * then dropped it back behind `beta` — a reorder of Swift's order-sensitive
+ * labeled arguments, i.e. a source break, from a purely additive API change.
+ */
+function orderingSpec(alphaRequired: boolean): ApiSpec {
+  const service: Service = {
+    name: 'Widgets',
+    operations: [
+      {
+        name: 'list_widgets',
+        httpMethod: 'get',
+        path: '/widgets/{id}',
+        pathParams: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+        queryParams: [
+          { name: 'beta', type: { kind: 'primitive', type: 'string' }, required: false },
+          { name: 'alpha', type: { kind: 'primitive', type: 'string' }, required: alphaRequired },
+        ],
+        headerParams: [],
+        response: { kind: 'array', items: { kind: 'primitive', type: 'string' } },
+        errors: [],
+        injectIdempotencyKey: false,
+      },
+    ],
+  };
+  return { ...spec, services: [service] };
+}
+
+/** Parameter labels of the emitted `get` signature, in order. */
+function signatureLabels(apiSpec: ApiSpec): string[] {
+  const content = generateResources(apiSpec.services, { ...ctx, spec: apiSpec })[0].content;
+  const start = content.indexOf('public func get(');
+  const body = content.slice(start, content.indexOf(') async throws', start));
+  return [...body.matchAll(/^\s{8}(\w+):/gm)].map((m) => m[1]);
+}
+
+describe('iOS signature order', () => {
+  it('keeps spec order rather than hoisting required params', () => {
+    expect(signatureLabels(orderingSpec(true))).toEqual(['id', 'beta', 'alpha', 'requestOptions']);
+  });
+
+  it('does not move a parameter when it flips required -> optional', () => {
+    expect(signatureLabels(orderingSpec(false))).toEqual(signatureLabels(orderingSpec(true)));
+  });
+});


### PR DESCRIPTION
Closes #240.

## Problem

`orderMethodParams` sorted parameters by optionality, making a parameter's *position* a function of its requiredness. The backend flips required ↔ optional routinely, and every flip moved the parameter across the bucket boundary and renumbered everything after it. Swift's labeled arguments are order-sensitive, so that is a source break — a purely additive API change arriving as a major version bump.

From batch `fcf9458a`:

```json
{"category":"parameter_position_changed_order_sensitive","symbol":"SSO.getProfileAndToken","old":{"parameter":"code2","position":"1"},"new":{"parameter":"code2","position":"4"}}
{"category":"parameter_position_changed_order_sensitive","symbol":"SSO.getProfileAndToken","old":{"parameter":"requestOptions","position":"2"},"new":{"parameter":"requestOptions","position":"5"}}
```

## Fix

Emit collection order — path params in template order, then body fields, then query params — and never re-sort. That order comes from spec structure and cannot see requiredness at all.

Required-first was **only cosmetic**: Swift permits a defaulted parameter in any position. Verified against real emitter output, a required param after a defaulted one is valid Swift:

```swift
public func get(
    id: String,
    beta: String? = nil,
    alpha: String,
    requestOptions: RequestOptions? = nil
) async throws {
```

## What this does not fix

Adding a parameter mid-spec still shifts the ones after it. That is inherent without a record of the previously emitted signature — but it is now the *only* thing that can move a parameter, where before a requiredness flip did it too.

## Breaking

This reorders existing Swift signatures once. That is itself a source break, and should land with an intentional iOS major rather than riding a routine batch.

## Tests

Two regression tests in `test/ios/resources.test.ts`. The fixture declares `beta` (optional) before `alpha` (required), which is exactly the shape the old sort reordered:

- signature stays in spec order rather than hoisting `alpha`
- flipping `alpha` to optional produces an identical parameter order

Both **fail on `main` and pass here** — verified by reverting the one-line change and re-running. Full suite: 862 tests, 103 files, all passing.

## Follow-up, deliberately not in this PR

`src/android/resources.ts:230` is the identical function with the identical latent bug. Fixing it reorders every Kotlin signature too — a second one-time break that should be opted into separately. Happy to do it in a follow-up if you want them landed together.