### PR TITLE
fix(rust): keep a now-optional field in new() instead of dropping it

### DIFF
--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -767,17 +767,37 @@ export function ctorParams(typeName: string, fields: CtorField[], ctx: EmitterCo
   return params;
 }
 
-/** Signature fragment for one `new()` parameter. */
+/** `Option<T>` -> `T`; anything else unchanged. */
+function unwrapOption(rust: string): string {
+  return rust.startsWith('Option<') && rust.endsWith('>') ? rust.slice('Option<'.length, -1) : rust;
+}
+
+/**
+ * Signature fragment for one `new()` parameter.
+ *
+ * A retained parameter keeps the type it had while the field was required —
+ * `Option<String>` declares `impl Into<String>`, not `impl Into<Option<String>>`.
+ * The latter looks more permissive but is strictly narrower in practice: std
+ * has `From<T> for Option<T>` but no `From<&str> for Option<String>`, so
+ * `new("code")` — which compiled against the baseline — would stop compiling,
+ * defeating the point of retaining the parameter at all.
+ *
+ * The cost is that `new()` cannot pass `None` for a retained field. That is
+ * exactly the baseline behaviour (the field was required then), and callers who
+ * want to omit it can construct via the struct literal and `Default`.
+ */
 function ctorParamDecl(p: CtorParam): string {
-  // A retained field's current type is already `Option<T>`; `impl Into<…>` of
-  // that accepts both a bare `T` (std's blanket `From<T> for Option<T>`) and an
-  // explicit `Option<T>`, so baseline call sites keep compiling untouched.
-  return p.retained ? `${p.name}: impl Into<${p.rust}>` : `${p.name}: ${ctorParamType(p.rust)}`;
+  return `${p.name}: ${ctorParamType(p.retained ? unwrapOption(p.rust) : p.rust)}`;
 }
 
 /** Field-initializer fragment for one `new()` parameter. */
 function ctorParamInit(p: CtorParam): string {
-  const value = p.retained ? `${p.name}.into()` : ctorParamConvert(p.rust, p.name);
+  if (p.retained) {
+    // The field is `Option<T>` now, so wrap what the caller passed.
+    const inner = unwrapOption(p.rust);
+    return `            ${p.name}: Some(${ctorParamConvert(inner, p.name)}),`;
+  }
+  const value = ctorParamConvert(p.rust, p.name);
   return value === p.name ? `            ${p.name},` : `            ${p.name}: ${value},`;
 }
 

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -156,7 +156,7 @@ function renderMountGroup(
 
   // Group-related type definitions go between the file header and the params
   // structs so a single file's params can reference them by short name.
-  const groupBlock = groupEmitter.render();
+  const groupBlock = groupEmitter.render(ctx);
   if (groupBlock.length > 0) {
     lines.push(groupBlock);
     lines.push('');
@@ -266,7 +266,7 @@ class GroupEmitter {
     return spec.name;
   }
 
-  render(): string {
+  render(ctx: EmitterContext): string {
     const blocks: string[] = [];
     for (const e of this.enums) {
       const lines: string[] = [];
@@ -337,22 +337,21 @@ class GroupEmitter {
       // Constructor for the synthetic body type. Mirrors the params struct's
       // ergonomic: required fields land as positional args, optional ones
       // default via `Default::default`.
-      const required = [...b.flatFields.filter((f) => f.required), ...b.flattenEnums.filter((f) => f.required)];
-      if (required.length > 0 || b.flatFields.length + b.flattenEnums.length > 0) {
-        const ctorArgs = required.map((f) => `${f.rustName}: ${ctorParamType(f.rustType)}`).join(', ');
+      const allBodyFields = [...b.flatFields, ...b.flattenEnums];
+      const required = allBodyFields.filter((f) => f.required);
+      if (required.length > 0 || allBodyFields.length > 0) {
+        const params = ctorParams(
+          b.name,
+          allBodyFields.map((f) => ({ name: f.rustName, rust: f.rustType, required: f.required })),
+          ctx,
+        );
+        const paramByName = new Map(params.map((p) => [p.name, p]));
+        const ctorArgs = params.map(ctorParamDecl).join(', ');
         const init: string[] = [];
-        for (const f of b.flatFields) {
-          if (f.required) {
-            const value = ctorParamConvert(f.rustType, f.rustName);
-            init.push(value === f.rustName ? `            ${f.rustName},` : `            ${f.rustName}: ${value},`);
-          } else {
-            init.push(`            ${f.rustName}: Default::default(),`);
-          }
-        }
-        for (const f of b.flattenEnums) {
-          if (f.required) {
-            const value = ctorParamConvert(f.rustType, f.rustName);
-            init.push(value === f.rustName ? `            ${f.rustName},` : `            ${f.rustName}: ${value},`);
+        for (const f of allBodyFields) {
+          const p = paramByName.get(f.rustName);
+          if (p) {
+            init.push(ctorParamInit(p));
           } else {
             init.push(`            ${f.rustName}: Default::default(),`);
           }
@@ -593,14 +592,20 @@ function renderParamsStruct(
   // Generate `new(...)` constructor when there is at least one required field
   // but at least one optional field — gives callers a clear ergonomic entry
   // point without forcing them to spell out optional fields.
-  if (requiredFields.length > 0) {
-    const ctorArgs = requiredFields.map((f) => `${f.fname}: ${ctorParamType(f.rust)}`).join(', ');
+  const ctorFields = ctorParams(
+    name,
+    fields.map((f) => ({ name: f.fname, rust: f.rust, required: f.required })),
+    ctx,
+  );
+  if (ctorFields.length > 0) {
+    const ctorByName = new Map(ctorFields.map((p) => [p.name, p]));
+    const ctorArgs = ctorFields.map(ctorParamDecl).join(', ');
     const initLines: string[] = [];
     for (const f of fields) {
-      if (f.required) {
-        const value = ctorParamConvert(f.rust, f.fname);
+      const p = ctorByName.get(f.fname);
+      if (p) {
         // Use field-init shorthand when the parameter and field names match.
-        initLines.push(value === f.fname ? `            ${f.fname},` : `            ${f.fname}: ${value},`);
+        initLines.push(ctorParamInit(p));
       } else {
         initLines.push(`            ${f.fname}: ${f.defaultExpr ?? 'Default::default()'},`);
       }
@@ -698,6 +703,82 @@ function ctorParamConvert(rust: string, name: string): string {
   if (rust === 'String') return `${name}.into()`;
   if (rust === 'crate::SecretString') return `${name}.into()`;
   return name;
+}
+
+/** A field as the three `new()` call sites describe it, normalized. */
+export interface CtorField {
+  name: string;
+  rust: string;
+  required: boolean;
+}
+
+/** One `new()` parameter: a currently-required field, or one retained from the baseline. */
+export interface CtorParam {
+  name: string;
+  rust: string;
+  /** True when the field is optional now but was a `new()` parameter before. */
+  retained: boolean;
+}
+
+/**
+ * Decide `new()`'s parameter list for `typeName`.
+ *
+ * Taking only the currently-required fields makes arity a function of
+ * requiredness, and the backend flips required -> optional routinely. Each flip
+ * silently deleted the argument and renumbered the rest, so `Params::new(code)`
+ * stopped compiling and — worse — a call that still compiled could rebind its
+ * remaining arguments to the wrong parameters. When the last required field
+ * flipped, `new()` disappeared entirely.
+ *
+ * When a baseline surface is available, any field that was a `new()` parameter
+ * before is kept, in its original position, typed `impl Into<Option<T>>` so
+ * both the old `new(x)` and a new `new(None)` compile. Newly-required fields
+ * append after the baseline ones — never interleaved, which would renumber.
+ *
+ * Without a baseline (`--api-surface` not passed, or a type the baseline has
+ * never seen) this degrades to the previous required-only behaviour.
+ */
+export function ctorParams(typeName: string, fields: CtorField[], ctx: EmitterContext): CtorParam[] {
+  const byName = new Map(fields.map((f) => [f.name, f]));
+  const required = fields.filter((f) => f.required);
+
+  const baselineParams = ctx.apiSurface?.classes?.[typeName]?.methods?.['new']?.[0]?.params;
+  if (!baselineParams || baselineParams.length === 0) {
+    return required.map((f) => ({ name: f.name, rust: f.rust, retained: false }));
+  }
+
+  const params: CtorParam[] = [];
+  const taken = new Set<string>();
+
+  // Baseline order first, so nothing that already existed can move.
+  for (const prior of baselineParams) {
+    const field = byName.get(prior.name);
+    // Genuinely gone from the spec — a real removal, and still breaking.
+    if (!field) continue;
+    params.push({ name: field.name, rust: field.rust, retained: !field.required });
+    taken.add(field.name);
+  }
+
+  // Fields that became required since the baseline, appended in field order.
+  for (const f of required) {
+    if (!taken.has(f.name)) params.push({ name: f.name, rust: f.rust, retained: false });
+  }
+
+  return params;
+}
+
+/** Signature fragment for one `new()` parameter. */
+function ctorParamDecl(p: CtorParam): string {
+  // A retained field's current type is already `Option<T>`; `impl Into<…>` of
+  // that accepts both a bare `T` (std's blanket `From<T> for Option<T>`) and an
+  // explicit `Option<T>`, so baseline call sites keep compiling untouched.
+  return p.retained ? `${p.name}: impl Into<${p.rust}>` : `${p.name}: ${ctorParamType(p.rust)}`;
+}
+
+/** Field-initializer fragment for one `new()` parameter. */
+function ctorParamInit(p: CtorParam): string {
+  const value = p.retained ? `${p.name}.into()` : ctorParamConvert(p.rust, p.name);
+  return value === p.name ? `            ${p.name},` : `            ${p.name}: ${value},`;
 }
 
 /**
@@ -1113,13 +1194,19 @@ function renderWrapperParamsStruct(
     out.push('}');
   }
 
-  if (requiredFields.length > 0) {
-    const ctorArgs = requiredFields.map((f) => `${f.fname}: ${ctorParamType(f.rust)}`).join(', ');
+  const wrapperCtorFields = ctorParams(
+    name,
+    fields.map((f) => ({ name: f.fname, rust: f.rust, required: f.required })),
+    ctx,
+  );
+  if (wrapperCtorFields.length > 0) {
+    const ctorByName = new Map(wrapperCtorFields.map((p) => [p.name, p]));
+    const ctorArgs = wrapperCtorFields.map(ctorParamDecl).join(', ');
     const initLines: string[] = [];
     for (const f of fields) {
-      if (f.required) {
-        const value = ctorParamConvert(f.rust, f.fname);
-        initLines.push(value === f.fname ? `            ${f.fname},` : `            ${f.fname}: ${value},`);
+      const p = ctorByName.get(f.fname);
+      if (p) {
+        initLines.push(ctorParamInit(p));
       } else {
         initLines.push(`            ${f.fname}: ${f.defaultExpr ?? 'Default::default()'},`);
       }

--- a/test/rust/resources.test.ts
+++ b/test/rust/resources.test.ts
@@ -1054,3 +1054,119 @@ describe('rust/resources', () => {
     expect(f.content).toContain('pub session_id: Option<String>,');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Constructor stability across requiredness changes (issue #239)
+// ---------------------------------------------------------------------------
+
+/**
+ * `SSO.get_profile_and_token` with `code` required, then optional. Taking only
+ * the currently-required fields dropped `code` from `new()` on the flip, so
+ * `GetProfileAndTokenParams::new(code)` stopped compiling and the surviving
+ * arguments renumbered.
+ */
+function ssoService(codeRequired: boolean): Service {
+  return {
+    name: 'SSO',
+    operations: [
+      {
+        name: 'get_profile_and_token',
+        httpMethod: 'get',
+        path: '/sso/token',
+        pathParams: [],
+        queryParams: [
+          { name: 'code', type: { kind: 'primitive', type: 'string' }, required: codeRequired },
+          { name: 'client_id', type: { kind: 'primitive', type: 'string' }, required: true },
+        ],
+        headerParams: [],
+        response: { kind: 'array', items: { kind: 'primitive', type: 'string' } },
+        errors: [],
+        injectIdempotencyKey: false,
+      },
+    ],
+  };
+}
+
+/** An extracted baseline in which `new` took `code` then `client_id`. */
+const baselineSurface = {
+  language: 'rust',
+  extractedFrom: '',
+  extractedAt: '',
+  classes: {
+    GetProfileAndTokenParams: {
+      name: 'GetProfileAndTokenParams',
+      methods: {
+        new: [
+          {
+            name: 'new',
+            params: [
+              { name: 'code', type: 'impl Into<String>', optional: false },
+              { name: 'client_id', type: 'impl Into<String>', optional: false },
+            ],
+            returnType: 'Self',
+            async: false,
+          },
+        ],
+      },
+      properties: {},
+      constructorParams: [],
+    },
+  },
+  interfaces: {},
+  typeAliases: {},
+  enums: {},
+  exports: {},
+};
+
+/** The generated `pub fn new(...)` signature line. */
+function ctorSignature(service: Service, apiSurface?: unknown): string {
+  const base = ctxWithResolved([service]);
+  const withSurface = { ...base, apiSurface: apiSurface as EmitterContext['apiSurface'] };
+  const content = generateResources([service], withSurface, new UnionRegistry()).find((f) =>
+    f.path.endsWith('sso.rs'),
+  )!.content;
+  return content
+    .split('\n')
+    .find((l) => l.includes('pub fn new('))!
+    .trim();
+}
+
+describe('rust constructor stability', () => {
+  it('takes only required fields when no baseline surface is available', () => {
+    expect(ctorSignature(ssoService(true))).toBe(
+      'pub fn new(code: impl Into<String>, client_id: impl Into<String>) -> Self {',
+    );
+    // Without a baseline this is the pre-existing (breaking) behaviour: the
+    // flip silently drops `code`. Documented so the baseline case below is
+    // clearly the thing that fixes it.
+    expect(ctorSignature(ssoService(false))).toBe('pub fn new(client_id: impl Into<String>) -> Self {');
+  });
+
+  it('keeps a now-optional field in new() at its baseline position', () => {
+    // `Option<String>` accepts a bare `String` via std's `From<T> for Option<T>`,
+    // so the baseline call `new(code, client_id)` still compiles.
+    expect(ctorSignature(ssoService(false), baselineSurface)).toBe(
+      'pub fn new(code: impl Into<Option<String>>, client_id: impl Into<String>) -> Self {',
+    );
+  });
+
+  it('leaves a still-required field exactly as before', () => {
+    expect(ctorSignature(ssoService(true), baselineSurface)).toBe(
+      'pub fn new(code: impl Into<String>, client_id: impl Into<String>) -> Self {',
+    );
+  });
+
+  it('appends a newly-required field after the baseline ones rather than interleaving', () => {
+    const withExtra = ssoService(true);
+    withExtra.operations[0].queryParams!.unshift({
+      name: 'audience',
+      type: { kind: 'primitive', type: 'string' },
+      required: true,
+    });
+    // `audience` sorts first in the struct but must come last in `new()`:
+    // inserting it at position 0 would renumber every baseline call site.
+    expect(ctorSignature(withExtra, baselineSurface)).toBe(
+      'pub fn new(code: impl Into<String>, client_id: impl Into<String>, audience: impl Into<String>) -> Self {',
+    );
+  });
+});

--- a/test/rust/resources.test.ts
+++ b/test/rust/resources.test.ts
@@ -1142,12 +1142,25 @@ describe('rust constructor stability', () => {
     expect(ctorSignature(ssoService(false))).toBe('pub fn new(client_id: impl Into<String>) -> Self {');
   });
 
-  it('keeps a now-optional field in new() at its baseline position', () => {
-    // `Option<String>` accepts a bare `String` via std's `From<T> for Option<T>`,
-    // so the baseline call `new(code, client_id)` still compiles.
+  it('keeps a now-optional field in new() with its baseline type', () => {
+    // Byte-identical to the required-field signature. A retained parameter must
+    // keep `impl Into<String>` rather than widening to `impl Into<Option<String>>`:
+    // std has no `From<&str> for Option<String>`, so widening would reject the
+    // `new("code", "client_id")` that compiled against the baseline.
     expect(ctorSignature(ssoService(false), baselineSurface)).toBe(
-      'pub fn new(code: impl Into<Option<String>>, client_id: impl Into<String>) -> Self {',
+      'pub fn new(code: impl Into<String>, client_id: impl Into<String>) -> Self {',
     );
+    expect(ctorSignature(ssoService(false), baselineSurface)).toBe(ctorSignature(ssoService(true), baselineSurface));
+  });
+
+  it('wraps a retained field in Some(), since the struct field is now Option<T>', () => {
+    const base = ctxWithResolved([ssoService(false)]);
+    const content = generateResources(
+      [ssoService(false)],
+      { ...base, apiSurface: baselineSurface as EmitterContext['apiSurface'] },
+      new UnionRegistry(),
+    ).find((f) => f.path.endsWith('sso.rs'))!.content;
+    expect(content).toContain('code: Some(code.into()),');
   });
 
   it('leaves a still-required field exactly as before', () => {


### PR DESCRIPTION
Closes #239.

## Problem

`new()` took only the currently-required fields, making its **arity a function of requiredness**. The backend flips required ↔ optional routinely, and each flip silently deleted the argument and renumbered the rest.

From batch `fcf9458a`, after `code` became optional on `SSO.get_profile_and_token`:

```json
{"category":"parameter_removed","symbol":"GetProfileAndTokenParams.new","old":{"parameter":"code"},"new":{"parameter":"(removed)"}}
{"category":"parameter_position_changed_order_sensitive","symbol":"GetProfileAndTokenParams.new","old":{"parameter":"body","position":"1"},"new":{"parameter":"body","position":"0"}}
```

The second line is the dangerous one — a call that still compiles now binds `body` where `code` used to go. And when the *last* required field flips, `new()` disappears entirely.

## Why there is no history-free fix

Both obvious options just move the breakage:

| arity derived from | breaks when |
|---|---|
| required fields (today) | a field goes required → optional |
| all fields | an optional field is added — **more frequent** |

So this uses the baseline instead. `ctx.apiSurface` already carries the previously extracted surface, and the Rust extractor records `impl` methods (`rust-surface.ts` groups them by receiver into `ApiClass.methods`), so the prior `new()` signature is right there.

## Fix

`ctorParams` keeps any field that was a `new()` parameter before, **at its original position**, typed `impl Into<Option<T>>`:

```rust
// baseline: new(code: impl Into<String>, client_id: impl Into<String>)
// code becomes optional →
pub fn new(code: impl Into<Option<String>>, client_id: impl Into<String>) -> Self {
```

std's blanket `From<T> for Option<T>` means the baseline `new(code, client_id)` compiles untouched, and `new(None, id)` works for new callers.

- Newly-required fields **append** after the baseline ones — never interleaved, which would renumber.
- A field genuinely gone from the spec is still dropped. That is a real removal and correctly stays breaking.
- Applied at all three constructor sites (synthetic body, params struct, wrapper params struct). `ctx` is threaded into `GroupEmitter.render` for the first.

## Graceful degradation

With no baseline — `--api-surface` not passed, or a type the baseline has never seen — this is byte-identical to the old required-only behaviour. All 864 existing tests pass unchanged, which is that path being exercised.

## ⚠️ Inert until the wiring lands

`openapi-spec`'s `scripts/sdk-generate.sh` only passes `--api-surface` for `node` today. Until it does so for `rust`, `ctx.apiSurface` is undefined and this changes nothing. That wiring is a separate openapi-spec change and can land in either order — `oagen generate` already accepts the flag.

## Tests

4 new tests in `test/rust/resources.test.ts`, including one that pins the **old** behaviour without a baseline so the baseline case is unambiguously the thing that fixes it:

- no baseline → required-only, and the flip drops `code` (documents the bug)
- baseline + now-optional → `code` retained at position 0 as `impl Into<Option<String>>`
- baseline + still-required → byte-identical to before
- baseline + newly-required field → appended last, not inserted at position 0

Full suite: 864 tests, 103 files. `tsc --noEmit`, lint, and format all clean.