### PR TITLE
fix(ios): leave out-of-scope model and enum files untouched in scoped runs

### DIFF
--- a/src/ios/enums.ts
+++ b/src/ios/enums.ts
@@ -1,6 +1,7 @@
 import type { Enum, EnumValue, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { toCamelCase } from '@workos/oagen';
 import { typeName, fileName, escapeReserved, swiftStringLiteral, moduleName } from './naming.js';
+import { isEnumInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate one forward-compatible Swift enum file per IR enum.
@@ -10,13 +11,17 @@ import { typeName, fileName, escapeReserved, swiftStringLiteral, moduleName } fr
  * so a server-added value never crashes decoding. Explicit `init(from:)` /
  * `encode(to:)` are emitted rather than relying on stdlib conditional
  * conformance.
+ *
+ * Scoped (`--services`) runs leave out-of-scope enum files untouched on disk.
  */
 export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile[] {
   const module = moduleName(ctx);
-  return enums.map((e) => ({
-    path: `Sources/${module}/Enums/${fileName(e.name)}.swift`,
-    content: renderEnum(e),
-  }));
+  return enums
+    .filter((e) => isEnumInScope(e.name, ctx))
+    .map((e) => ({
+      path: `Sources/${module}/Enums/${fileName(e.name)}.swift`,
+      content: renderEnum(e),
+    }));
 }
 
 function docComment(description: string | undefined, indent: string): string {

--- a/src/ios/models.ts
+++ b/src/ios/models.ts
@@ -2,6 +2,7 @@ import type { Model, Field, EmitterContext, GeneratedFile } from '@workos/oagen'
 import { toCamelCase } from '@workos/oagen';
 import { typeName, fileName, propertyName, escapeReserved, moduleName } from './naming.js';
 import { fieldSwiftType } from './type-map.js';
+import { isModelInScope } from '../shared/resolved-ops.js';
 
 /**
  * Generate one Swift `Codable` struct file per IR model.
@@ -9,13 +10,20 @@ import { fieldSwiftType } from './type-map.js';
  * Each struct gets: a doc comment, `public let` properties (camelCase), a
  * `public init` (required params first, optionals defaulted to `nil`), and a
  * `CodingKeys` enum mapping Swift properties to wire keys.
+ *
+ * Scoped (`--services`) runs leave out-of-scope model files untouched on disk.
+ * Resources and tests are already scoped, so refreshing every model here would
+ * hand a non-selected service's untouched test fixtures a model shape they
+ * were never regenerated against.
  */
 export function generateModels(models: Model[], ctx: EmitterContext): GeneratedFile[] {
   const module = moduleName(ctx);
-  return models.map((model) => ({
-    path: `Sources/${module}/Models/${fileName(model.name)}.swift`,
-    content: renderModel(model),
-  }));
+  return models
+    .filter((model) => isModelInScope(model.name, ctx))
+    .map((model) => ({
+      path: `Sources/${module}/Models/${fileName(model.name)}.swift`,
+      content: renderModel(model),
+    }));
 }
 
 /** Render a doc comment block from a description (each line prefixed `/// `). */

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -300,10 +300,16 @@ interface SyntheticCollector {
   }>;
   /** Track names already used to avoid duplicates. */
   usedNames: Set<string>;
+  /**
+   * Synthetic name → the model whose inline schema minted it. A synthetic type
+   * is never in the engine's IR-derived scope allow-lists, so scoped runs place
+   * it wherever its parent lives (see `isModelInScope` / `isEnumInScope`).
+   */
+  parents: Map<string, string>;
 }
 
 function createCollector(): SyntheticCollector {
-  return { models: [], enums: [], usedNames: new Set() };
+  return { models: [], enums: [], usedNames: new Set(), parents: new Map() };
 }
 
 /**
@@ -345,6 +351,7 @@ function rawSchemaToTypeRef(
     const syntheticName = `${parentModelName}_${fName}`;
     if (!collector.usedNames.has(syntheticName) && !collector.usedNames.has(toSnakeCase(syntheticName))) {
       collector.usedNames.add(syntheticName);
+      collector.parents.set(syntheticName, parentModelName);
       collector.enums.push({
         name: syntheticName,
         values: (schema.enum as string[]).map((v: string) => ({
@@ -383,6 +390,7 @@ function rawSchemaToTypeRef(
     const syntheticName = `${parentModelName}_${fName}`;
     if (!collector.usedNames.has(syntheticName) && !collector.usedNames.has(toSnakeCase(syntheticName))) {
       collector.usedNames.add(syntheticName);
+      collector.parents.set(syntheticName, parentModelName);
       const fields: Field[] = [];
       const requiredSet = new Set<string>(schema.required ?? []);
       for (const [propName, propSchema] of Object.entries(schema.properties) as [string, Record<string, any>][]) {
@@ -562,6 +570,7 @@ function upgradeArrayItemType(
 // Consumed by `getSyntheticEnums()` after `enrichModelsFromSpec` runs.
 // ---------------------------------------------------------------------------
 let _lastSyntheticEnums: Enum[] = [];
+let _lastSyntheticParents: ReadonlyMap<string, string> = new Map();
 
 /**
  * Return the synthetic enums generated during the last call to
@@ -570,6 +579,16 @@ let _lastSyntheticEnums: Enum[] = [];
  */
 export function getSyntheticEnums(): Enum[] {
   return _lastSyntheticEnums;
+}
+
+/**
+ * The model whose inline schema minted the synthetic model or enum `name`
+ * during the last `enrichModelsFromSpec` call, or `undefined` for a declared
+ * (non-synthetic) type. A synthetic nested inside another synthetic reports
+ * that synthetic as its parent; walk up to reach the declared root.
+ */
+export function getSyntheticParent(name: string): string | undefined {
+  return _lastSyntheticParents.get(name);
 }
 
 // ---------------------------------------------------------------------------
@@ -687,6 +706,7 @@ export function enrichModelsFromSpec(models: Model[], enums: Enum[] = []): Model
   const spec = loadRawSpec();
   if (!spec) {
     _lastSyntheticEnums = [];
+    _lastSyntheticParents = new Map();
     return models;
   }
 
@@ -788,6 +808,7 @@ export function enrichModelsFromSpec(models: Model[], enums: Enum[] = []): Model
       description: v.description,
     })),
   })) as Enum[];
+  _lastSyntheticParents = collector.parents;
 
   // Append synthetic models, skipping those whose snake_case name collides
   // with an existing model (prevents broken TypeAlias self-imports).

--- a/src/shared/resolved-ops.ts
+++ b/src/shared/resolved-ops.ts
@@ -9,6 +9,7 @@ import type {
   TypeRef,
 } from '@workos/oagen';
 import { toPascalCase } from '@workos/oagen';
+import { getSyntheticParent } from './model-utils.js';
 
 /**
  * Fail fast when two distinct paths in the same mount resolve to the same SDK
@@ -141,13 +142,36 @@ export function isMountInScope(mountName: string, ctx: EmitterContext): boolean 
  */
 export function isModelInScope(modelName: string, ctx: EmitterContext): boolean {
   const scope = ctx.scopedModelNames;
-  return !scope || scope.has(modelName);
+  return !scope || scope.has(modelName) || syntheticRootInScope(modelName, scope);
 }
 
-/** Like {@link isModelInScope} but for an ENUM's per-enum file (`ctx.scopedEnumNames`). */
+/**
+ * Like {@link isModelInScope} but for an ENUM's per-enum file (`ctx.scopedEnumNames`).
+ * A synthetic enum's parent is a MODEL, so its scope is decided by the model
+ * allow-list.
+ */
 export function isEnumInScope(enumName: string, ctx: EmitterContext): boolean {
   const scope = ctx.scopedEnumNames;
-  return !scope || scope.has(enumName);
+  if (!scope || scope.has(enumName)) return true;
+  return !!ctx.scopedModelNames && syntheticRootInScope(enumName, ctx.scopedModelNames);
+}
+
+/**
+ * A synthetic model or enum (minted by `enrichModelsFromSpec` from an inline
+ * schema) never appears in the engine's IR-derived allow-lists, yet the file
+ * that references it — its parent model — may be in scope and freshly
+ * rewritten. Follow the parent chain (synthetics nest) to the declared model
+ * and let that decide, so a scoped run emits every dependent the model needs.
+ */
+function syntheticRootInScope(name: string, modelScope: ReadonlySet<string>): boolean {
+  const seen = new Set<string>();
+  let parent = getSyntheticParent(name);
+  while (parent && !seen.has(parent)) {
+    if (modelScope.has(parent)) return true;
+    seen.add(parent);
+    parent = getSyntheticParent(parent);
+  }
+  return false;
 }
 
 /** True when a scoped (`--services`) run is active. */

--- a/test/ios/enums.test.ts
+++ b/test/ios/enums.test.ts
@@ -119,3 +119,28 @@ describe('ios/enums', () => {
     `);
   });
 });
+
+describe('ios/enums scoped runs', () => {
+  const enumDef = (name: string): Enum => ({
+    name,
+    values: [{ name: 'a', value: 'a' }],
+  });
+
+  it('writes only in-scope enum files under --services', () => {
+    const scopedCtx: EmitterContext = {
+      ...ctx,
+      scopedServices: new Set(['SSO']),
+      scopedEnumNames: new Set(['SSOGrantType']),
+    };
+    const files = generateEnums([enumDef('SSOGrantType'), enumDef('DataIntegrationOwnership')], scopedCtx);
+    expect(files.map((f) => f.path)).toEqual(['Sources/WorkOS/Enums/SSOGrantType.swift']);
+  });
+
+  it('writes every enum file in a full run', () => {
+    const files = generateEnums([enumDef('SSOGrantType'), enumDef('DataIntegrationOwnership')], ctx);
+    expect(files.map((f) => f.path)).toEqual([
+      'Sources/WorkOS/Enums/SSOGrantType.swift',
+      'Sources/WorkOS/Enums/DataIntegrationOwnership.swift',
+    ]);
+  });
+});

--- a/test/ios/models.test.ts
+++ b/test/ios/models.test.ts
@@ -107,3 +107,31 @@ describe('ios/models', () => {
     `);
   });
 });
+
+describe('ios/models scoped runs', () => {
+  const model = (name: string): Model => ({
+    name,
+    fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }],
+  });
+
+  it('writes only in-scope model files under --services', () => {
+    // Regression: an SSO-scoped batch rewrote every model (DataIntegration
+    // gained a required field) while Pipes' untouched test fixtures still
+    // lacked it, so decoding failed in the tests the run never regenerated.
+    const scopedCtx: EmitterContext = {
+      ...ctx,
+      scopedServices: new Set(['SSO']),
+      scopedModelNames: new Set(['Profile']),
+    };
+    const files = generateModels([model('Profile'), model('DataIntegration')], scopedCtx);
+    expect(files.map((f) => f.path)).toEqual(['Sources/WorkOS/Models/Profile.swift']);
+  });
+
+  it('writes every model file in a full run', () => {
+    const files = generateModels([model('Profile'), model('DataIntegration')], ctx);
+    expect(files.map((f) => f.path)).toEqual([
+      'Sources/WorkOS/Models/Profile.swift',
+      'Sources/WorkOS/Models/DataIntegration.swift',
+    ]);
+  });
+});

--- a/test/ios/scoped-emitter.test.ts
+++ b/test/ios/scoped-emitter.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ApiSpec, EmitterContext, Model } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { iosEmitter } from '../../src/ios/index.js';
+
+// Emitter-level coverage for scoped runs: goes through `iosEmitter` so model
+// enrichment runs and mints synthetic dependents from the raw spec. An
+// in-scope model's synthetic model/enum files must be emitted alongside it;
+// out-of-scope declared models must be left untouched.
+const SPEC = {
+  openapi: '3.0.0',
+  info: { title: 'fixture', version: '1.0.0' },
+  paths: {},
+  components: {
+    schemas: {
+      Parent: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              kind: { type: 'string', enum: ['a', 'b'] },
+              child: { type: 'object', properties: { id: { type: 'string' } } },
+            },
+          },
+        ],
+      },
+      Other: { type: 'object', properties: { id: { type: 'string' } } },
+    },
+  },
+};
+
+const models: Model[] = [
+  { name: 'Parent', fields: [] },
+  { name: 'Other', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+];
+
+const spec: ApiSpec = {
+  name: 'Test',
+  version: '1.0.0',
+  baseUrl: '',
+  services: [],
+  models,
+  enums: [{ name: 'DeclaredOther', values: [{ name: 'z', value: 'z' }] }],
+  sdk: defaultSdkBehavior(),
+};
+
+const scopedCtx: EmitterContext = {
+  namespace: 'workos',
+  namespacePascal: 'WorkOS',
+  spec,
+  scopedServices: new Set(['Parents']),
+  scopedModelNames: new Set(['Parent']),
+  scopedEnumNames: new Set(),
+};
+
+const fullCtx: EmitterContext = { namespace: 'workos', namespacePascal: 'WorkOS', spec };
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ios-scoped-emitter-'));
+  const specPath = join(dir, 'spec.yaml');
+  writeFileSync(specPath, JSON.stringify(SPEC));
+  process.env.OPENAPI_SPEC_PATH = specPath;
+});
+
+afterAll(() => {
+  delete process.env.OPENAPI_SPEC_PATH;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+const paths = (files: { path: string }[]) => files.map((f) => f.path).sort();
+
+describe('ios emitter under --services', () => {
+  it('emits the in-scope model with its synthetic dependents and skips the rest', () => {
+    const modelFiles = iosEmitter.generateModels(models, scopedCtx);
+    const enumFiles = iosEmitter.generateEnums(spec.enums, scopedCtx);
+
+    expect(paths(modelFiles)).toEqual([
+      'Sources/WorkOS/Models/Parent.swift',
+      'Sources/WorkOS/Models/ParentChild.swift',
+    ]);
+    expect(paths(enumFiles)).toEqual(['Sources/WorkOS/Enums/ParentKind.swift']);
+
+    // The rewritten parent references both dependents by their emitted names.
+    const parent = modelFiles.find((f) => f.path.endsWith('/Parent.swift'))!.content;
+    expect(parent).toContain('ParentKind');
+    expect(parent).toContain('ParentChild');
+  });
+
+  it('emits everything in a full run', () => {
+    expect(paths(iosEmitter.generateModels(models, fullCtx))).toEqual([
+      'Sources/WorkOS/Models/Other.swift',
+      'Sources/WorkOS/Models/Parent.swift',
+      'Sources/WorkOS/Models/ParentChild.swift',
+    ]);
+    expect(paths(iosEmitter.generateEnums(spec.enums, fullCtx))).toEqual([
+      'Sources/WorkOS/Enums/DeclaredOther.swift',
+      'Sources/WorkOS/Enums/ParentKind.swift',
+    ]);
+  });
+});

--- a/test/shared/synthetic-scope.test.ts
+++ b/test/shared/synthetic-scope.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ApiSpec, EmitterContext, Model } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { enrichModelsFromSpec, getSyntheticEnums, getSyntheticParent } from '../../src/shared/model-utils.js';
+import { isEnumInScope, isModelInScope } from '../../src/shared/resolved-ops.js';
+
+// A scoped (`--services`) run's allow-lists come from the engine's IR
+// reachability, which cannot know about the synthetic models/enums the
+// emitters mint from inline schemas during enrichment. Those synthetics must
+// follow their parent model's scope, or the rewritten parent file references
+// a type whose file the scoped run never wrote.
+const SPEC = {
+  openapi: '3.0.0',
+  info: { title: 'fixture', version: '1.0.0' },
+  paths: {},
+  components: {
+    schemas: {
+      Parent: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              kind: { type: 'string', enum: ['a', 'b'] },
+              child: {
+                type: 'object',
+                properties: {
+                  mode: { type: 'string', enum: ['x', 'y'] },
+                  id: { type: 'string' },
+                },
+              },
+            },
+          },
+        ],
+      },
+      Other: { type: 'object', properties: { id: { type: 'string' } } },
+    },
+  },
+};
+
+const models: Model[] = [
+  { name: 'Parent', fields: [] },
+  { name: 'Other', fields: [{ name: 'id', type: { kind: 'primitive', type: 'string' }, required: true }] },
+];
+
+const spec: ApiSpec = {
+  name: 'Test',
+  version: '1.0.0',
+  baseUrl: '',
+  services: [],
+  models,
+  enums: [],
+  sdk: defaultSdkBehavior(),
+};
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'synthetic-scope-'));
+  const specPath = join(dir, 'spec.yaml');
+  writeFileSync(specPath, JSON.stringify(SPEC));
+  process.env.OPENAPI_SPEC_PATH = specPath;
+  enrichModelsFromSpec(models, []);
+});
+
+afterAll(() => {
+  delete process.env.OPENAPI_SPEC_PATH;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('synthetic types follow their parent model into scope', () => {
+  it('records the minting parent, including for nested synthetics', () => {
+    expect(getSyntheticParent('Parent_kind')).toBe('Parent');
+    expect(getSyntheticParent('Parent_child')).toBe('Parent');
+    expect(getSyntheticParent('Parent_child_mode')).toBe('Parent_child');
+    expect(getSyntheticParent('Parent')).toBeUndefined();
+    expect(getSyntheticEnums().map((e) => e.name)).toEqual(['Parent_kind', 'Parent_child_mode']);
+  });
+
+  it('treats a synthetic as in scope exactly when its declared root model is', () => {
+    const scoped: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec,
+      scopedServices: new Set(['Parents']),
+      scopedModelNames: new Set(['Parent']),
+      scopedEnumNames: new Set(),
+    };
+    expect(isModelInScope('Parent', scoped)).toBe(true);
+    expect(isModelInScope('Parent_child', scoped)).toBe(true);
+    expect(isEnumInScope('Parent_kind', scoped)).toBe(true);
+    expect(isEnumInScope('Parent_child_mode', scoped)).toBe(true);
+    // Declared types outside the allow-list stay out.
+    expect(isModelInScope('Other', scoped)).toBe(false);
+    expect(isEnumInScope('SomeDeclaredEnum', scoped)).toBe(false);
+  });
+
+  it('keeps a synthetic out of scope when its parent is', () => {
+    const scoped: EmitterContext = {
+      namespace: 'workos',
+      namespacePascal: 'WorkOS',
+      spec,
+      scopedServices: new Set(['Others']),
+      scopedModelNames: new Set(['Other']),
+      scopedEnumNames: new Set(),
+    };
+    expect(isModelInScope('Parent_child', scoped)).toBe(false);
+    expect(isEnumInScope('Parent_kind', scoped)).toBe(false);
+    expect(isEnumInScope('Parent_child_mode', scoped)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `src/ios/models.ts` and `src/ios/enums.ts` now skip files outside the scoped-run allow-lists (`isModelInScope` / `isEnumInScope`), mirroring the Android emitter. Full runs are unchanged.
- **Shared follow-through (from review):** synthetic models/enums minted by `enrichModelsFromSpec` never appear in the engine's IR-derived allow-lists, so every gating emitter skipped them in scoped runs even when their parent model was in scope. The collector now records each synthetic's minting parent, and `isModelInScope` / `isEnumInScope` follow that chain to the declared root model. On the live spec this affects `ConnectApplication_redirect_uri`.
- Tests: focused scoped/full tests for the iOS generators, a shared test for the synthetic parent chain, and an iOS emitter-level scoped test that runs through enrichment.

## Why

workos/workos-ios#31 (an SSO-scoped batch) failed four `PipesTests` with `keyNotFound: ownership`. The iOS emitter ignored scope for models and enums, so the batch rewrote 21 unrelated files including `DataIntegration.swift` (new required `ownership` field), while iOS resources and tests *are* scoped, so `PipesTests.swift` kept its old fixtures. The sibling Kotlin, Go, and Rust PRs in the same batch touched exactly one file each and are green.

This is the exact mismatch the engine's scoped-run contract in `generate-files.ts` warns about: model files, resources, and fixtures must move together.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format`, `npm test` (878 tests, 9 new) all green.
- Regenerated against a fresh `workos-ios` main clone with oagen 0.30.2 and this build, `--services SSO`: only `Sources/WorkOS/Resources/SSO.swift` and `Tests/WorkOSTests/SSOTests.swift` change. No model or enum files, no manifest change.
- Full iOS run against the same clone: 22 files, the same set as #31 plus `Resources/Pipes.swift` and `Tests/WorkOSTests/PipesTests.swift`, which a scoped batch can never legitimately produce.
- `--services Connect` into an empty directory (iOS and Kotlin): emits `ConnectApplicationRedirectUri` beside `ConnectApplication`, and no out-of-scope models.

## Next

Close workos/workos-ios#31 and re-dispatch iOS for `SSO` after this releases and openapi-spec bumps the emitters.
