### PR TITLE
ci: route npm downloads through Socket Firewall with publish-aware teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,7 @@ jobs:
           allow-external-fork-fallback: true
 
       - run: npm install
+        env:
+          NPM_CONFIG_REPLACE_REGISTRY_HOST: npmjs
       - run: npm run typecheck
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # 6.1.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # 6.5.0
         with:
           node-version-file: .node-version
+
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+          allow-external-fork-fallback: true
 
       - run: npm install
       - run: npm run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,8 @@ jobs:
           allow-external-fork-fallback: true
 
       - run: npm install
+        env:
+          NPM_CONFIG_REPLACE_REGISTRY_HOST: npmjs
       - run: npm run lint
       - run: npm run format
       - run: npx prettier --check '**/*.md'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,22 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # 6.1.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # 6.5.0
         with:
           node-version-file: .node-version
+
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+          allow-external-fork-fallback: true
 
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,3 +36,5 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/release.yml
+    secrets:
+      PUBLIC_SOCKET_FIREWALL_TOKEN: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      PUBLIC_SOCKET_FIREWALL_TOKEN:
+        required: true
 
 jobs:
   publish:
@@ -19,6 +22,11 @@ jobs:
           node-version-file: .node-version
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+
       - name: Install Dependencies
         run: npm install
 
@@ -27,6 +35,9 @@ jobs:
 
       - name: Run Tests
         run: npm run test
+
+      - name: Restore public package registry
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
 
       - name: Publish
         run: npm publish --tag latest --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Restore public package registry
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+
       - name: Build Project
         run: npm run build
 
       - name: Run Tests
         run: npm run test
-
-      - name: Restore public package registry
-        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
 
       - name: Publish
         run: npm publish --tag latest --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install Dependencies
         run: npm install
+        env:
+          NPM_CONFIG_REPLACE_REGISTRY_HOST: npmjs
 
       - name: Restore public package registry
         uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1


### PR DESCRIPTION
This routes npm-registry dependency downloads in CI, lint and release installs through Socket Firewall. Trusted jobs require `PUBLIC_SOCKET_FIREWALL_TOKEN` and fail closed; the limited public external-fork fallback remains confined to read-only contribution jobs. Release installs are protected, then the firewall is torn down before the existing build, test and publish steps, preserving npm authentication and provenance.

The install steps use `NPM_CONFIG_REPLACE_REGISTRY_HOST=npmjs` so npm-registry tarballs still route through Socket without rewriting GitHub archive URLs to nonexistent proxy paths. **The existing `tree-sitter-kotlin` GitHub archive, reached through `@workos/oagen`, downloads directly and is not inspected by Socket.** This is the sole non-npm-registry source in the unchanged lockfile, with its original commit and integrity pin retained. No dependencies, versions, source URLs, lockfiles or global action configuration changed.

Current-head hosted CI installed 182 packages and passed all 878 tests, typechecking and lint checks. The previous archive 404 no longer occurs. Release ordering was reviewed without running a publisher.

To verify, inspect the completed install and test logs below. The install environment shows both the Socket registry and `NPM_CONFIG_REPLACE_REGISTRY_HOST=npmjs`:

```bash
gh run view 34499215774 --repo workos/oagen-emitters --log
```
