### PR TITLE
fix: walk body-owned query declarations when placing and reaching types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.24.11",
       "license": "MIT",
       "dependencies": {
-        "@workos/oagen": "^0.29.3"
+        "@workos/oagen": "^0.30.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.2.2",
@@ -2388,9 +2388,9 @@
       }
     },
     "node_modules/@workos/oagen": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.29.3.tgz",
-      "integrity": "sha512-HH3ASAG+lgwcTP3O1gVlW9XKp5RLUmXg9b5qFLxCHJBYYv+fIQ1mMgtTD9JnfZOFrYqLo7ZNG+pMPPjIkz5vkA==",
+      "version": "0.30.2",
+      "resolved": "https://socket-firewall.workos.dev/@workos/oagen/-/oagen-0.30.2.tgz",
+      "integrity": "sha512-peFACjpXJ+lxlvGLiUM8yHgk29LFLL1kzOalAcxOSU/RZS3zcF9/htCBRGzW+pdETDyn59uxs0UtXEezH6EsWg==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^2.40.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2389,7 +2389,7 @@
     },
     "node_modules/@workos/oagen": {
       "version": "0.30.2",
-      "resolved": "https://socket-firewall.workos.dev/@workos/oagen/-/oagen-0.30.2.tgz",
+      "resolved": "https://registry.npmjs.org/@workos/oagen/-/oagen-0.30.2.tgz",
       "integrity": "sha512-peFACjpXJ+lxlvGLiUM8yHgk29LFLL1kzOalAcxOSU/RZS3zcF9/htCBRGzW+pdETDyn59uxs0UtXEezH6EsWg==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "node": ">=24.10.0"
   },
   "dependencies": {
-    "@workos/oagen": "^0.29.3"
+    "@workos/oagen": "^0.30.2"
   }
 }

--- a/src/dotnet/enums.ts
+++ b/src/dotnet/enums.ts
@@ -3,7 +3,7 @@ import { walkTypeRef } from '@workos/oagen';
 import { className, deprecationMessage, escapeCsAttributeString, humanize } from './naming.js';
 import { setEnumAliases, setSingleValueEnumNames } from './type-map.js';
 import { enrichModelsFromSpec } from '../shared/model-utils.js';
-import { isEnumInScope } from '../shared/resolved-ops.js';
+import { isEnumInScope, declaredParams } from '../shared/resolved-ops.js';
 
 /**
  * Generate C# enum definitions from IR Enum definitions.
@@ -317,7 +317,7 @@ function collectReferencedEnumNames(ctx: EmitterContext): Set<string> {
     for (const op of service.operations) {
       if (op.requestBody) collect(op.requestBody);
       if (op.response) collect(op.response);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type);
       }
     }
@@ -343,7 +343,7 @@ export function assignEnumsToServices(enums: Enum[], services: Service[]): Map<s
       };
       if (op.requestBody) collect(op.requestBody);
       collect(op.response);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type);
       }
       for (const name of refs) {

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -27,7 +27,7 @@ import {
   collectNonPaginatedResponseModelNames,
   collectReferencedListMetadataModels,
 } from '../shared/model-utils.js';
-import { isModelInScope } from '../shared/resolved-ops.js';
+import { isModelInScope, declaredParams } from '../shared/resolved-ops.js';
 export { isListWrapperModel, isListMetadataModel };
 
 /**
@@ -544,7 +544,7 @@ function collectRequestBodyOnlyModelNames(services: Service[], models: Model[]):
       }
       collect(op.response, otherReferences);
       if (op.pagination) collect(op.pagination.itemType, otherReferences);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type, otherReferences);
       }
       if (op.successResponses) {

--- a/src/go/enums.ts
+++ b/src/go/enums.ts
@@ -2,7 +2,7 @@ import type { Enum, EmitterContext, GeneratedFile, Service } from '@workos/oagen
 import { walkTypeRef } from '@workos/oagen';
 import { className } from './naming.js';
 import { humanize } from './humanize.js';
-import { isEnumInScope, isScopedRun } from '../shared/resolved-ops.js';
+import { isEnumInScope, isScopedRun, declaredParams } from '../shared/resolved-ops.js';
 import { reconcileFlatBlocks, readPriorFile, type NamedBlock } from './flat-merge.js';
 
 /**
@@ -297,7 +297,7 @@ export function assignEnumsToServices(enums: Enum[], services: Service[]): Map<s
       };
       if (op.requestBody) collect(op.requestBody);
       collect(op.response);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type);
       }
       for (const name of refs) {

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -4,7 +4,7 @@ import { mapTypeRef } from './type-map.js';
 import { className, domainFieldName } from './naming.js';
 import { humanize } from './humanize.js';
 import { lowerFirstForDoc, fieldDocComment, articleFor } from '../shared/naming-utils.js';
-import { isModelInScope, isScopedRun } from '../shared/resolved-ops.js';
+import { isModelInScope, isScopedRun, declaredParams } from '../shared/resolved-ops.js';
 import { reconcileFlatBlocks, readPriorFile, parseFlatGoBlocks, type NamedBlock } from './flat-merge.js';
 
 // Import and re-export shared model detection utilities
@@ -50,7 +50,7 @@ function collectRequestBodyOnlyModelNames(services: Service[], models: Model[]):
       }
       collect(op.response, otherReferences);
       if (op.pagination) collect(op.pagination.itemType, otherReferences);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type, otherReferences);
       }
       if (op.successResponses) {

--- a/src/node/enums.ts
+++ b/src/node/enums.ts
@@ -5,7 +5,7 @@ import { docComment, assignModelsToEmittableServices } from './utils.js';
 import { isInlineEnum } from './type-map.js';
 import { isNodeOwnedService } from './options.js';
 import { liveSurfaceConstEnumMembers, liveSurfaceInterfacePath } from './live-surface.js';
-import { isEnumInScope } from '../shared/resolved-ops.js';
+import { isEnumInScope, declaredParams } from '../shared/resolved-ops.js';
 
 /**
  * PascalCase a wire value into a member name, unique within `taken`.
@@ -202,7 +202,7 @@ export function assignEnumsToServices(
       };
       if (op.requestBody) collect(op.requestBody);
       collect(op.response);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type);
       }
       for (const name of refs) {

--- a/src/node/models.ts
+++ b/src/node/models.ts
@@ -46,7 +46,13 @@ import {
 } from './field-plan.js';
 import { liveSurfaceHasExistingSdk, liveSurfaceHasManagedFile, liveSurfaceInterfacePath } from './live-surface.js';
 import { isNodeOwnedService, isHandOwnedType } from './options.js';
-import { groupByMount, buildResolvedLookup, lookupResolved, isModelInScope } from '../shared/resolved-ops.js';
+import {
+  groupByMount,
+  buildResolvedLookup,
+  lookupResolved,
+  isModelInScope,
+  declaredParams,
+} from '../shared/resolved-ops.js';
 import { resolveWrapperParams } from '../shared/wrapper-utils.js';
 import { collectWrapperResponseModels } from './wrappers.js';
 import { resolveResourceClassName } from './resources.js';
@@ -1166,7 +1172,7 @@ function buildGeneratedResourceModelUsage(
         requestRoots.add(name);
       }
 
-      for (const param of [...op.pathParams, ...op.queryParams, ...op.headerParams]) {
+      for (const param of declaredParams(op)) {
         collectTypeRefModels(param.type, interfaceRoots);
       }
 

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -16,7 +16,7 @@ import {
   resolveMethodName,
   buildServiceNameMap,
 } from './naming.js';
-import { getMountTarget, groupByMount } from '../shared/resolved-ops.js';
+import { getMountTarget, groupByMount, declaredParams } from '../shared/resolved-ops.js';
 import { assignModelsToServices, collectModelRefs, collectFieldDependencies } from '@workos/oagen';
 import { isNodeOwnedService } from './options.js';
 import { liveSurfaceHasExistingSdk, liveSurfaceHasFile } from './live-surface.js';
@@ -352,7 +352,7 @@ function collectServiceModelClosure(service: Service, modelsByName: Map<string, 
   for (const op of service.operations) {
     add(op.requestBody);
     add(op.response);
-    for (const param of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+    for (const param of declaredParams(op)) {
       add(param.type);
     }
     if (op.pagination) add(op.pagination.itemType);

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -11,6 +11,7 @@ import {
   priorManifestBasenames,
   isMountInScope,
   getMountTarget,
+  declaredParams,
 } from '../shared/resolved-ops.js';
 
 /**
@@ -761,7 +762,7 @@ function collectReachableEnumNames(ctx: EmitterContext): Set<string> {
 
   for (const service of ctx.spec.services) {
     for (const op of service.operations) {
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collectFromTypeRef(p.type);
       }
       if (op.requestBody) collectFromTypeRef(op.requestBody);

--- a/src/python/shared-schemas.ts
+++ b/src/python/shared-schemas.ts
@@ -2,6 +2,7 @@ import type { ApiSpec, EmitterContext, Enum, Model, Service } from '@workos/oage
 import { assignModelsToServices, collectFieldDependencies, planOperation, walkTypeRef } from '@workos/oagen';
 import { fileName } from './naming.js';
 import { buildListScaffoldingSkip, detectDiscriminators } from '../shared/model-utils.js';
+import { declaredParams } from '../shared/resolved-ops.js';
 
 /**
  * Walk every operation across all services and tally, per schema, the set of
@@ -39,7 +40,7 @@ export function findSharedSchemas(spec: ApiSpec): { models: Set<string>; enums: 
     for (const op of service.operations) {
       if (op.requestBody) collect(op.requestBody);
       collect(op.response);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type);
       }
       if (op.pagination) collect(op.pagination.itemType);
@@ -476,7 +477,7 @@ function assignEnumsToServicesNatural(enums: Enum[], services: Service[]): Map<s
     for (const op of service.operations) {
       if (op.requestBody) collect(op.requestBody);
       collect(op.response);
-      for (const p of [...op.pathParams, ...op.queryParams, ...op.headerParams, ...(op.cookieParams ?? [])]) {
+      for (const p of declaredParams(op)) {
         collect(p.type);
       }
     }

--- a/src/shared/resolved-ops.ts
+++ b/src/shared/resolved-ops.ts
@@ -1,5 +1,6 @@
 import type {
   Operation,
+  Parameter,
   EmitterContext,
   Service,
   ResolvedOperation,
@@ -329,4 +330,22 @@ export function collectBodyFieldTypes(op: Operation, models: Model[]): Map<strin
   }
 
   return fieldTypes;
+}
+
+/**
+ * Every parameter an operation declares, in every location, including the
+ * query declarations oagen keeps off the wire because the request body owns
+ * them (`bodyOwnedQueryParams`). Use this for reachability, placement, and
+ * import walks — anything deciding which types exist and where they live —
+ * so a type declared only by a body-owned parameter keeps its home.
+ * Serialization code keeps reading the location-specific arrays.
+ */
+export function declaredParams(op: Operation): Parameter[] {
+  return [
+    ...op.pathParams,
+    ...op.queryParams,
+    ...(op.bodyOwnedQueryParams ?? []),
+    ...op.headerParams,
+    ...(op.cookieParams ?? []),
+  ];
 }

--- a/test/shared/resolved-ops.test.ts
+++ b/test/shared/resolved-ops.test.ts
@@ -4,6 +4,7 @@ import {
   assertUniqueResolvedMethods,
   buildResolvedLookup,
   collectBodyFieldTypes,
+  declaredParams,
 } from '../../src/shared/resolved-ops.js';
 
 function makeResolvedOperation(
@@ -118,5 +119,56 @@ describe('shared/resolved-ops', () => {
       kind: 'array',
       items: { kind: 'primitive', type: 'string' },
     });
+  });
+});
+
+describe('declaredParams', () => {
+  const param = (name: string): Operation['pathParams'][number] => ({
+    name,
+    type: { kind: 'primitive', type: 'string' },
+    required: false,
+  });
+
+  it('includes body-owned query declarations alongside every wire location', () => {
+    const op = {
+      name: 'getProfileAndToken',
+      httpMethod: 'post',
+      path: '/sso/token',
+      pathParams: [param('id')],
+      queryParams: [param('trace')],
+      bodyOwnedQueryParams: [param('code'), param('grant_type')],
+      headerParams: [param('x-request-id')],
+      cookieParams: [param('session')],
+      response: { kind: 'primitive', type: 'string' },
+      errors: [],
+      injectIdempotencyKey: false,
+    } as unknown as Operation;
+
+    // Placement and reachability walks must see the declaration oagen kept
+    // off the wire, or a type declared only there loses its home package.
+    expect(declaredParams(op).map((p) => p.name)).toEqual([
+      'id',
+      'trace',
+      'code',
+      'grant_type',
+      'x-request-id',
+      'session',
+    ]);
+  });
+
+  it('tolerates operations without the optional arrays', () => {
+    const op = {
+      name: 'list',
+      httpMethod: 'get',
+      path: '/users',
+      pathParams: [],
+      queryParams: [param('limit')],
+      headerParams: [],
+      response: { kind: 'primitive', type: 'string' },
+      errors: [],
+      injectIdempotencyKey: false,
+    } as unknown as Operation;
+
+    expect(declaredParams(op).map((p) => p.name)).toEqual(['limit']);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to workos/oagen#168 (released in oagen 0.30.2).

- oagen now keeps a query parameter the request body also declares off the wire and records it on `Operation.bodyOwnedQueryParams`.
- Emitter walks that decide which types exist and where they live read only `pathParams`/`queryParams`/`headerParams`/`cookieParams`, so a type declared solely by such a parameter lost its service package. Concretely, `SSOGrantType` moved from the `sso` package to `common` in python and node.
- Adds `declaredParams(op)` to `src/shared/resolved-ops.ts` and uses it at all eleven placement/reachability sites (python x3, node x3, go x2, dotnet x3) instead of hand-spread arrays. Serialization code is untouched.
- Bumps `@workos/oagen` to `^0.30.2` for the new IR field.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format`, `npm test` (867 tests, plus 2 new for `declaredParams`) all green.
- Regenerated all 11 SDKs from the current WorkOS spec with oagen 0.30.2 + this build, diffed against a baseline generated with oagen 0.30.1 + emitters 0.24.11:
  - **dotnet, elixir, php, python, ruby:** byte-identical.
  - **go, ios, kotlin, rust, android:** only the SSO resource file (query copy of `code` removed; iOS/Android lose the bogus `code2` parameter; Rust loses the query-side `code` field).
  - **node:** only `getProfileAndToken`, its options interface, and its spec. No enum moves.

## Next

openapi-spec bumps oagen + emitters and regenerates. Kotlin picks up the VULN-1278 fix as a two-line diff in `SSO.kt`.
