### PR TITLE
fix: harden Rust secret redaction and .NET auto-paging filters

### DIFF
--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -1019,8 +1019,10 @@ function generateAutoPagingMethod(
   const pathExpr = buildPathExpr(op);
   const optionsArg = optionsClass ? 'options' : 'null';
   if (hasGroups) {
-    // Group properties are JsonIgnore'd; preserve their flat query parameters
-    // in the request that the client carries forward across pages.
+    // Group properties are JsonIgnore'd; serialize them onto the request
+    // explicitly, with the same body-vs-query placement as the single-page
+    // method, so the client carries them forward across pages.
+    const groupTarget = plan.hasBody && op.requestBody && !plan.isDelete ? 'body' : 'query';
     lines.push(`            options ??= new ${optionsClass}();`);
     lines.push('');
     lines.push('            var request = new WorkOSRequest');
@@ -1031,7 +1033,7 @@ function generateAutoPagingMethod(
     lines.push('                RequestOptions = requestOptions,');
     lines.push('            };');
     lines.push('');
-    lines.push(...emitGroupSerialization(op, '            ', ctx.spec.models, 'query', groupNames));
+    lines.push(...emitGroupSerialization(op, '            ', ctx.spec.models, groupTarget, groupNames));
     lines.push('');
     lines.push(`            return this.Client.ListAutoPagingAsync<${itemType}>(request, cancellationToken);`);
   } else {

--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -516,7 +516,16 @@ function generateServiceFile(mountName: string, operations: Operation[], ctx: Em
       // Generate auto-pagination method for paginated list operations
       if (plan.isPaginated && op.pagination) {
         lines.push('');
-        const autoPagingCode = generateAutoPagingMethod(mountName, method, methodStem, op, plan, ctx, resolvedOp);
+        const autoPagingCode = generateAutoPagingMethod(
+          mountName,
+          method,
+          methodStem,
+          op,
+          plan,
+          ctx,
+          groupNames,
+          resolvedOp,
+        );
         lines.push(autoPagingCode);
       }
     }
@@ -957,6 +966,7 @@ function generateAutoPagingMethod(
   op: Operation,
   plan: OperationPlan,
   ctx: EmitterContext,
+  groupNames: Map<string, GroupClassNames>,
   resolvedOp?: ResolvedOperation,
 ): string {
   const lines: string[] = [];
@@ -1008,9 +1018,27 @@ function generateAutoPagingMethod(
 
   const pathExpr = buildPathExpr(op);
   const optionsArg = optionsClass ? 'options' : 'null';
-  lines.push(
-    `            return this.ListAutoPagingAsync<${itemType}>(${pathExpr}, ${optionsArg}, requestOptions, cancellationToken);`,
-  );
+  if (hasGroups) {
+    // Group properties are JsonIgnore'd; preserve their flat query parameters
+    // in the request that the client carries forward across pages.
+    lines.push(`            options ??= new ${optionsClass}();`);
+    lines.push('');
+    lines.push('            var request = new WorkOSRequest');
+    lines.push('            {');
+    lines.push(`                Method = HttpMethod.${httpMethodCs(op.httpMethod)},`);
+    lines.push(`                Path = ${pathExpr},`);
+    lines.push('                Options = options,');
+    lines.push('                RequestOptions = requestOptions,');
+    lines.push('            };');
+    lines.push('');
+    lines.push(...emitGroupSerialization(op, '            ', ctx.spec.models, 'query', groupNames));
+    lines.push('');
+    lines.push(`            return this.Client.ListAutoPagingAsync<${itemType}>(request, cancellationToken);`);
+  } else {
+    lines.push(
+      `            return this.ListAutoPagingAsync<${itemType}>(${pathExpr}, ${optionsArg}, requestOptions, cancellationToken);`,
+    );
+  }
   lines.push('        }');
 
   return lines.join('\n');

--- a/src/rust/models.ts
+++ b/src/rust/models.ts
@@ -148,7 +148,9 @@ function renderModel(model: Model, registry: UnionRegistry, tagField?: string): 
   lines.push('#[derive(Debug, Clone, Serialize, Deserialize)]');
 
   const resolvedNames = resolveFieldNames(model.fields);
-  const fieldLines = model.fields.map((f, i) => renderField(f, resolvedNames[i]!, model.name, registry, tagField));
+  const fieldLines = model.fields.map((f, i) =>
+    renderField(f, resolvedNames[i]!, model.name, registry, model.fields, tagField),
+  );
 
   // rustfmt collapses zero-field structs to `pub struct Foo {}` on a single
   // line. Match that shape so `cargo fmt --check` passes.
@@ -194,6 +196,7 @@ function renderField(
   rustField: string,
   modelName: string,
   registry: UnionRegistry,
+  siblings: Field[],
   tagField?: string,
 ): string {
   const lines: string[] = [];
@@ -216,9 +219,8 @@ function renderField(
   if (isOptional && !baseType.startsWith('Option<')) {
     baseType = makeOptional(baseType);
   }
-  // Wrap String / Option<String> in SecretString when the field name implies
-  // the value is a credential or token. Wire format is unchanged.
-  baseType = applySecretRedaction(baseType, field.name);
+  // Spec markers and semantic fallbacks redact secrets without changing the wire format.
+  baseType = applySecretRedaction(baseType, field.name, field, siblings);
 
   if (tagField === field.name) {
     // This field is the discriminator of an internally-tagged union it belongs

--- a/src/rust/resources.ts
+++ b/src/rust/resources.ts
@@ -461,7 +461,7 @@ function renderParamsStruct(
       registry,
     });
     if (!p.required && !rust.startsWith('Option<')) rust = makeOptional(rust);
-    rust = applySecretRedaction(rust, p.name);
+    rust = applySecretRedaction(rust, p.name, p);
     // Spec-level defaults on HTTP params are materialized so
     // `Default::default()` and `new(…)` produce the documented value. URL
     // builders keep optional query params omitted unless the caller supplies
@@ -670,7 +670,7 @@ function registerSyntheticBody(
         registry,
       });
       if (!f.required && !rust.startsWith('Option<')) rust = makeOptional(rust);
-      rust = applySecretRedaction(rust, f.name);
+      rust = applySecretRedaction(rust, f.name, f, model.fields);
       return {
         // Domain identifier honors a `fieldHints` override (e.g. wire
         // `connection_type` → domain `type`); `wireName` keeps `f.name`, and
@@ -1157,7 +1157,7 @@ function renderWrapperParamsStruct(
       rust = 'String';
     }
     if (rp.isOptional && !rust.startsWith('Option<')) rust = makeOptional(rust);
-    rust = applySecretRedaction(rust, rp.paramName);
+    rust = applySecretRedaction(rust, rp.paramName, rp.field ?? undefined);
     const desc = rp.field?.description?.trim();
     if (desc) {
       for (const c of paramDocComment(desc)) fieldLines.push(`    ${c}`);

--- a/src/rust/secret.ts
+++ b/src/rust/secret.ts
@@ -46,13 +46,28 @@ function hasPasswordFormat(type?: TypeRef): boolean {
   return type?.kind === 'primitive' && type.type === 'string' && type.format === 'password';
 }
 
+/**
+ * Leading-clause wording that says the field is a partial, masked, or locating
+ * form of a secret (identifier, hint, provider endpoint) rather than the
+ * secret itself.
+ */
+const PARTIAL_SECRET_SUBJECT = /error code|endpoint|obfuscat|mask|last (?:four|few|\d)|hint|suffix/i;
+
+function describesPartialSecret(description: string): boolean {
+  // Only the leading clause names what the field is. A later caveat such as
+  // "...; its suffix is displayed separately" must not disarm redaction of a
+  // documented full secret.
+  const subject = description.split(/[.;:,(]/, 1)[0] ?? '';
+  return PARTIAL_SECRET_SUBJECT.test(subject);
+}
+
 function holdsSecret(field: SecretField): boolean {
   if (hasPasswordFormat(field.type)) return true;
   if (isSensitiveFieldName(field.name)) return true;
   const description = field.description ?? '';
   // A mention of a secret is not enough: identifiers, hints, and provider
   // endpoints describe credentials without containing them.
-  if (/error code|endpoint|obfuscat|last (?:four|few|\d)|hint|suffix/i.test(description)) return false;
+  if (describesPartialSecret(description)) return false;
   if (/^(?:value|credential)$/.test(field.name)) {
     return /plaintext|\b(?:access token|API key|secret)\b/i.test(description);
   }

--- a/src/rust/secret.ts
+++ b/src/rust/secret.ts
@@ -1,13 +1,6 @@
-/**
- * Heuristics for spotting fields that hold secrets. The Rust emitter wraps
- * such fields in `crate::SecretString` so their `Debug` representation does
- * not accidentally leak the value.
- *
- * The list is intentionally conservative — only fields whose names strongly
- * imply a credential or token are redacted. Generic names like `value` are
- * skipped; the cost of a leaked secret is high enough that we'd rather miss
- * the occasional secret than redact non-secret data and surprise users.
- */
+import type { Field, TypeRef } from '@workos/oagen';
+
+/** Spec sensitivity markers take precedence over conservative fallback heuristics. */
 const EXACT_NAMES = new Set<string>([
   'password',
   'new_password',
@@ -46,13 +39,57 @@ export function isSensitiveFieldName(name: string): boolean {
   return false;
 }
 
-/**
- * If `rustType` is `String` or `Option<String>` and `fieldName` looks
- * sensitive, return the redacted equivalent (`crate::SecretString` or
- * `Option<crate::SecretString>`). Otherwise return `rustType` unchanged.
- */
-export function applySecretRedaction(rustType: string, fieldName: string): string {
-  if (!isSensitiveFieldName(fieldName)) return rustType;
+type SecretField = Pick<Field, 'name' | 'type' | 'description'>;
+
+function hasPasswordFormat(type?: TypeRef): boolean {
+  if (type?.kind === 'nullable') return hasPasswordFormat(type.inner);
+  return type?.kind === 'primitive' && type.type === 'string' && type.format === 'password';
+}
+
+function holdsSecret(field: SecretField): boolean {
+  if (hasPasswordFormat(field.type)) return true;
+  if (isSensitiveFieldName(field.name)) return true;
+  const description = field.description ?? '';
+  // A mention of a secret is not enough: identifiers, hints, and provider
+  // endpoints describe credentials without containing them.
+  if (/error code|endpoint|obfuscat|last (?:four|few|\d)|hint|suffix/i.test(description)) return false;
+  if (/^(?:value|credential)$/.test(field.name)) {
+    return /plaintext|\b(?:access token|API key|secret)\b/i.test(description);
+  }
+  return (
+    /(?:^|_)code$/.test(field.name) &&
+    /one-time|authorization code|verification code|TOTP code|code used to verify/i.test(description)
+  );
+}
+
+/** Redact string fields, including documented encoded forms of secret siblings. */
+export function applySecretRedaction(
+  rustType: string,
+  fieldName: string,
+  field?: SecretField,
+  siblings: readonly SecretField[] = [],
+): string {
+  let sensitive = field ? holdsSecret(field) : isSensitiveFieldName(fieldName);
+  if (!sensitive && field && /(?:^|_)(?:(?:uri|url)(?:_complete)?|qr_code)$/.test(field.name)) {
+    const description = field.description ?? '';
+    // Match documented sibling references such as "user code" to user_code.
+    // This normalization is only for classification, never for emitted names.
+    const words = (text: string) =>
+      ` ${text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim()} `;
+    sensitive =
+      !/endpoint/i.test(description) &&
+      /contain|encod|includ|deriv/i.test(description) &&
+      siblings.some(
+        (sibling) =>
+          sibling.name !== field.name &&
+          holdsSecret(sibling) &&
+          (words(description).includes(words(sibling.name)) || /\b(?:secret|token|seed)\b/i.test(description)),
+      );
+  }
+  if (!sensitive) return rustType;
   if (rustType === 'String') return 'crate::SecretString';
   if (rustType === 'Option<String>') return 'Option<crate::SecretString>';
   return rustType;

--- a/test/dotnet/resources.test.ts
+++ b/test/dotnet/resources.test.ts
@@ -432,7 +432,10 @@ describe('dotnet/resources', () => {
     expect(content).toContain('ListAsync(');
 
     // Auto-pagination method
-    expect(content).toContain('ListAutoPagingAsync');
+    expect(content).toContain(
+      'return this.ListAutoPagingAsync<Organization>("/organizations", options, requestOptions, cancellationToken);',
+    );
+    expect(content).not.toContain('this.Client.ListAutoPagingAsync');
     expect(content).toContain('IAsyncEnumerable<Organization>');
   });
 
@@ -605,6 +608,98 @@ describe('dotnet/resources', () => {
     expect(svcContent).toContain('AddQueryParam("parent_resource_id"');
     expect(svcContent).toContain('AddQueryParam("parent_resource_type_slug"');
     expect(svcContent).toContain('AddQueryParam("parent_resource_external_id"');
+  });
+
+  it.each([
+    ['listResources', 'parent', 'parent_external_id', '/authorization/resources', false],
+    [
+      'listResourcesForMembership',
+      'parent_resource',
+      'parent_resource_external_id',
+      '/authorization/organization_memberships/{id}/resources',
+      true,
+    ],
+  ] as const)('preserves grouped query dispatch in %s auto-paging', (name, group, externalId, path, membership) => {
+    const param = (name: string) => ({
+      name,
+      type: { kind: 'primitive', type: 'string' } as const,
+      required: true,
+    });
+    const services: Service[] = [
+      {
+        name: 'Authorization',
+        operations: [
+          {
+            name,
+            httpMethod: 'get',
+            path,
+            pathParams: membership ? [param('id')] : [],
+            queryParams: [param('parent_resource_id'), param('parent_resource_type_slug'), param(externalId)],
+            headerParams: [],
+            response: { kind: 'model', name: 'ResourceList' },
+            errors: [],
+            injectIdempotencyKey: false,
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'Resource' },
+            },
+            parameterGroups: [
+              {
+                name: group,
+                optional: !membership,
+                variants: [
+                  { name: 'by_id', parameters: [param('parent_resource_id')] },
+                  { name: 'by_external_id', parameters: [param('parent_resource_type_slug'), param(externalId)] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const models: Model[] = [
+      { name: 'Resource', fields: [param('id')] },
+      {
+        name: 'ResourceList',
+        fields: [{ name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Resource' } }, required: true }],
+      },
+    ];
+    primeEnumAliases([]);
+    const files = generateResources(services, { ...ctx, spec: { ...emptySpec, services, models } });
+    const service = files.find((f) => f.path.endsWith('Service.cs'))!.content;
+    const options = files.find((f) => f.path.endsWith('Options.cs'))!.content;
+    const pager = service.slice(service.indexOf('        public virtual IAsyncEnumerable<'));
+    const singlePage = service.slice(0, service.indexOf('        public virtual IAsyncEnumerable<'));
+    const dispatch = (body: string) =>
+      body.slice(
+        body.indexOf('            if (options?.'),
+        body.indexOf('\n            return', body.indexOf('            if (options?.')),
+      );
+    expect(dispatch(pager)).not.toBe('');
+    expect(dispatch(pager)).toBe(dispatch(singlePage));
+    for (const key of ['parent_resource_id', 'parent_resource_type_slug', externalId]) {
+      expect(pager).toContain(`request.AddQueryParam("${key}",`);
+    }
+    expect(pager).toContain('ById byId');
+    expect(pager).toContain('ByExternalId byExternalId');
+    expect(pager).toContain(
+      `options ??= new Authorization${membership ? 'ListResourcesForMembership' : 'ListResources'}Options();`,
+    );
+    expect(pager).toContain('var request = new WorkOSRequest');
+    expect(pager).toContain('Method = HttpMethod.Get,');
+    expect(pager).toContain(
+      membership
+        ? 'Path = $"/authorization/organization_memberships/{Uri.EscapeDataString(id)}/resources",'
+        : 'Path = "/authorization/resources",',
+    );
+    expect(pager).toContain('Options = options,');
+    expect(pager).toContain('RequestOptions = requestOptions,');
+    expect(pager).toContain('return this.Client.ListAutoPagingAsync<Resource>(request, cancellationToken);');
+    expect(pager).not.toContain('return this.ListAutoPagingAsync');
+    // The generic serializer must ignore the union to avoid nested/duplicate query keys.
+    expect(options).toContain('[JsonIgnore]\n        [STJS.JsonIgnore]\n        public AuthorizationParent');
   });
 
   it('emits optional variant members as trailing nullable properties omitted from the body when unset', () => {

--- a/test/dotnet/resources.test.ts
+++ b/test/dotnet/resources.test.ts
@@ -702,6 +702,86 @@ describe('dotnet/resources', () => {
     expect(options).toContain('[JsonIgnore]\n        [STJS.JsonIgnore]\n        public AuthorizationParent');
   });
 
+  it('places grouped params in the body for paginated body operations, matching the single-page method', () => {
+    const str = { kind: 'primitive', type: 'string' } as const;
+    const models: Model[] = [
+      { name: 'Resource', fields: [{ name: 'id', type: str, required: true }] },
+      {
+        name: 'ResourceList',
+        fields: [{ name: 'data', type: { kind: 'array', items: { kind: 'model', name: 'Resource' } }, required: true }],
+      },
+      {
+        name: 'SearchResourcesRequest',
+        fields: [
+          { name: 'parent_resource_id', type: str, required: false },
+          { name: 'parent_resource_type_slug', type: str, required: false },
+          { name: 'parent_external_id', type: str, required: false },
+        ],
+      },
+    ];
+    const services: Service[] = [
+      {
+        name: 'Authorization',
+        operations: [
+          {
+            name: 'searchResources',
+            httpMethod: 'post',
+            path: '/authorization/resources/search',
+            pathParams: [],
+            queryParams: [],
+            headerParams: [],
+            requestBody: { kind: 'model', name: 'SearchResourcesRequest' },
+            response: { kind: 'model', name: 'ResourceList' },
+            errors: [],
+            injectIdempotencyKey: false,
+            pagination: {
+              strategy: 'cursor',
+              param: 'after',
+              dataPath: 'data',
+              itemType: { kind: 'model', name: 'Resource' },
+            },
+            parameterGroups: [
+              {
+                name: 'parent',
+                optional: true,
+                variants: [
+                  { name: 'by_id', parameters: [{ name: 'parent_resource_id', type: str, required: true }] },
+                  {
+                    name: 'by_external_id',
+                    parameters: [
+                      { name: 'parent_resource_type_slug', type: str, required: true },
+                      { name: 'parent_external_id', type: str, required: true },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    primeEnumAliases([]);
+    const files = generateResources(services, { ...ctx, spec: { ...emptySpec, services, models } });
+    const service = files.find((f) => f.path.endsWith('Service.cs'))!.content;
+    const pagerStart = service.indexOf('        public virtual IAsyncEnumerable<');
+    expect(pagerStart).toBeGreaterThan(0);
+    const pager = service.slice(pagerStart);
+    const singlePage = service.slice(0, pagerStart);
+    const dispatch = (body: string) =>
+      body.slice(
+        body.indexOf('            if (options?.'),
+        body.indexOf('\n            return', body.indexOf('            if (options?.')),
+      );
+    expect(dispatch(pager)).not.toBe('');
+    expect(dispatch(pager)).toBe(dispatch(singlePage));
+    for (const key of ['parent_resource_id', 'parent_resource_type_slug', 'parent_external_id']) {
+      expect(pager).toContain(`request.AddBodyParam("${key}",`);
+    }
+    expect(pager).not.toContain('AddQueryParam(');
+    expect(pager).toContain('Method = HttpMethod.Post,');
+    expect(pager).toContain('return this.Client.ListAutoPagingAsync<Resource>(request, cancellationToken);');
+  });
+
   it('emits optional variant members as trailing nullable properties omitted from the body when unset', () => {
     const models: Model[] = [
       {

--- a/test/rust/models.test.ts
+++ b/test/rust/models.test.ts
@@ -22,6 +22,49 @@ const ctx: EmitterContext = {
 };
 
 describe('rust/models', () => {
+  it('passes sensitivity markers and sibling descriptions through model rendering', () => {
+    const model: Model = {
+      name: 'SensitivePayload',
+      fields: [
+        { name: 'value', type: { kind: 'primitive', type: 'string', format: 'password' }, required: false },
+        {
+          name: 'uri',
+          type: { kind: 'primitive', type: 'string' },
+          required: true,
+          description: 'A URI containing the value.',
+        },
+        {
+          name: 'token_url',
+          type: { kind: 'primitive', type: 'string' },
+          required: true,
+          description: 'The provider token endpoint.',
+        },
+        { name: 'user_code', type: { kind: 'primitive', type: 'string', format: 'password' }, required: true },
+        {
+          name: 'verification_uri_complete',
+          type: { kind: 'primitive', type: 'string', format: 'uri' },
+          required: true,
+          description: 'Verification URI that includes the user code.',
+        },
+        {
+          name: 'verification_uri',
+          type: { kind: 'primitive', type: 'string', format: 'uri' },
+          required: true,
+          description: 'The end-user verification URI.',
+        },
+      ],
+    };
+    const file = generateModels([model], ctx, new UnionRegistry()).find(
+      (f) => f.path === 'src/models/sensitive_payload.rs',
+    )!;
+    expect(file.content).toContain('pub value: Option<crate::SecretString>');
+    expect(file.content).toContain('pub uri: crate::SecretString');
+    expect(file.content).toContain('pub token_url: String');
+    expect(file.content).toContain('pub user_code: crate::SecretString');
+    expect(file.content).toContain('pub verification_uri_complete: crate::SecretString');
+    expect(file.content).toContain('pub verification_uri: String');
+  });
+
   it('emits only an empty barrel when no models', () => {
     const files = generateModels([], ctx, new UnionRegistry());
     expect(files).toHaveLength(1);

--- a/test/rust/resources.test.ts
+++ b/test/rust/resources.test.ts
@@ -44,6 +44,32 @@ function ctxWithResolved(services: Service[]): EmitterContext {
 }
 
 describe('rust/resources', () => {
+  it('redacts spec-marked HTTP parameters and constructor inputs', () => {
+    const service: Service = {
+      name: 'Secrets',
+      operations: [
+        {
+          name: 'validate',
+          httpMethod: 'get',
+          path: '/validate',
+          pathParams: [],
+          headerParams: [],
+          queryParams: [
+            { name: 'value', required: true, type: { kind: 'primitive', type: 'string', format: 'password' } },
+          ],
+          response: { kind: 'primitive', type: 'boolean' },
+          errors: [],
+          injectIdempotencyKey: false,
+        },
+      ],
+    };
+    const file = generateResources([service], ctxWithResolved([service]), new UnionRegistry()).find(
+      (f) => f.path === 'src/resources/secrets.rs',
+    )!;
+    expect(file.content).toContain('pub value: crate::SecretString');
+    expect(file.content).toContain('value: impl Into<crate::SecretString>');
+  });
+
   it('skips services with no operations', () => {
     const services: Service[] = [{ name: 'Empty', operations: [] }];
     const files = generateResources(services, ctxWithResolved(services), new UnionRegistry());

--- a/test/rust/secret.test.ts
+++ b/test/rust/secret.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { Field } from '@workos/oagen';
+import { applySecretRedaction } from '../../src/rust/secret.js';
+
+const field = (name: string, description?: string, format?: string): Field => ({
+  name,
+  description,
+  type: { kind: 'primitive', type: 'string', format },
+  required: true,
+});
+
+const redact = (f: Field, type = 'String', siblings: Field[] = []) => applySecretRedaction(type, f.name, f, siblings);
+
+describe('rust secret classification', () => {
+  it('honors password format even for generic names and nullable strings', () => {
+    const marked = field('value', undefined, 'password');
+    expect(redact(marked)).toBe('crate::SecretString');
+    expect(redact({ ...marked, type: { kind: 'nullable', inner: marked.type } }, 'Option<String>')).toBe(
+      'Option<crate::SecretString>',
+    );
+    expect(redact(marked, 'Vec<String>')).toBe('Vec<String>');
+    expect(redact(field('value', 'A public hint.', 'password'))).toBe('crate::SecretString');
+  });
+
+  it.each([
+    ['value', 'The OAuth access token.'],
+    ['value', 'The full API Key value. Only returned once at creation time.'],
+    ['value', 'Decrypted plaintext value.'],
+    ['credential', 'The credential value to validate: the API key value.'],
+    ['code', 'The one-time code for the challenge.'],
+    ['authkit_authorization_code', 'An authorization code that can be exchanged for tokens.'],
+  ])('redacts semantic secret %s: %s', (name, description) => {
+    expect(redact(field(name, description))).toBe('crate::SecretString');
+  });
+
+  it.each([
+    ['code', 'The error code identifying the type of error.'],
+    ['token_url', "The provider's OAuth token endpoint."],
+    ['refresh_token_url', 'The endpoint used to refresh tokens.'],
+    ['value', 'An obfuscated representation of the API Key value.'],
+    ['value', 'A hint showing the last few characters of the secret value.'],
+    ['id', 'The unique ID of the client secret.'],
+    ['value', 'The PEM-encoded public X.509 certificate.'],
+    ['code', 'A public classification code.'],
+  ])('preserves non-secret %s: %s', (name, description) => {
+    expect(redact(field(name, description))).toBe('String');
+  });
+
+  it.each(['uri', 'qr_code', 'reset_url'])('redacts documented secret-derived %s siblings', (name) => {
+    const derived = field(name, 'Encoded form containing the secret.');
+    expect(redact(derived, 'String', [field('secret')])).toBe('crate::SecretString');
+    expect(redact(derived)).toBe('String');
+    expect(redact(field(name, 'Public endpoint containing the token.'), 'String', [field('token')])).toBe('String');
+  });
+
+  it.each(['user code', '`user_code`', 'USER CODE'])(
+    'redacts complete URIs referencing %s without losing URI format',
+    (reference) => {
+      const uri = field('verification_uri_complete', `Verification URI that includes the ${reference}.`, 'uri');
+      const userCode = field('user_code', 'The end-user verification code.', 'password');
+      expect(redact(uri, 'String', [userCode])).toBe('crate::SecretString');
+      expect(redact(uri, 'Option<String>', [userCode])).toBe('Option<crate::SecretString>');
+      expect(uri.name).toBe('verification_uri_complete');
+      expect(uri.type).toEqual({ kind: 'primitive', type: 'string', format: 'uri' });
+      expect(redact(uri)).toBe('String');
+      expect(redact(uri, 'String', [field('user_code', 'A public display code.')])).toBe('String');
+      expect(redact(field('verification_uri', 'The end-user verification URI.', 'uri'), 'String', [userCode])).toBe(
+        'String',
+      );
+      expect(
+        redact(field('token_url', `Provider endpoint including the ${reference}.`, 'uri'), 'String', [userCode]),
+      ).toBe('String');
+      expect(
+        redact(field('verification_uri_complete', 'URI including the superuser code.', 'uri'), 'String', [userCode]),
+      ).toBe('String');
+    },
+  );
+
+  it('retains existing name-based redaction', () => {
+    expect(applySecretRedaction('Option<String>', 'access_token')).toBe('Option<crate::SecretString>');
+  });
+});

--- a/test/rust/secret.test.ts
+++ b/test/rust/secret.test.ts
@@ -29,6 +29,10 @@ describe('rust secret classification', () => {
     ['credential', 'The credential value to validate: the API key value.'],
     ['code', 'The one-time code for the challenge.'],
     ['authkit_authorization_code', 'An authorization code that can be exchanged for tokens.'],
+    // A caveat about a separately displayed partial must not disarm the full secret.
+    ['value', 'The full API key value; its suffix is displayed separately.'],
+    ['value', 'The API key value (only the last four characters are shown in the dashboard).'],
+    ['code', 'The one-time code, delivered with a hint about the channel used.'],
   ])('redacts semantic secret %s: %s', (name, description) => {
     expect(redact(field(name, description))).toBe('crate::SecretString');
   });
@@ -39,6 +43,8 @@ describe('rust secret classification', () => {
     ['refresh_token_url', 'The endpoint used to refresh tokens.'],
     ['value', 'An obfuscated representation of the API Key value.'],
     ['value', 'A hint showing the last few characters of the secret value.'],
+    ['value', 'The last four characters of the API key, for display.'],
+    ['value', 'Masked API key value.'],
     ['id', 'The unique ID of the client secret.'],
     ['value', 'The PEM-encoded public X.509 certificate.'],
     ['code', 'A public classification code.'],


### PR DESCRIPTION
## Summary

- **Rust (VULN-1265, workos/workos-rust#154):** `SecretString` classification is now semantic instead of name-only. Spec `format: password` markers take precedence, generic names (`value`, `credential`, `*code`) fall back to their documented meaning, and URI/QR/URL fields that embed a redacted sibling's secret inherit the redaction. The old heuristic left OAuth tokens, full API keys, Vault plaintext, one-time codes, and TOTP seeds (via `uri`/`qr_code`) in plain `Debug` output. Wire format is unchanged.
- **.NET (VULN-1274):** auto-paging methods on operations with parameter groups now build the `WorkOSRequest` locally, run the same `AddQueryParam` dispatch as the single-page method, and hand it to `Client.ListAutoPagingAsync`, which carries `ExtraQueryParams` across pages. Group properties are `JsonIgnore`'d, so the base helper silently dropped them: `ListResourcesAutoPagingAsync` returned the unfiltered environment-wide listing instead of the parent-scoped one.
- Operations without parameter groups keep the existing base-helper call. On the live spec only `Authorization.ListResources` and `ListResourcesForMembership` change.
