### PR TITLE
fix: escape spec metadata in generated SDKs

### DIFF
--- a/src/dotnet/enums.ts
+++ b/src/dotnet/enums.ts
@@ -1,6 +1,6 @@
 import type { Enum, EmitterContext, GeneratedFile, Service } from '@workos/oagen';
 import { walkTypeRef } from '@workos/oagen';
-import { className, deprecationMessage, escapeCsAttributeString, humanize } from './naming.js';
+import { className, csLiteral, deprecationMessage, escapeCsAttributeString, escapeXml, humanize } from './naming.js';
 import { setEnumAliases, setSingleValueEnumNames } from './type-map.js';
 import { enrichModelsFromSpec } from '../shared/model-utils.js';
 import { isEnumInScope, declaredParams } from '../shared/resolved-ops.js';
@@ -124,7 +124,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         const msg = escapeCsAttributeString(deprecationMessage(v.description, 'value'));
         lines.push(`        [System.Obsolete("${msg}")]`);
       }
-      lines.push(`        [EnumMember(Value = "${v.value}")]`);
+      lines.push(`        [EnumMember(Value = ${csLiteral(String(v.value))})]`);
       // Explicit ordinals only when we promoted a default to position 0.
       const ordinal = defaultMatch ? ` = ${i}` : '';
       lines.push(`        ${memberName}${ordinal},`);
@@ -152,10 +152,6 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
   }
 
   return files;
-}
-
-function escapeXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 /**

--- a/src/dotnet/index.ts
+++ b/src/dotnet/index.ts
@@ -1,3 +1,4 @@
+import { csLiteral, escapeXml } from './naming.js';
 import type {
   Emitter,
   EmitterContext,
@@ -150,7 +151,7 @@ export const dotnetEmitter: Emitter = {
         lines.push('');
         lines.push(`    /// <summary>`);
         lines.push(`    /// JSON converter that deserializes discriminated union variants`);
-        lines.push(`    /// based on the "${disc.property}" property.`);
+        lines.push(`    /// based on the "${escapeXml(disc.property)}" property.`);
         lines.push(`    /// </summary>`);
         lines.push(`    public class ${converterName} : Newtonsoft.Json.JsonConverter`);
         lines.push('    {');
@@ -164,7 +165,7 @@ export const dotnetEmitter: Emitter = {
         );
         lines.push('        {');
         lines.push('            var jObject = JObject.Load(reader);');
-        lines.push(`            var discriminatorValue = jObject["${disc.property}"]?.ToString();`);
+        lines.push(`            var discriminatorValue = jObject[${csLiteral(disc.property)}]?.ToString();`);
         lines.push('            switch (discriminatorValue)');
         lines.push('            {');
         for (const [value, modelName] of Object.entries(disc.mapping)) {
@@ -174,7 +175,7 @@ export const dotnetEmitter: Emitter = {
           // values fall through to the `default` arm below.
           if (!variantFileExistsAfterRun(modelName, c)) continue;
           const csName = modelClassName(resolveModelName(modelName));
-          lines.push(`                case "${value}": return jObject.ToObject<${csName}>(serializer);`);
+          lines.push(`                case ${csLiteral(value)}: return jObject.ToObject<${csName}>(serializer);`);
         }
         lines.push('                default: return jObject.ToObject<object>(serializer);');
         lines.push('            }');
@@ -221,7 +222,7 @@ export const dotnetEmitter: Emitter = {
       lines.push('');
       lines.push(`    /// <summary>`);
       lines.push(`    /// JSON converter that deserializes <see cref="${baseClass}"/> into the`);
-      lines.push(`    /// correct variant subclass based on the "${disc.property}" property.`);
+      lines.push(`    /// correct variant subclass based on the "${escapeXml(disc.property)}" property.`);
       lines.push(`    /// </summary>`);
       lines.push(`    public class ${converterName} : Newtonsoft.Json.JsonConverter`);
       lines.push('    {');
@@ -237,7 +238,7 @@ export const dotnetEmitter: Emitter = {
       );
       lines.push('        {');
       lines.push('            var jObject = JObject.Load(reader);');
-      lines.push(`            var discriminatorValue = jObject["${disc.property}"]?.ToString();`);
+      lines.push(`            var discriminatorValue = jObject[${csLiteral(disc.property)}]?.ToString();`);
       lines.push('');
       lines.push('            object target;');
       lines.push('            switch (discriminatorValue)');
@@ -252,7 +253,7 @@ export const dotnetEmitter: Emitter = {
         // which deserializes into the base class.
         if (!variantFileExistsAfterRun(variantModelName, c)) continue;
         const csName = modelClassName(variantModelName);
-        lines.push(`                case "${value}": target = new ${csName}(); break;`);
+        lines.push(`                case ${csLiteral(value)}: target = new ${csName}(); break;`);
       }
       lines.push(`                default: target = new ${baseClass}(); break;`);
       lines.push('            }');

--- a/src/dotnet/models.ts
+++ b/src/dotnet/models.ts
@@ -11,6 +11,7 @@ import {
 } from './type-map.js';
 import {
   articleFor,
+  csLiteral,
   fieldName,
   domainFieldName,
   humanize,
@@ -423,7 +424,7 @@ function singleValueConstInitializer(ref: TypeRef, enumConstByName: Map<string, 
     if (ref.value === null) return null;
     if (typeof ref.value === 'boolean') return ref.value ? 'true' : 'false';
     if (typeof ref.value === 'number') return String(ref.value);
-    if (typeof ref.value === 'string') return JSON.stringify(ref.value);
+    if (typeof ref.value === 'string') return csLiteral(ref.value);
     return null;
   }
   if (ref.kind !== 'enum') return null;
@@ -437,7 +438,7 @@ function singleValueConstInitializer(ref: TypeRef, enumConstByName: Map<string, 
   if (wire === null) return null;
   // Enum wire values serialize as strings in JSON, and mapTypeRef returns
   // `string` for single-value enums — so always quote.
-  return JSON.stringify(wire);
+  return csLiteral(wire);
 }
 
 /**

--- a/src/dotnet/naming.ts
+++ b/src/dotnet/naming.ts
@@ -164,7 +164,7 @@ export function localName(name: string): string {
 
 /** Escape a value as a C# literal. */
 export function csLiteral(value: string | number | boolean): string {
-  if (typeof value === 'string') return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (typeof value === 'string') return `"${escapeCsAttributeString(value)}"`;
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   return String(value);
 }
@@ -229,7 +229,11 @@ export function httpMethodHelperName(method: string): string {
 
 /** Escape XML special characters for use in XML doc comments. */
 export function escapeXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/[\r\n\u0085\u2028\u2029]/g, (char) => `&#${char.charCodeAt(0)};`);
 }
 
 /**
@@ -269,7 +273,9 @@ export function deprecationMessage(
  * Doubles embedded quotes and escapes backslashes.
  */
 export function escapeCsAttributeString(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return JSON.stringify(s)
+    .slice(1, -1)
+    .replace(/[\u0085\u2028\u2029]/g, (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`);
 }
 
 /**

--- a/src/dotnet/resources.ts
+++ b/src/dotnet/resources.ts
@@ -318,11 +318,11 @@ function emitParamValue(
       return [
         `${indent}if (${accessor} != null)`,
         `${indent}{`,
-        `${indent}    request.${method}("${wireName}", ${valueExpr});`,
+        `${indent}    request.${method}(${csLiteral(wireName)}, ${valueExpr});`,
         `${indent}}`,
       ];
     }
-    return [`${indent}request.${method}("${wireName}", ${valueExpr});`];
+    return [`${indent}request.${method}(${csLiteral(wireName)}, ${valueExpr});`];
   }
 
   if (inner.kind === 'enum') {
@@ -331,23 +331,23 @@ function emitParamValue(
       return [
         `${indent}if (${accessor} != null)`,
         `${indent}{`,
-        `${indent}    request.${method}("${wireName}", ${serExpr});`,
+        `${indent}    request.${method}(${csLiteral(wireName)}, ${serExpr});`,
         `${indent}}`,
       ];
     }
-    return [`${indent}request.${method}("${wireName}", ${serExpr});`];
+    return [`${indent}request.${method}(${csLiteral(wireName)}, ${serExpr});`];
   }
 
   if (needsNullGuard) {
     return [
       `${indent}if (${accessor} != null)`,
       `${indent}{`,
-      `${indent}    request.${method}("${wireName}", ${accessor});`,
+      `${indent}    request.${method}(${csLiteral(wireName)}, ${accessor});`,
       `${indent}}`,
     ];
   }
 
-  return [`${indent}request.${method}("${wireName}", ${accessor});`];
+  return [`${indent}request.${method}(${csLiteral(wireName)}, ${accessor});`];
 }
 
 /** Check whether any parameter group variant contains an enum-typed parameter. */

--- a/src/dotnet/type-map.ts
+++ b/src/dotnet/type-map.ts
@@ -1,6 +1,6 @@
 import type { TypeRef, PrimitiveType, UnionType } from '@workos/oagen';
 import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
-import { className, modelClassName } from './naming.js';
+import { className, modelClassName, csLiteral } from './naming.js';
 
 /** Known C# value types that need `?` for nullable. */
 const VALUE_TYPES = new Set(['int', 'long', 'double', 'bool', 'float', 'decimal', 'byte', 'short', 'DateTimeOffset']);
@@ -167,12 +167,15 @@ export function emitJsonPropertyAttributes(
   if (options.explicitWireName) {
     if (options.isRequiredEnum) {
       return [
-        `        [JsonProperty("${wireName}", DefaultValueHandling = DefaultValueHandling.Ignore)]`,
+        `        [JsonProperty(${csLiteral(wireName)}, DefaultValueHandling = DefaultValueHandling.Ignore)]`,
         `        [STJS.JsonIgnore(Condition = STJS.JsonIgnoreCondition.WhenWritingDefault)]`,
-        `        [STJS.JsonPropertyName("${wireName}")]`,
+        `        [STJS.JsonPropertyName(${csLiteral(wireName)})]`,
       ];
     }
-    return [`        [JsonProperty("${wireName}")]`, `        [STJS.JsonPropertyName("${wireName}")]`];
+    return [
+      `        [JsonProperty(${csLiteral(wireName)})]`,
+      `        [STJS.JsonPropertyName(${csLiteral(wireName)})]`,
+    ];
   }
   if (options.isRequiredEnum) {
     return [

--- a/src/go/enums.ts
+++ b/src/go/enums.ts
@@ -1,3 +1,4 @@
+import { goStringLiteral } from './strings.js';
 import type { Enum, EmitterContext, GeneratedFile, Service } from '@workos/oagen';
 import { walkTypeRef } from '@workos/oagen';
 import { className } from './naming.js';
@@ -112,9 +113,13 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       }
       const constName = `${typeName}${constSuffix}`;
       usedNames.add(constName);
-      const valueStr = typeof v.value === 'string' ? `"${v.value}"` : String(v.value);
+      const valueStr = typeof v.value === 'string' ? goStringLiteral(v.value) : String(v.value);
       if (v.description) {
-        blockLines.push(`\t// ${constName} is ${v.description}.`);
+        blockLines.push(
+          ...`\t// ${constName} is ${v.description}.`
+            .split('\n')
+            .map((line, index) => (index === 0 ? line : `\t// ${line}`)),
+        );
       }
       if (v.deprecated) {
         if (v.description) blockLines.push(`\t//`);
@@ -218,7 +223,11 @@ function generateEventConstantsFile(enums: Enum[], ctx: EmitterContext): Generat
     usedNames.add(constName);
 
     if (value.description) {
-      lines.push(`\t// ${constName} is ${value.description}.`);
+      lines.push(
+        ...`\t// ${constName} is ${value.description}.`
+          .split('\n')
+          .map((line, index) => (index === 0 ? line : `\t// ${line}`)),
+      );
     }
     if (value.deprecated) {
       if (value.description) lines.push('\t//');
@@ -226,7 +235,7 @@ function generateEventConstantsFile(enums: Enum[], ctx: EmitterContext): Generat
     }
     // Keep constants untyped so callers can use them as plain strings,
     // events.Event values, or typed root-package enum values.
-    lines.push(`\t${constName} = "${escapeGoString(valueStr)}"`);
+    lines.push(`\t${constName} = ${goStringLiteral(valueStr)}`);
   }
 
   lines.push(')');
@@ -279,10 +288,6 @@ function uniqueEventConstantName(value: string, usedNames: Set<string>): string 
   let suffix = 2;
   while (usedNames.has(`${base}${suffix}`)) suffix++;
   return `${base}${suffix}`;
-}
-
-function escapeGoString(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 export function assignEnumsToServices(enums: Enum[], services: Service[]): Map<string, string> {

--- a/src/go/models.ts
+++ b/src/go/models.ts
@@ -1,3 +1,4 @@
+import { goStructTag } from './strings.js';
 import type { Model, EmitterContext, GeneratedFile, TypeRef, Service } from '@workos/oagen';
 import { walkTypeRef } from '@workos/oagen';
 import { mapTypeRef } from './type-map.js';
@@ -245,7 +246,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       const isOptional = !field.required;
       const goType = isOptional ? makeOptional(mapTypeRef(field.type)) : mapTypeRef(field.type);
 
-      const jsonTag = field.required ? `json:"${field.name}"` : `json:"${field.name},omitempty"`;
+      const jsonTag = goStructTag({ json: field.name + (field.required ? '' : ',omitempty') });
 
       if (field.description) {
         const fdLines = field.description.split('\n').filter((l) => l.trim());
@@ -259,7 +260,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
         const deprecationReason = extractDeprecationReason(field.description);
         blockLines.push(`\t// Deprecated: ${deprecationReason}`);
       }
-      blockLines.push(`\t${goFieldName} ${goType} \`${jsonTag}\``);
+      blockLines.push(`\t${goFieldName} ${goType} ${jsonTag}`);
     }
 
     blockLines.push('}');

--- a/src/go/resources.ts
+++ b/src/go/resources.ts
@@ -1,3 +1,4 @@
+import { goStructTag, goStringLiteral } from './strings.js';
 import type {
   Service,
   Operation,
@@ -420,7 +421,7 @@ function emitCollectedGroupTypes(mountName: string, groups: CollectedGroup[], re
       if (group.needsQuery) {
         lines.push(`func (p ${typeName}) applyToQuery(v url.Values) {`);
         for (const { param, goField, isOptional, valueExpr } of members) {
-          const setLine = `v.Set("${param.name}", ${formatQueryValue(valueExpr, param.type)})`;
+          const setLine = `v.Set(${goStringLiteral(param.name)}, ${formatQueryValue(valueExpr, param.type)})`;
           if (isOptional) {
             lines.push(`\tif p.${goField} != nil {`);
             lines.push(`\t\t${setLine}`);
@@ -437,10 +438,10 @@ function emitCollectedGroupTypes(mountName: string, groups: CollectedGroup[], re
         for (const { param, goField, isOptional, valueExpr } of members) {
           if (isOptional) {
             lines.push(`\tif p.${goField} != nil {`);
-            lines.push(`\t\tm["${param.name}"] = ${valueExpr}`);
+            lines.push(`\t\tm[${goStringLiteral(param.name)}] = ${valueExpr}`);
             lines.push('\t}');
           } else {
-            lines.push(`\tm["${param.name}"] = ${valueExpr}`);
+            lines.push(`\tm[${goStringLiteral(param.name)}] = ${valueExpr}`);
           }
         }
         lines.push('}');
@@ -509,12 +510,11 @@ function generateParamsStruct(
         if (!field.required && field.type.kind === 'nullable') clearableBodyFieldNames.push(field.name);
         const isOptional = !field.required;
         const goType = isOptional ? makeOptional(mapTypeRef(field.type)) : mapTypeRef(field.type);
-        const jsonTag = field.required ? `json:"${field.name}"` : `json:"${field.name},omitempty"`;
+        const jsonTag = field.name + (field.required ? '' : ',omitempty');
         // Body fields are JSON-marshaled into the request body. Emit `url:"-"`
         // so go-querystring's default field-name fallback doesn't also place
         // them in the URL — important when the spec duplicates a field as both
         // body and query param (e.g. /sso/token's `code`).
-        const urlTag = ' url:"-"';
         if (field.description) {
           const fdLines = field.description.split('\n').filter((l) => l.trim());
           lines.push(`\t// ${fieldDocComment(goField, fdLines[0])}`);
@@ -526,7 +526,7 @@ function generateParamsStruct(
           if (field.description) lines.push(`\t//`);
           lines.push(`\t// Deprecated: this field is deprecated.`);
         }
-        lines.push(`\t${goField} ${goType} \`${jsonTag}${urlTag}\``);
+        lines.push(`\t${goField} ${goType} ${goStructTag({ json: jsonTag, url: '-' })}`);
       }
     }
   } else if (hasBody) {
@@ -556,8 +556,7 @@ function generateParamsStruct(
     const isOptional = !param.required;
     const paramType = mapQueryParamType(param.name, param.type);
     const goType = isOptional ? makeOptional(paramType) : paramType;
-    const urlTag = param.required ? `url:"${param.name}"` : `url:"${param.name},omitempty"`;
-    const jsonTag = 'json:"-"';
+    const urlTag = param.name + (param.required ? '' : ',omitempty');
     if (param.description) {
       const pdLines = param.description.split('\n').filter((l) => l.trim());
       lines.push(`\t// ${fieldDocComment(goField, pdLines[0])}`);
@@ -574,7 +573,7 @@ function generateParamsStruct(
       if (param.description || param.default != null) lines.push(`\t//`);
       lines.push(`\t// Deprecated: this parameter is deprecated.`);
     }
-    lines.push(`\t${goField} ${goType} \`${urlTag} ${jsonTag}\``);
+    lines.push(`\t${goField} ${goType} ${goStructTag({ url: urlTag, json: '-' })}`);
   }
 
   // Parameter group fields (sum-type interfaces, serialized via applyToQuery)
@@ -632,7 +631,7 @@ function generateParamsStruct(
     }
     if (hasNullFields) {
       lines.push('\tnullable := map[string]bool{');
-      for (const name of clearableBodyFieldNames) lines.push(`\t\t"${name}": true,`);
+      for (const name of clearableBodyFieldNames) lines.push(`\t\t${goStringLiteral(name)}: true,`);
       lines.push('\t}');
       lines.push('\tfor _, f := range p.NullFields {');
       lines.push('\t\tif !nullable[f] {');
@@ -726,7 +725,9 @@ function generateMethod(
   for (const p of op.pathParams) {
     if (p.deprecated) {
       lines.push(`//`);
-      lines.push(`// Deprecated parameter ${fieldName(p.name)}${p.description ? ': ' + p.description : '.'}`);
+      lines.push(
+        `// Deprecated parameter ${fieldName(p.name)}${p.description ? ': ' + p.description.replace(/\n/g, '\n// ') : '.'}`,
+      );
     }
   }
   if (op.deprecated) {
@@ -791,7 +792,7 @@ function generateMethod(
     );
   } else if (isPaginated && op.pagination) {
     const itemType = resolveIteratorItemType(op.pagination.itemType, _ctx);
-    const dataPath = op.pagination.dataPath ? `"${op.pagination.dataPath}"` : `"data"`;
+    const dataPath = op.pagination.dataPath ? `${goStringLiteral(op.pagination.dataPath)}` : `"data"`;
     const cursorParam = '"after"';
     lines.push(
       `\treturn newIterator[${itemType}](ctx, s.client, "${op.httpMethod.toUpperCase()}", ${pathExpr}, ${hasVisibleQueryParams ? 'params' : 'nil'}, ${cursorParam}, ${dataPath}, opts, ${paginationDefaultsLiteral(op)})`,
@@ -837,7 +838,7 @@ function generateMethod(
 
 /** Convert a JS value to a Go literal. */
 function goLiteral(value: string | number | boolean): string {
-  if (typeof value === 'string') return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (typeof value === 'string') return goStringLiteral(value);
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   return String(value);
 }
@@ -877,14 +878,14 @@ function emitGetWithHiddenParams(
 
   // Inject constant defaults
   for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
-    lines.push(`\tquery.Set("${key}", ${goLiteralForQuery(value as string | number | boolean)})`);
+    lines.push(`\tquery.Set(${goStringLiteral(key)}, ${goLiteralForQuery(value as string | number | boolean)})`);
   }
 
   // Inject inferred fields from client config
   for (const field of getOpInferFromClient(resolvedOp)) {
     const expr = clientFieldExpression(field);
     lines.push(`\tif ${expr} != "" {`);
-    lines.push(`\t\tquery.Set("${field}", ${expr})`);
+    lines.push(`\t\tquery.Set(${goStringLiteral(field)}, ${expr})`);
     lines.push('\t}');
   }
 
@@ -900,23 +901,27 @@ function emitGetWithHiddenParams(
         // Maps use bracket encoding: param[key]=value
         if (param.required) {
           lines.push(`\tfor k, v := range params.${goField} {`);
-          lines.push(`\t\tquery.Set(fmt.Sprintf("${param.name}[%s]", k), fmt.Sprintf("%v", v))`);
+          lines.push(
+            `\t\tquery.Set(fmt.Sprintf(${goStringLiteral(`${param.name.replace(/%/g, '%%')}[%s]`)}, k), fmt.Sprintf("%v", v))`,
+          );
           lines.push('\t}');
         } else {
           lines.push(`\tif params.${goField} != nil {`);
           lines.push(`\t\tfor k, v := range params.${goField} {`);
-          lines.push(`\t\t\tquery.Set(fmt.Sprintf("${param.name}[%s]", k), fmt.Sprintf("%v", v))`);
+          lines.push(
+            `\t\t\tquery.Set(fmt.Sprintf(${goStringLiteral(`${param.name.replace(/%/g, '%%')}[%s]`)}, k), fmt.Sprintf("%v", v))`,
+          );
           lines.push('\t\t}');
           lines.push('\t}');
         }
       } else if (param.required) {
-        lines.push(`\tquery.Set("${param.name}", ${formatQueryValue(`params.${goField}`, param.type)})`);
+        lines.push(`\tquery.Set(${goStringLiteral(param.name)}, ${formatQueryValue(`params.${goField}`, param.type)})`);
       } else {
         // Slices are reference types in Go -- nil-able without pointer wrapping
         const isRefType = param.type.kind === 'array';
         const valueExpr = isRefType ? `params.${goField}` : `*params.${goField}`;
         lines.push(`\tif params.${goField} != nil {`);
-        lines.push(`\t\tquery.Set("${param.name}", ${formatQueryValue(valueExpr, param.type)})`);
+        lines.push(`\t\tquery.Set(${goStringLiteral(param.name)}, ${formatQueryValue(valueExpr, param.type)})`);
         lines.push('\t}');
       }
     }
@@ -933,7 +938,7 @@ function emitGetWithHiddenParams(
   // Make the request with query as the 4th arg
   if (isPaginated && op.pagination) {
     const itemType = resolveIteratorItemType(op.pagination.itemType, ctx);
-    const dataPath = op.pagination.dataPath ? `"${op.pagination.dataPath}"` : `"data"`;
+    const dataPath = op.pagination.dataPath ? `${goStringLiteral(op.pagination.dataPath)}` : `"data"`;
     const cursorParam = '"after"';
     lines.push(
       `\treturn newIterator[${itemType}](ctx, s.client, "GET", ${pathExpr}, query, ${cursorParam}, ${dataPath}, opts, ${paginationDefaultsLiteral(op)})`,
@@ -982,14 +987,14 @@ function emitUrlBuilderMethod(
 
   // Inject constant defaults (e.g., response_type=code)
   for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
-    lines.push(`\tquery.Set("${key}", ${goLiteralForQuery(value as string | number | boolean)})`);
+    lines.push(`\tquery.Set(${goStringLiteral(key)}, ${goLiteralForQuery(value as string | number | boolean)})`);
   }
 
   // Inject inferred fields from client config (e.g., client_id)
   for (const field of getOpInferFromClient(resolvedOp)) {
     const expr = clientFieldExpression(field);
     lines.push(`\tif ${expr} != "" {`);
-    lines.push(`\t\tquery.Set("${field}", ${expr})`);
+    lines.push(`\t\tquery.Set(${goStringLiteral(field)}, ${expr})`);
     lines.push('\t}');
   }
 
@@ -1002,22 +1007,26 @@ function emitUrlBuilderMethod(
       if (isMap) {
         if (param.required) {
           lines.push(`\tfor k, v := range params.${goField} {`);
-          lines.push(`\t\tquery.Set(fmt.Sprintf("${param.name}[%s]", k), fmt.Sprintf("%v", v))`);
+          lines.push(
+            `\t\tquery.Set(fmt.Sprintf(${goStringLiteral(`${param.name.replace(/%/g, '%%')}[%s]`)}, k), fmt.Sprintf("%v", v))`,
+          );
           lines.push('\t}');
         } else {
           lines.push(`\tif params.${goField} != nil {`);
           lines.push(`\t\tfor k, v := range params.${goField} {`);
-          lines.push(`\t\t\tquery.Set(fmt.Sprintf("${param.name}[%s]", k), fmt.Sprintf("%v", v))`);
+          lines.push(
+            `\t\t\tquery.Set(fmt.Sprintf(${goStringLiteral(`${param.name.replace(/%/g, '%%')}[%s]`)}, k), fmt.Sprintf("%v", v))`,
+          );
           lines.push('\t\t}');
           lines.push('\t}');
         }
       } else if (param.required) {
-        lines.push(`\tquery.Set("${param.name}", ${formatQueryValue(`params.${goField}`, param.type)})`);
+        lines.push(`\tquery.Set(${goStringLiteral(param.name)}, ${formatQueryValue(`params.${goField}`, param.type)})`);
       } else {
         const isRefType = param.type.kind === 'array';
         const valueExpr = isRefType ? `params.${goField}` : `*params.${goField}`;
         lines.push(`\tif params.${goField} != nil {`);
-        lines.push(`\t\tquery.Set("${param.name}", ${formatQueryValue(valueExpr, param.type)})`);
+        lines.push(`\t\tquery.Set(${goStringLiteral(param.name)}, ${formatQueryValue(valueExpr, param.type)})`);
         lines.push('\t}');
       }
     }
@@ -1054,7 +1063,7 @@ function emitHiddenParamsBodyStruct(
   for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
     const goField = fieldName(key);
     const goType = typeof value === 'boolean' ? 'bool' : typeof value === 'number' ? 'int' : 'string';
-    lines.push(`\t${goField} ${goType} \`json:"${key}"\``);
+    lines.push(`\t${goField} ${goType} ${goStructTag({ json: key })}`);
   }
 
   // Required exposed body fields
@@ -1067,14 +1076,14 @@ function emitHiddenParamsBodyStruct(
       // Domain struct field; the json tag below keeps deriving from field.name.
       const goField = domainFieldName(field);
       const goType = mapTypeRef(field.type);
-      lines.push(`\t${goField} ${goType} \`json:"${field.name}"\``);
+      lines.push(`\t${goField} ${goType} ${goStructTag({ json: field.name })}`);
     }
   }
 
   // Inferred fields from client config (omitempty drops empty strings)
   for (const inferred of getOpInferFromClient(resolvedOp)) {
     const goField = fieldName(inferred);
-    lines.push(`\t${goField} string \`json:"${inferred},omitempty"\``);
+    lines.push(`\t${goField} string ${goStructTag({ json: inferred + ',omitempty' })}`);
   }
 
   // Optional exposed body fields (pointer/slice/map + omitempty)
@@ -1087,7 +1096,7 @@ function emitHiddenParamsBodyStruct(
       // Domain struct field; the json tag below keeps deriving from field.name.
       const goField = domainFieldName(field);
       const goType = makeOptional(mapTypeRef(field.type));
-      lines.push(`\t${goField} ${goType} \`json:"${field.name},omitempty"\``);
+      lines.push(`\t${goField} ${goType} ${goStructTag({ json: field.name + ',omitempty' })}`);
       if (field.type.kind === 'nullable') clearableBodyFieldNames.push(field.name);
     }
   }
@@ -1117,7 +1126,7 @@ function emitHiddenParamsBodyStruct(
     lines.push('\t\treturn nil, err');
     lines.push('\t}');
     lines.push('\tnullable := map[string]bool{');
-    for (const name of clearableBodyFieldNames) lines.push(`\t\t"${name}": true,`);
+    for (const name of clearableBodyFieldNames) lines.push(`\t\t${goStringLiteral(name)}: true,`);
     lines.push('\t}');
     lines.push('\tfor _, f := range b.NullFields {');
     lines.push('\t\tif !nullable[f] {');
@@ -1244,7 +1253,7 @@ function emitBodyWithHiddenParams(
 
 /** Format a Go value as a string for url.Values.Set(). */
 function goLiteralForQuery(value: string | number | boolean): string {
-  if (typeof value === 'string') return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (typeof value === 'string') return goStringLiteral(value);
   if (typeof value === 'boolean') return value ? `"true"` : `"false"`;
   return `fmt.Sprintf("%v", ${String(value)})`;
 }
@@ -1407,7 +1416,7 @@ function paginationDefaultsLiteral(op: Operation): string {
   for (const name of PAGINATION_DEFAULTS) {
     const param = op.queryParams.find((qp) => qp.name === name);
     if (param?.default != null) {
-      entries.push(`"${name}": "${param.default}"`);
+      entries.push(`${goStringLiteral(name)}: ${goStringLiteral(String(param.default))}`);
     }
   }
   if (entries.length === 0) return 'nil';

--- a/src/go/strings.ts
+++ b/src/go/strings.ts
@@ -1,0 +1,14 @@
+/** Render an interpreted Go string literal, including control characters. */
+export function goStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+/** Quote tag values separately from the source literal that contains the tags. */
+export function goStructTag(tags: Record<string, string>): string {
+  const content = Object.entries(tags)
+    .map(([key, value]) => `${key}:${goStringLiteral(value)}`)
+    .join(' ');
+  // Preserve idiomatic raw tags where possible; backticks require an
+  // interpreted literal with a second layer of escaping.
+  return content.includes('`') ? goStringLiteral(content) : `\`${content}\``;
+}

--- a/src/go/wrappers.ts
+++ b/src/go/wrappers.ts
@@ -1,3 +1,4 @@
+import { goStringLiteral } from './strings.js';
 import type { EmitterContext, ResolvedOperation, ResolvedWrapper } from '@workos/oagen';
 import {
   className as goClassName,
@@ -61,7 +62,7 @@ function emitWrapperBodyStruct(lines: string[], wrapper: ResolvedWrapper, wrappe
   for (const [key, value] of Object.entries(wrapper.defaults)) {
     const goField = goFieldName(key);
     const goType = typeof value === 'boolean' ? 'bool' : typeof value === 'number' ? 'int' : 'string';
-    lines.push(`\t${goField} ${goType} \`json:"${key}"\``);
+    lines.push(`\t${goField} ${goType} \`json:${goStringLiteral(key)}\``);
   }
 
   // Required exposed params
@@ -227,7 +228,7 @@ function emitWrapperMethod(
 
 /** Convert a value to a Go literal. */
 function goLiteral(value: string | number | boolean): string {
-  if (typeof value === 'string') return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (typeof value === 'string') return goStringLiteral(value);
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   return String(value);
 }

--- a/src/go/wrappers.ts
+++ b/src/go/wrappers.ts
@@ -1,4 +1,4 @@
-import { goStringLiteral } from './strings.js';
+import { goStringLiteral, goStructTag } from './strings.js';
 import type { EmitterContext, ResolvedOperation, ResolvedWrapper } from '@workos/oagen';
 import {
   className as goClassName,
@@ -62,7 +62,7 @@ function emitWrapperBodyStruct(lines: string[], wrapper: ResolvedWrapper, wrappe
   for (const [key, value] of Object.entries(wrapper.defaults)) {
     const goField = goFieldName(key);
     const goType = typeof value === 'boolean' ? 'bool' : typeof value === 'number' ? 'int' : 'string';
-    lines.push(`\t${goField} ${goType} \`json:${goStringLiteral(key)}\``);
+    lines.push(`\t${goField} ${goType} ${goStructTag({ json: key })}`);
   }
 
   // Required exposed params
@@ -70,13 +70,13 @@ function emitWrapperBodyStruct(lines: string[], wrapper: ResolvedWrapper, wrappe
     if (isOptional) continue;
     const goField = goFieldName(paramName);
     const goType = field ? resolveSimpleGoType(field.type) : 'string';
-    lines.push(`\t${goField} ${goType} \`json:"${paramName}"\``);
+    lines.push(`\t${goField} ${goType} ${goStructTag({ json: paramName })}`);
   }
 
   // Inferred fields (from client config) — omit when empty
   for (const inferred of wrapper.inferFromClient) {
     const goField = goFieldName(inferred);
-    lines.push(`\t${goField} string \`json:"${inferred},omitempty"\``);
+    lines.push(`\t${goField} string ${goStructTag({ json: inferred + ',omitempty' })}`);
   }
 
   // Optional exposed params
@@ -85,7 +85,7 @@ function emitWrapperBodyStruct(lines: string[], wrapper: ResolvedWrapper, wrappe
     const goField = goFieldName(paramName);
     const baseType = field ? resolveSimpleGoType(field.type) : 'string';
     const optType = baseType.startsWith('*') || baseType.startsWith('[]') ? baseType : `*${baseType}`;
-    lines.push(`\t${goField} ${optType} \`json:"${paramName},omitempty"\``);
+    lines.push(`\t${goField} ${optType} ${goStructTag({ json: paramName + ',omitempty' })}`);
   }
 
   lines.push('}');
@@ -115,9 +115,9 @@ function emitWrapperParamsStruct(
     }
     if (isOptional) {
       const optType = goType.startsWith('*') || goType.startsWith('[]') ? goType : `*${goType}`;
-      lines.push(`\t${goField} ${optType} \`json:"${paramName},omitempty"\``);
+      lines.push(`\t${goField} ${optType} ${goStructTag({ json: paramName + ',omitempty' })}`);
     } else {
-      lines.push(`\t${goField} ${goType} \`json:"${paramName}"\``);
+      lines.push(`\t${goField} ${goType} ${goStructTag({ json: paramName })}`);
     }
   }
 

--- a/src/node/discriminated-models.ts
+++ b/src/node/discriminated-models.ts
@@ -1,3 +1,5 @@
+import { tsStringLiteral, tsPropertyName, tsPropertyAccess } from './strings.js';
+import { docComment } from './utils.js';
 import type { EmitterContext, GeneratedFile, Model } from '@workos/oagen';
 import { toPascalCase, toCamelCase } from '@workos/oagen';
 import { loadRawSpec } from '../shared/model-utils.js';
@@ -446,7 +448,7 @@ function rawSchemaToTS(
     return isWire ? wireInterfaceName(domain) : domain;
   }
   if (typeof schema.const === 'string') {
-    return `'${schema.const}'`;
+    return tsStringLiteral(schema.const);
   }
   if (typeof schema.const === 'boolean') {
     return String(schema.const);
@@ -661,11 +663,11 @@ function buildInlineUnionAlias(name: string, shape: DiscriminatedShape, isWire: 
   shape.variants.forEach((variant, idx) => {
     const isLast = idx === shape.variants.length - 1;
     const discKey = isWire ? shape.discriminatorProperty : shape.discriminatorPropertyDomain;
-    const members = [`${discKey}: ${discLiteral(variant)}`];
+    const members = [`${tsPropertyName(discKey)}: ${discLiteral(variant)}`];
     for (const field of variant.fields) {
       const key = isWire ? field.name : toCamelCase(field.name);
       const opt = field.required ? '' : '?';
-      members.push(`${key}${opt}: ${inlineFieldType(field, isWire)}`);
+      members.push(`${tsPropertyName(key)}${opt}: ${inlineFieldType(field, isWire)}`);
     }
     lines.push(`  | { ${members.join('; ')} }${isLast ? ';' : ''}`);
   });
@@ -687,9 +689,9 @@ function buildInterfaceBody(name: string, shape: DiscriminatedShape, variant: Va
   // Discriminator (typed as the variant's const value)
   const discKey = isWire ? shape.discriminatorProperty : shape.discriminatorPropertyDomain;
   if (shape.discriminatorDescription) {
-    lines.push(`  /** ${shape.discriminatorDescription} */`);
+    lines.push(...docComment(shape.discriminatorDescription, 2));
   }
-  lines.push(`  ${discKey}: ${discLiteral(variant)};`);
+  lines.push(`  ${tsPropertyName(discKey)}: ${discLiteral(variant)};`);
   // Variant-specific fields
   for (const field of variant.fields) {
     pushFieldLine(lines, field, isWire);
@@ -703,7 +705,7 @@ function buildInterfaceBody(name: string, shape: DiscriminatedShape, variant: Va
  * bare for booleans (`true`).
  */
 function discLiteral(variant: VariantSpec): string {
-  return variant.discriminatorIsBoolean ? variant.discriminatorValue : `'${variant.discriminatorValue}'`;
+  return variant.discriminatorIsBoolean ? variant.discriminatorValue : tsStringLiteral(variant.discriminatorValue);
 }
 
 /**
@@ -718,7 +720,7 @@ function discLiteral(variant: VariantSpec): string {
  */
 function inlineFieldType(field: FieldSpec, isWire: boolean): string {
   if (field.enumValues) {
-    return field.enumValues.map((v) => `'${v}'`).join(' | ');
+    return field.enumValues.map((v) => tsStringLiteral(v)).join(' | ');
   }
   return isWire ? field.wireType : field.domainType;
 }
@@ -728,9 +730,9 @@ function pushFieldLine(lines: string[], field: FieldSpec, isWire: boolean): void
   const opt = field.required ? '' : '?';
   const type = isWire ? field.wireType : field.domainType;
   if (field.description) {
-    lines.push(`  /** ${field.description} */`);
+    lines.push(...docComment(field.description, 2));
   }
-  lines.push(`  ${key}${opt}: ${type};`);
+  lines.push(`  ${tsPropertyName(key)}${opt}: ${type};`);
 }
 
 interface ImportSpec {
@@ -814,7 +816,7 @@ function buildSerializerFile(plan: DiscriminatedPlan, _ctx: EmitterContext): Gen
 
   // Deserializer
   lines.push(`export const deserialize${domain} = (response: ${wire}): ${domain} => {`);
-  lines.push(`  switch (response.${shape.discriminatorProperty}) {`);
+  lines.push(`  switch (response${tsPropertyAccess(shape.discriminatorProperty)}) {`);
   for (const variant of shape.variants) {
     lines.push(`    case ${discLiteral(variant)}:`);
     lines.push(`      return {`);
@@ -829,7 +831,7 @@ function buildSerializerFile(plan: DiscriminatedPlan, _ctx: EmitterContext): Gen
   }
   lines.push(`    default:`);
   lines.push(
-    `      throw new Error(\`Unknown ${shape.discriminatorProperty}: \${String((response as Record<string, unknown>).${shape.discriminatorProperty})}\`);`,
+    `      throw new Error(${tsStringLiteral(`Unknown ${shape.discriminatorProperty}: `)} + String((response as Record<string, unknown>)${tsPropertyAccess(shape.discriminatorProperty)}));`,
   );
   lines.push(`  }`);
   lines.push(`};`);
@@ -845,7 +847,7 @@ function buildSerializerFile(plan: DiscriminatedPlan, _ctx: EmitterContext): Gen
       for (const field of shape.baseFields) {
         lines.push(`        ${assignmentLine(field, /*serialize*/ true, allDeps)},`);
       }
-      lines.push(`        ${shape.discriminatorProperty}: ${discLiteral(variant)},`);
+      lines.push(`        ${tsPropertyName(shape.discriminatorProperty)}: ${discLiteral(variant)},`);
       for (const field of variant.fields) {
         lines.push(`        ${assignmentLine(field, /*serialize*/ true, allDeps)},`);
       }
@@ -865,9 +867,9 @@ function buildSerializerFile(plan: DiscriminatedPlan, _ctx: EmitterContext): Gen
 function assignmentLine(field: FieldSpec, serialize: boolean, _allDeps: Set<string>): string {
   const camel = toCamelCase(field.name);
   const snake = field.name;
-  const lhs = serialize ? snake : camel;
+  const lhs = tsPropertyName(serialize ? snake : camel);
   const rhsKey = serialize ? camel : snake;
-  const source = serialize ? `model.${rhsKey}` : `response.${rhsKey}`;
+  const source = `${serialize ? 'model' : 'response'}${tsPropertyAccess(rhsKey)}`;
 
   if (field.hasDateTime) {
     if (serialize) {

--- a/src/node/enums.ts
+++ b/src/node/enums.ts
@@ -1,3 +1,4 @@
+import { tsStringLiteral } from './strings.js';
 import type { Enum, EmitterContext, GeneratedFile, Model, Service } from '@workos/oagen';
 import { collectFieldDependencies, toPascalCase, walkTypeRef } from '@workos/oagen';
 import { fileName, resolveServiceDir, buildServiceNameMap } from './naming.js';
@@ -22,7 +23,7 @@ import { isEnumInScope, declaredParams } from '../shared/resolved-ops.js';
  */
 function memberNameFor(value: string, taken: Set<string>): string {
   const pascal = toPascalCase(value);
-  const base = !pascal || /^[0-9]/.test(pascal) ? `Value${pascal || value}` : pascal;
+  const base = !pascal || /^[0-9]/.test(pascal) ? `Value${pascal}` : pascal;
   let name = base;
   let suffix = 2;
   while (taken.has(name)) name = `${base}${suffix++}`;
@@ -81,22 +82,25 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       // redeclare one of them.
       const takenMembers = new Set(Object.keys(baselineEnum.members));
       for (const [memberName, memberValue] of Object.entries(baselineEnum.members)) {
-        const valueStr = typeof memberValue === 'string' ? `'${memberValue}'` : String(memberValue);
+        const valueStr = typeof memberValue === 'string' ? tsStringLiteral(memberValue) : String(memberValue);
         lines.push(`  ${memberName} = ${valueStr},`);
       }
       for (const val of missingValues) {
         const memberName = memberNameFor(val, takenMembers);
-        lines.push(`  ${memberName} = '${val}',`);
+        lines.push(`  ${memberName} = ${tsStringLiteral(val)},`);
       }
       lines.push('}');
     } else if (baselineAlias?.value) {
-      const baselineValues = extractLiteralUnionValues(baselineAlias.value);
+      const baselineValues = extractLiteralUnionTokens(baselineAlias.value);
       const irValues = enumDef.values.map((v) => String(v.value));
-      const missing = irValues.filter((v) => !baselineValues.has(v));
+      const missing = irValues.filter(
+        (v) => !baselineValues.has(tsStringLiteral(v)) && !baselineValues.has(JSON.stringify(v)),
+      );
       hasNewValues = missing.length > 0;
       if (missing.length > 0) {
-        const allValues = [...baselineValues, ...missing];
-        const parts = allValues.map((v) => `'${v}'`);
+        // Keep baseline source intact: decoding and re-encoding escaped tokens
+        // would change wire values or lose non-literal union members.
+        const parts = [baselineAlias.value, ...missing.map(tsStringLiteral)];
         lines.push(`export type ${enumDef.name} = ${parts.join(' | ')};`);
       } else {
         lines.push(`export type ${enumDef.name} = ${baselineAlias.value};`);
@@ -148,7 +152,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         if (shipped && emitted.has(shipped)) continue;
         const memberName = shipped ?? memberNameFor(valueKey, taken);
         emitted.add(memberName);
-        const valueStr = typeof v.value === 'string' ? `'${v.value}'` : String(v.value);
+        const valueStr = typeof v.value === 'string' ? tsStringLiteral(v.value) : String(v.value);
         if (v.description || v.deprecated) {
           const parts: string[] = [];
           if (v.description) parts.push(v.description);
@@ -175,14 +179,8 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
   return files;
 }
 
-function extractLiteralUnionValues(aliasValue: string): Set<string> {
-  const values = new Set<string>();
-  const regex = /'([^']+)'/g;
-  let match;
-  while ((match = regex.exec(aliasValue)) !== null) {
-    values.add(match[1]);
-  }
-  return values;
+function extractLiteralUnionTokens(aliasValue: string): Set<string> {
+  return new Set(aliasValue.match(/'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g) ?? []);
 }
 
 export function assignEnumsToServices(

--- a/src/node/field-plan.ts
+++ b/src/node/field-plan.ts
@@ -1,3 +1,4 @@
+import { tsStringLiteral, tsPropertyAccess } from './strings.js';
 import type { Model, Field, EmitterContext, TypeRef, UnionType, PrimitiveType } from '@workos/oagen';
 import { mapTypeRef as tsMapTypeRef } from './type-map.js';
 import { fieldName, wireFieldName, fileName, resolveInterfaceName, wireInterfaceName } from './naming.js';
@@ -218,13 +219,14 @@ function renderDiscriminatorSwitch(
   for (const [value, modelName] of Object.entries(disc.mapping)) {
     const resolved = resolveInterfaceName(modelName, ctx);
     const fn = `${direction}${resolved}`;
-    cases.push(`case '${value}': return ${fn}(${expr} as any)`);
+    cases.push(`case ${tsStringLiteral(value)}: return ${fn}(${expr} as any)`);
   }
   // No mapping → passthrough. Without this guard, an empty `disc.mapping`
   // emits `switch { ; default: ... }` which is invalid TypeScript syntax
   // (the leading `;` looks like a stray statement before the first case).
   if (cases.length === 0) return expr;
-  return `(() => { switch ((${expr} as any).${disc.property}) { ${cases.join('; ')}; default: return ${expr} } })()`;
+
+  return `(() => { switch ((${expr} as any)${tsPropertyAccess(disc.property)}) { ${cases.join('; ')}; default: return ${expr} } })()`;
 }
 
 function renderAllOfMerge(
@@ -314,7 +316,7 @@ export function collectSerializedModelRefs(ref: TypeRef): string[] {
 export function defaultForType(ref: TypeRef): string | null {
   switch (ref.kind) {
     case 'literal':
-      return typeof ref.value === 'string' ? `'${ref.value}'` : String(ref.value);
+      return typeof ref.value === 'string' ? tsStringLiteral(ref.value) : String(ref.value);
     case 'enum':
       return null;
     case 'map':

--- a/src/node/resources.ts
+++ b/src/node/resources.ts
@@ -1,3 +1,4 @@
+import { tsStringLiteral } from './strings.js';
 // @oagen-ignore: Operation.async — all TypeScript SDK methods are async by nature
 
 import fs from 'node:fs';
@@ -1695,7 +1696,7 @@ function renderMethod(
       // Flatten all parts, splitting multiline descriptions into individual lines
       const allLines: string[] = [];
       for (const part of docParts) {
-        for (const line of part.split('\n')) {
+        for (const line of part.replace(/\*\//g, '*\u200b/').split('\n')) {
           allLines.push(line);
         }
       }
@@ -2355,7 +2356,7 @@ function renderGetMethod(
 
 /** Convert a JS value to a TypeScript literal. */
 function tsLiteral(value: string | number | boolean): string {
-  if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`;
+  if (typeof value === 'string') return tsStringLiteral(value);
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   return String(value);
 }
@@ -2697,7 +2698,7 @@ function renderUnionBodySerializer(
     const resolved = resolveInterfaceName(modelName, ctx);
     // Switch on a typed discriminator narrows `payload` to the variant, so the
     // serializer call type-checks without any casts.
-    cases.push(`case '${value}': return serialize${resolved}(payload)`);
+    cases.push(`case ${tsStringLiteral(value)}: return serialize${resolved}(payload)`);
   }
   // Assign `payload` to `never` in the default branch to get a compile-time
   // exhaustiveness check — if a new variant is added to the union but not to
@@ -2867,7 +2868,9 @@ function mapParamType(type: TypeRef, specEnumNames: Set<string>): string {
   if (type.kind === 'enum' && !specEnumNames.has(type.name)) {
     // Inline enum with no generated file — render values as string literal union
     if (type.values && type.values.length > 0) {
-      return type.values.map((v: string | number) => (typeof v === 'string' ? `'${v}'` : String(v))).join(' | ');
+      return type.values
+        .map((v: string | number) => (typeof v === 'string' ? tsStringLiteral(v) : String(v)))
+        .join(' | ');
     }
     return 'string';
   }

--- a/src/node/strings.ts
+++ b/src/node/strings.ts
@@ -1,0 +1,21 @@
+/** Render a single-quoted TypeScript string without changing its runtime value. */
+export function tsStringLiteral(value: string): string {
+  const escaped = value.replace(/['\\\x00-\x1f\u2028\u2029]/g, (char) =>
+    char === "'"
+      ? "\\'"
+      : JSON.stringify(char)
+          .slice(1, -1)
+          .replace(/\u2028/g, '\\u2028')
+          .replace(/\u2029/g, '\\u2029'),
+  );
+  return `'${escaped}'`;
+}
+
+/** Preserve ordinary property spelling and quote names that contain source syntax. */
+export function tsPropertyName(value: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(value) ? value : tsStringLiteral(value);
+}
+
+export function tsPropertyAccess(value: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(value) ? `.${value}` : `[${tsStringLiteral(value)}]`;
+}

--- a/src/node/type-map.ts
+++ b/src/node/type-map.ts
@@ -1,3 +1,4 @@
+import { tsStringLiteral } from './strings.js';
 import type { TypeRef, PrimitiveType, UnionType } from '@workos/oagen';
 import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
 import { wireInterfaceName } from './naming.js';
@@ -55,7 +56,7 @@ export function mapTypeRef(ref: TypeRef, opts?: MapTypeRefOpts): string {
     enum: (r) => inlineEnumUnions.get(r.name) ?? r.name,
     union: (r, variants) => joinUnionVariants(r, variants),
     nullable: (_r, inner) => `${inner} | null`,
-    literal: (r) => (typeof r.value === 'string' ? `'${r.value}'` : String(r.value)),
+    literal: (r) => (typeof r.value === 'string' ? tsStringLiteral(r.value) : String(r.value)),
     map: (_r, value) => `Record<string, ${value}>`,
   });
 }
@@ -73,7 +74,7 @@ export function mapWireTypeRef(ref: TypeRef, opts?: { genericDefaults?: Map<stri
     enum: (r) => inlineEnumUnions.get(r.name) ?? r.name,
     union: (r, variants) => joinUnionVariants(r, variants),
     nullable: (_r, inner) => `${inner} | null`,
-    literal: (r) => (typeof r.value === 'string' ? `'${r.value}'` : String(r.value)),
+    literal: (r) => (typeof r.value === 'string' ? tsStringLiteral(r.value) : String(r.value)),
     map: (_r, value) => `Record<string, ${value}>`,
   });
 }

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -49,7 +49,7 @@ export function relativeImport(fromFile: string, toFile: string): string {
  */
 export function docComment(description: string, indent = 0): string[] {
   const pad = ' '.repeat(indent);
-  const descLines = description.split('\n');
+  const descLines = description.replace(/\*\//g, '*\u200b/').split('\n');
   if (descLines.length === 1) {
     return [`${pad}/** ${descLines[0]} */`];
   }

--- a/src/node/wrappers.ts
+++ b/src/node/wrappers.ts
@@ -1,3 +1,4 @@
+import { tsStringLiteral } from './strings.js';
 import type { EmitterContext, ResolvedOperation, ResolvedWrapper } from '@workos/oagen';
 import { toCamelCase } from '@workos/oagen';
 import { fieldName, resolveInterfaceName, wireInterfaceName } from './naming.js';
@@ -90,11 +91,11 @@ function emitWrapperMethod(
   }
 
   if (docParts.length === 1) {
-    lines.push(`  /** ${docParts[0]} */`);
+    lines.push(`  /** ${docParts[0].replace(/\*\//g, '*\u200b/')} */`);
   } else {
     lines.push('  /**');
     for (const part of docParts) {
-      for (const line of part.split('\n')) {
+      for (const line of part.replace(/\*\//g, '*\u200b/').split('\n')) {
         lines.push(line === '' ? '   *' : `   * ${line}`);
       }
     }
@@ -144,7 +145,7 @@ function buildPathStr(op: { path: string; pathParams: Array<{ name: string }> })
 }
 
 function tsLiteral(value: string | number | boolean): string {
-  if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`;
+  if (typeof value === 'string') return tsStringLiteral(value);
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   return String(value);
 }

--- a/src/php/enums.ts
+++ b/src/php/enums.ts
@@ -1,3 +1,4 @@
+import { phpStringLiteral } from './strings.js';
 import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { toPascalCase } from '@workos/oagen';
 import { className, guardEnumCaseName, resolveEnumName } from './naming.js';
@@ -59,7 +60,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
       }
 
       if (typeof val.value === 'string') {
-        lines.push(`    case ${caseName} = '${val.value}';`);
+        lines.push(`    case ${caseName} = ${phpStringLiteral(val.value)};`);
       } else {
         lines.push(`    case ${caseName} = ${val.value};`);
       }

--- a/src/php/models.ts
+++ b/src/php/models.ts
@@ -1,3 +1,4 @@
+import { phpStringLiteral } from './strings.js';
 import type { Model, TypeRef, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { mapTypeRef, mapTypeRefForPHPDoc } from './type-map.js';
 import { className, enumClassName, domainFieldName } from './naming.js';
@@ -134,7 +135,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       // WIRE key: the JSON key emitted into the array (stays `field.name`).
       const wireName = field.name;
       const serialized = generateToArrayValue(field.type, `$this->${phpName}`, !field.required);
-      lines.push(`            '${wireName}' => ${serialized},`);
+      lines.push(`            ${phpStringLiteral(wireName)} => ${serialized},`);
     }
     lines.push('        ];');
     lines.push('    }');
@@ -189,22 +190,22 @@ function generateFromArrayAccessor(ref: TypeRef, wireName: string, required: boo
   const isNullable = ref.kind === 'nullable';
   if (!required || isNullable) {
     const innerRef = isNullable ? ref.inner : ref;
-    const inner = generateFromArrayValue(innerRef, `$data['${wireName}']`);
+    const inner = generateFromArrayValue(innerRef, `$data[${phpStringLiteral(wireName)}]`);
     if (isComplexType(innerRef)) {
-      return `isset($data['${wireName}']) ? ${inner} : null`;
+      return `isset($data[${phpStringLiteral(wireName)}]) ? ${inner} : null`;
     }
     if (isNullable) {
-      return `$data['${wireName}'] ?? null`;
+      return `$data[${phpStringLiteral(wireName)}] ?? null`;
     }
-    return `$data['${wireName}'] ?? null`;
+    return `$data[${phpStringLiteral(wireName)}] ?? null`;
   }
   // Literal fields have a statically known value; use ?? with a default
   // so deserialization is resilient when the API omits the key.
   if (ref.kind === 'literal') {
-    return `$data['${wireName}'] ?? ${phpLiteralDefault(ref.value)}`;
+    return `$data[${phpStringLiteral(wireName)}] ?? ${phpLiteralDefault(ref.value)}`;
   }
   // Required field: access directly
-  return generateFromArrayValue(ref, `$data['${wireName}']`);
+  return generateFromArrayValue(ref, `$data[${phpStringLiteral(wireName)}]`);
 }
 
 /**
@@ -252,11 +253,13 @@ function generateFromArrayValue(ref: TypeRef, accessor: string): string {
         const entries = Object.entries(ref.discriminator.mapping);
         if (entries.length > 0) {
           const arms = entries
-            .map(([value, modelName]) => `'${value}' => ${className(modelName)}::fromArray(${accessor})`)
+            .map(
+              ([value, modelName]) => `${phpStringLiteral(value)} => ${className(modelName)}::fromArray(${accessor})`,
+            )
             .join(', ');
           const discProp = ref.discriminator.property;
-          const throwArm = `default => throw new \\UnexpectedValueException(sprintf('Unknown ${discProp}: %s', json_encode(${accessor}['${discProp}'] ?? null)))`;
-          return `match (${accessor}['${discProp}'] ?? null) { ${arms}, ${throwArm} }`;
+          const throwArm = `default => throw new \\UnexpectedValueException(sprintf(${phpStringLiteral(`Unknown ${discProp}: %s`)}, json_encode(${accessor}[${phpStringLiteral(discProp)}] ?? null)))`;
+          return `match (${accessor}[${phpStringLiteral(discProp)}] ?? null) { ${arms}, ${throwArm} }`;
         }
       }
       const resolved = resolveDegenerateUnion(ref);
@@ -274,7 +277,7 @@ function generateFromArrayValue(ref: TypeRef, accessor: string): string {
 function phpLiteralDefault(value: string | number | boolean | null): string {
   if (value === null) return 'null';
   if (typeof value === 'boolean') return value ? 'true' : 'false';
-  if (typeof value === 'string') return `'${value}'`;
+  if (typeof value === 'string') return phpStringLiteral(value);
   return String(value);
 }
 

--- a/src/php/resources.ts
+++ b/src/php/resources.ts
@@ -1,3 +1,4 @@
+import { phpStringLiteral } from './strings.js';
 import type {
   Service,
   Operation,
@@ -274,10 +275,10 @@ function generateGroupDispatch(op: Operation, indent: string, target: '$query' |
         if (optionalNames.has(param.name)) {
           // Optional members stay off the wire when unset rather than being sent as null.
           lines.push(`${indent}    if (${accessor} !== null) {`);
-          lines.push(`${indent}        ${target}['${param.name}'] = ${accessor};`);
+          lines.push(`${indent}        ${target}[${phpStringLiteral(param.name)}] = ${accessor};`);
           lines.push(`${indent}    }`);
         } else {
-          lines.push(`${indent}    ${target}['${param.name}'] = ${accessor};`);
+          lines.push(`${indent}    ${target}[${phpStringLiteral(param.name)}] = ${accessor};`);
         }
       }
 
@@ -447,7 +448,7 @@ function generateMethod(
       }
       // Inject constant defaults
       for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
-        lines.push(`            '${key}' => ${phpLiteral(value)},`);
+        lines.push(`            ${phpStringLiteral(key)} => ${phpLiteral(value)},`);
       }
       if (hasOptionalQuery) {
         lines.push('        ], fn ($v) => $v !== null);');
@@ -456,7 +457,7 @@ function generateMethod(
       }
       // Inject fields from client config
       for (const clientField of getOpInferFromClient(resolvedOp)) {
-        lines.push(`        $query['${clientField}'] = ${clientFieldExpression(clientField)};`);
+        lines.push(`        $query[${phpStringLiteral(clientField)}] = ${clientFieldExpression(clientField)};`);
       }
       // Inject parameter group dispatch (instanceof checks)
       lines.push(...generateGroupDispatch(op, '        '));
@@ -525,11 +526,11 @@ function generateMethod(
           : isDateTimeType(field.type)
             ? `$${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED)`
             : `$${phpName}`;
-        lines.push(`            '${field.name}' => ${valueExpr},`);
+        lines.push(`            ${phpStringLiteral(field.name)} => ${valueExpr},`);
       }
       // Inject constant defaults
       for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
-        lines.push(`            '${key}' => ${phpLiteral(value)},`);
+        lines.push(`            ${phpStringLiteral(key)} => ${phpLiteral(value)},`);
       }
       if (hasOptionalFields) {
         lines.push('        ], fn ($v) => $v !== null);');
@@ -538,7 +539,7 @@ function generateMethod(
       }
       // Inject fields from client config
       for (const clientField of getOpInferFromClient(resolvedOp)) {
-        lines.push(`        $body['${clientField}'] = ${clientFieldExpression(clientField)};`);
+        lines.push(`        $body[${phpStringLiteral(clientField)}] = ${clientFieldExpression(clientField)};`);
       }
       // Inject parameter group dispatch into body
       if ((op.parameterGroups?.length ?? 0) > 0) {
@@ -586,11 +587,11 @@ function generateMethod(
         : isDateTimeType(field.type)
           ? `$${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED)`
           : `$${phpName}`;
-      lines.push(`            '${field.name}' => ${valueExpr},`);
+      lines.push(`            ${phpStringLiteral(field.name)} => ${valueExpr},`);
     }
     // Inject constant defaults
     for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
-      lines.push(`            '${key}' => ${phpLiteral(value)},`);
+      lines.push(`            ${phpStringLiteral(key)} => ${phpLiteral(value)},`);
     }
     if (hasOptionalFields) {
       lines.push('        ], fn ($v) => $v !== null);');
@@ -599,7 +600,7 @@ function generateMethod(
     }
     // Inject fields from client config
     for (const clientField of getOpInferFromClient(resolvedOp)) {
-      lines.push(`        $body['${clientField}'] = ${clientFieldExpression(clientField)};`);
+      lines.push(`        $body[${phpStringLiteral(clientField)}] = ${clientFieldExpression(clientField)};`);
     }
     // Inject parameter group dispatch into body so sensitive fields
     // (passwords, role slugs) never leak into the URL query string.
@@ -647,7 +648,7 @@ function generateMethod(
       }
       // Inject constant defaults
       for (const [key, value] of Object.entries(getOpDefaults(resolvedOp))) {
-        lines.push(`            '${key}' => ${phpLiteral(value)},`);
+        lines.push(`            ${phpStringLiteral(key)} => ${phpLiteral(value)},`);
       }
       if (hasOptionalQuery) {
         lines.push('        ], fn ($v) => $v !== null);');
@@ -656,7 +657,7 @@ function generateMethod(
       }
       // Inject fields from client config
       for (const clientField of getOpInferFromClient(resolvedOp)) {
-        lines.push(`        $query['${clientField}'] = ${clientFieldExpression(clientField)};`);
+        lines.push(`        $query[${phpStringLiteral(clientField)}] = ${clientFieldExpression(clientField)};`);
       }
       // Inject parameter group dispatch (instanceof checks)
       lines.push(...generateGroupDispatch(op, '        '));
@@ -845,13 +846,13 @@ function buildQueryArray(
         // non-nullable, so other optional enum params use the nullsafe op.
         const hasEnumDefault = shouldMaterializeQueryDefault(q, opts?.materializeQueryDefaults ?? true);
         const nullsafe = q.required || hasEnumDefault ? '' : '?';
-        return `'${q.name}' => $${phpName}${nullsafe}->value,`;
+        return `${phpStringLiteral(q.name)} => $${phpName}${nullsafe}->value,`;
       }
       if (isDateTimeType(q.type)) {
         const nullsafe = q.required ? '' : '?';
-        return `'${q.name}' => $${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED),`;
+        return `${phpStringLiteral(q.name)} => $${phpName}${nullsafe}->format(\\DateTimeInterface::RFC3339_EXTENDED),`;
       }
-      return `'${q.name}' => $${phpName},`;
+      return `${phpStringLiteral(q.name)} => $${phpName},`;
     });
 }
 
@@ -860,7 +861,7 @@ function shouldMaterializeQueryDefault(param: Parameter, enabled: boolean): bool
 }
 
 function phpLiteral(value: unknown): string {
-  if (typeof value === 'string') return `'${value}'`;
+  if (typeof value === 'string') return phpStringLiteral(value);
   if (typeof value === 'number') return String(value);
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   return 'null';

--- a/src/php/strings.ts
+++ b/src/php/strings.ts
@@ -1,0 +1,4 @@
+/** PHP single-quoted strings only interpret escaped quotes and backslashes. */
+export function phpStringLiteral(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}

--- a/src/php/utils.ts
+++ b/src/php/utils.ts
@@ -5,7 +5,7 @@
  */
 export function phpDocComment(description: string, indent = 0): string[] {
   const pad = ' '.repeat(indent);
-  const descLines = description.split('\n');
+  const descLines = description.replace(/\*\//g, '*\u200b/').split('\n');
   if (descLines.length === 1) {
     return [`${pad}/** ${descLines[0]} */`];
   }

--- a/src/php/wrappers.ts
+++ b/src/php/wrappers.ts
@@ -1,3 +1,4 @@
+import { phpStringLiteral } from './strings.js';
 import type { EmitterContext, ResolvedOperation, ResolvedWrapper, TypeRef } from '@workos/oagen';
 import { toCamelCase } from '@workos/oagen';
 import { mapTypeRef, mapTypeRefForPHPDoc } from './type-map.js';
@@ -81,7 +82,7 @@ function emitWrapperMethod(
   // Defaults (always included)
   if (wrapper.defaults) {
     for (const [key, value] of Object.entries(wrapper.defaults)) {
-      bodyEntries.push(`'${key}' => ${phpLiteral(value)}`);
+      bodyEntries.push(`${phpStringLiteral(key)} => ${phpLiteral(value)}`);
     }
   }
 
@@ -89,9 +90,9 @@ function emitWrapperMethod(
   for (const { paramName, field } of wrapperParams) {
     const phpName = fieldName(paramName);
     if (field && isEnumType(field.type)) {
-      bodyEntries.push(`'${paramName}' => $${phpName}?->value`);
+      bodyEntries.push(`${phpStringLiteral(paramName)} => $${phpName}?->value`);
     } else {
-      bodyEntries.push(`'${paramName}' => $${phpName}`);
+      bodyEntries.push(`${phpStringLiteral(paramName)} => $${phpName}`);
     }
   }
 
@@ -135,7 +136,7 @@ function isEnumType(ref: TypeRef): boolean {
 }
 
 function phpLiteral(value: unknown): string {
-  if (typeof value === 'string') return `'${value}'`;
+  if (typeof value === 'string') return phpStringLiteral(value);
   if (typeof value === 'number') return String(value);
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   return 'null';

--- a/src/python/enums.ts
+++ b/src/python/enums.ts
@@ -1,3 +1,4 @@
+import { pythonStringLiteral, pythonDocstring } from './strings.js';
 import type { Enum, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { toUpperSnakeCase } from '@workos/oagen';
 import { className, fileName, buildMountDirMap, dirToModule } from './naming.js';
@@ -181,7 +182,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         lines.push('');
         const literals = uniqueValues.map((v) =>
           typeof v.value === 'string'
-            ? `"${v.value}"`
+            ? pythonStringLiteral(v.value)
             : typeof v.value === 'boolean'
               ? v.value
                 ? 'True'
@@ -213,7 +214,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         usedNames.add(memberName);
         const valueStr =
           typeof v.value === 'string'
-            ? `"${v.value}"`
+            ? pythonStringLiteral(v.value)
             : typeof v.value === 'boolean'
               ? v.value
                 ? 'True'
@@ -224,7 +225,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
           const parts: string[] = [];
           if (v.description) parts.push(v.description);
           if (v.deprecated) parts.push('.. deprecated::');
-          lines.push(`    """${parts.join('\n\n    ')}"""`);
+          lines.push(`    """${pythonDocstring(parts.join('\n\n    '))}"""`);
         }
       }
       if (allStrings) {
@@ -243,7 +244,7 @@ export function generateEnums(enums: Enum[], ctx: EmitterContext): GeneratedFile
         `${cls}Literal: TypeAlias = Literal[${uniqueValues
           .map((v) =>
             typeof v.value === 'string'
-              ? `"${v.value}"`
+              ? pythonStringLiteral(v.value)
               : typeof v.value === 'boolean'
                 ? v.value
                   ? 'True'

--- a/src/python/models.ts
+++ b/src/python/models.ts
@@ -1,3 +1,4 @@
+import { pythonStringLiteral, pythonDocstring } from './strings.js';
 import type { Model, EmitterContext, GeneratedFile } from '@workos/oagen';
 import { collectFieldDependencies, walkTypeRef } from '@workos/oagen';
 import { mapTypeRef } from './type-map.js';
@@ -149,29 +150,31 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       // Dispatcher class
       if (model.description) {
         dispLines.push(`class ${modelClassName}:`);
-        dispLines.push(`    """${model.description}"""`);
+        dispLines.push(`    """${pythonDocstring(model.description)}"""`);
       } else {
         dispLines.push(`class ${modelClassName}:`);
-        dispLines.push(`    """Discriminated union dispatcher (discriminated by '${disc.property}')."""`);
+        dispLines.push(
+          `    """Discriminated union dispatcher (discriminated by '${pythonDocstring(disc.property)}')."""`,
+        );
       }
       dispLines.push('');
       dispLines.push(`    _DISPATCH: ClassVar[Dict[str, type]] = {`);
       for (const [value, variantModelName] of Object.entries(disc.mapping).sort(([a], [b]) => a.localeCompare(b))) {
-        dispLines.push(`        "${value}": ${className(variantModelName)},`);
+        dispLines.push(`        ${pythonStringLiteral(value)}: ${className(variantModelName)},`);
       }
       dispLines.push('    }');
       dispLines.push('');
       dispLines.push('    @classmethod');
       dispLines.push(`    def from_dict(cls, data: Dict[str, Any]) -> "${variantTypeName}":`);
       dispLines.push('        """Deserialize from a dictionary, dispatching to the correct variant."""');
-      dispLines.push(`        if "${disc.property}" not in data:`);
+      dispLines.push(`        if ${pythonStringLiteral(disc.property)} not in data:`);
       dispLines.push(
-        `            _raise_deserialize_error("${modelClassName}", ValueError("Missing required field '${disc.property}'"))`,
+        `            _raise_deserialize_error("${modelClassName}", ValueError(${pythonStringLiteral(`Missing required field '${disc.property}'`)}))`,
       );
-      dispLines.push(`        disc_value = data["${disc.property}"]`);
+      dispLines.push(`        disc_value = data[${pythonStringLiteral(disc.property)}]`);
       dispLines.push('        if disc_value is None:');
       dispLines.push(
-        `            _raise_deserialize_error("${modelClassName}", ValueError("${disc.property} must not be None"))`,
+        `            _raise_deserialize_error("${modelClassName}", ValueError(${pythonStringLiteral(`${disc.property} must not be None`)}))`,
       );
       dispLines.push('        dispatch_cls = cls._DISPATCH.get(disc_value)');
       dispLines.push('        if dispatch_cls is not None:');
@@ -346,7 +349,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
     lines.push('@dataclass(slots=True)');
     lines.push(`class ${modelClassName}:`);
     if (model.description) {
-      lines.push(`    """${model.description}"""`);
+      lines.push(`    """${pythonDocstring(model.description)}"""`);
     } else {
       // Generate a default docstring from the class name when the spec
       // doesn't provide a description.
@@ -382,7 +385,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
         if (field.description) parts.push(field.description);
         if (field.deprecated) parts.push('.. deprecated:: This field is deprecated.');
         lines.push(`    ${pyFieldName}: ${pyType}`);
-        lines.push(`    """${parts.join('\n\n    ')}"""`);
+        lines.push(`    """${pythonDocstring(parts.join('\n\n    '))}"""`);
       } else {
         lines.push(`    ${pyFieldName}: ${pyType}`);
       }
@@ -399,7 +402,7 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
         if (field.description) parts.push(field.description);
         if (field.deprecated) parts.push('.. deprecated:: This field is deprecated.');
         lines.push(`    ${pyFieldName}: ${pyType} = None`);
-        lines.push(`    """${parts.join('\n\n    ')}"""`);
+        lines.push(`    """${pythonDocstring(parts.join('\n\n    '))}"""`);
       } else {
         lines.push(`    ${pyFieldName}: ${pyType} = None`);
       }
@@ -432,9 +435,9 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       if (field.type.kind === 'literal' && isRequired) {
         // Required literal fields have a statically known value; use .get() with a default
         // so deserialization is resilient when the API omits the key.
-        accessor = `data.get("${wireKey}", ${pythonLiteralDefault(field.type.value)})`;
+        accessor = `data.get(${pythonStringLiteral(wireKey)}, ${pythonLiteralDefault(field.type.value)})`;
       } else {
-        accessor = isRequired ? `data["${wireKey}"]` : `data.get("${wireKey}")`;
+        accessor = isRequired ? `data[${pythonStringLiteral(wireKey)}]` : `data.get(${pythonStringLiteral(wireKey)})`;
       }
       // For deserialization expressions, nullable types must always handle None
       // even when the field itself is required (the key must be present, but value can be null).
@@ -467,20 +470,20 @@ export function generateModels(models: Model[], ctx: EmitterContext): GeneratedF
       if (isRequired && !isNullable) {
         // Required non-nullable: always serialize directly
         const serExpr = serializeField(field.type, `self.${pyFieldName}`);
-        lines.push(`        result["${wireKey}"] = ${serExpr}`);
+        lines.push(`        result[${pythonStringLiteral(wireKey)}] = ${serExpr}`);
       } else if (isNullable) {
         // Nullable fields should round-trip explicit None as null, even when optional
         const innerType = (field.type as any).inner;
         const serExpr = serializeField(innerType, `self.${pyFieldName}`);
         lines.push(`        if self.${pyFieldName} is not None:`);
-        lines.push(`            result["${wireKey}"] = ${serExpr}`);
+        lines.push(`            result[${pythonStringLiteral(wireKey)}] = ${serExpr}`);
         lines.push(`        else:`);
-        lines.push(`            result["${wireKey}"] = None`);
+        lines.push(`            result[${pythonStringLiteral(wireKey)}] = None`);
       } else {
         // Optional non-nullable fields should be omitted when unset
         const serExpr = serializeField(field.type, `self.${pyFieldName}`);
         lines.push(`        if self.${pyFieldName} is not None:`);
-        lines.push(`            result["${wireKey}"] = ${serExpr}`);
+        lines.push(`            result[${pythonStringLiteral(wireKey)}] = ${serExpr}`);
       }
     }
 
@@ -814,7 +817,7 @@ function isOptionalField(modelName: string, field: Model['fields'][number], ctx:
 function pythonLiteralDefault(value: string | number | boolean | null): string {
   if (value === null) return 'None';
   if (typeof value === 'boolean') return value ? 'True' : 'False';
-  if (typeof value === 'string') return `"${value}"`;
+  if (typeof value === 'string') return pythonStringLiteral(value);
   return String(value);
 }
 
@@ -882,17 +885,17 @@ function renderDiscriminatedUnionPrelude(
   const dispatchBlock = (innerIndent: string): string[] => {
     const lines: string[] = [];
     lines.push(`${innerIndent}${dataVar} = cast(Dict[str, Any], ${rawVar})`);
-    lines.push(`${innerIndent}${typeVar} = cast(str, ${dataVar}.get("${discProp}"))`);
+    lines.push(`${innerIndent}${typeVar} = cast(str, ${dataVar}.get(${pythonStringLiteral(discProp)}))`);
     lines.push(`${innerIndent}${mapVar}: Dict[str, Any] = {`);
     for (const [value, variantModelName] of entries) {
-      lines.push(`${innerIndent}    "${value}": ${className(variantModelName)},`);
+      lines.push(`${innerIndent}    ${pythonStringLiteral(value)}: ${className(variantModelName)},`);
     }
     lines.push(`${innerIndent}}`);
     lines.push(`${innerIndent}${clsVar} = ${mapVar}.get(${typeVar})`);
     lines.push(`${innerIndent}if ${clsVar} is None:`);
     lines.push(`${innerIndent}    raise ValueError(`);
     lines.push(
-      `${innerIndent}        f"Unknown discriminator '${discProp}' for ${parentClassName}.${pyFieldName}: {${typeVar}!r}. "`,
+      `${innerIndent}        ${pythonStringLiteral(`Unknown discriminator '${discProp}' for ${parentClassName}.${pyFieldName}: `)} f"{${typeVar}!r}. "`,
     );
     lines.push(`${innerIndent}        f"Expected one of {sorted(${mapVar})}."`);
     lines.push(`${innerIndent}    )`);
@@ -901,13 +904,13 @@ function renderDiscriminatedUnionPrelude(
 
   const prelude: string[] = [];
   if (isRequired && !nullable) {
-    prelude.push(`${indent}${rawVar} = data["${wireKey}"]`);
+    prelude.push(`${indent}${rawVar} = data[${pythonStringLiteral(wireKey)}]`);
     prelude.push(...dispatchBlock(indent));
     return { prelude, expr: `${clsVar}.from_dict(${dataVar})` };
   }
 
   // Optional or nullable: handle missing/None explicitly.
-  const accessor = isRequired ? `data["${wireKey}"]` : `data.get("${wireKey}")`;
+  const accessor = isRequired ? `data[${pythonStringLiteral(wireKey)}]` : `data.get(${pythonStringLiteral(wireKey)})`;
   prelude.push(`${indent}${rawVar} = ${accessor}`);
   prelude.push(`${indent}if ${rawVar} is None:`);
   prelude.push(`${indent}    ${valueVar} = None`);

--- a/src/python/resources.ts
+++ b/src/python/resources.ts
@@ -1,3 +1,4 @@
+import { pythonStringLiteral, pythonDocstring } from './strings.js';
 import type {
   Service,
   Operation,
@@ -181,7 +182,7 @@ interface SignatureMetadata {
 
 function emitDocArg(lines: string[], name: string, desc?: string): void {
   const fallback = `The ${name.replace(/_/g, ' ')}.`;
-  const description = desc ?? fallback;
+  const description = pythonDocstring(desc ?? fallback);
   const descLines = description
     .split('\n')
     .map((line) => line.trim())
@@ -436,7 +437,7 @@ function emitMethodDocstring(
 
   // Description — indent continuation lines to align with the opening `"""`
   if (op.description) {
-    const descLines = op.description.split('\n');
+    const descLines = pythonDocstring(op.description).split('\n');
     const indentedDesc = descLines
       .map((line, i) => (i === 0 ? line : line.trim() === '' ? '' : `        ${line}`))
       .join('\n');
@@ -570,7 +571,7 @@ function emitMethodDocstring(
   if (returnType !== 'None') {
     lines.push('');
     lines.push('        Returns:');
-    lines.push(`            ${returnType}`);
+    lines.push(`            ${pythonDocstring(returnType)}`);
   }
 
   // Per-operation error documentation from spec error responses
@@ -578,7 +579,7 @@ function emitMethodDocstring(
   lines.push('');
   lines.push('        Raises:');
   for (const line of errorRaises) {
-    lines.push(`            ${line}`);
+    lines.push(`            ${pythonDocstring(line)}`);
   }
   if (op.deprecated) {
     lines.push('');
@@ -659,13 +660,13 @@ function emitMethodBody(
         const value = param
           ? serializeParameterValue(param.type, entry.varName, false, (param as ParameterExt).explode)
           : entry.varName;
-        lines.push(`            "${entry.key}": ${value},`);
+        lines.push(`            ${pythonStringLiteral(entry.key)}: ${value},`);
       }
       lines.push('        }.items() if v is not None}');
       // Inject constant defaults
       if (Object.keys(opDefaults).length > 0) {
         for (const [key, value] of Object.entries(opDefaults)) {
-          lines.push(`        params["${key}"] = ${pythonLiteral(value)}`);
+          lines.push(`        params[${pythonStringLiteral(key)}] = ${pythonLiteral(value)}`);
         }
       }
       // Inject fields from client config. Fields surfaced as optional
@@ -675,11 +676,11 @@ function emitMethodBody(
         for (const field of opInferFromClient) {
           const expr = clientFieldExpression(field);
           if (clientOverrides.has(field)) {
-            lines.push(`        if "${field}" not in params and ${expr} is not None:`);
+            lines.push(`        if ${pythonStringLiteral(field)} not in params and ${expr} is not None:`);
           } else {
             lines.push(`        if ${expr} is not None:`);
           }
-          lines.push(`            params["${field}"] = ${expr}`);
+          lines.push(`            params[${pythonStringLiteral(field)}] = ${expr}`);
         }
       }
       if (usesClientCredentialDefaults) {
@@ -719,13 +720,13 @@ function emitMethodBody(
       if (paginatedGroupedParams.has(param.name)) continue;
       const pn = fieldName(param.name);
       const value = serializeParameterValue(param.type, pn, param.required, (param as ParameterExt).explode);
-      lines.push(`            "${param.name}": ${value},`);
+      lines.push(`            ${pythonStringLiteral(param.name)}: ${value},`);
     }
     lines.push('        }.items() if v is not None}');
     // Inject constant defaults
     if (Object.keys(opDefaults).length > 0) {
       for (const [key, value] of Object.entries(opDefaults)) {
-        lines.push(`        params["${key}"] = ${pythonLiteral(value)}`);
+        lines.push(`        params[${pythonStringLiteral(key)}] = ${pythonLiteral(value)}`);
       }
     }
     // Inject fields from client config
@@ -733,7 +734,7 @@ function emitMethodBody(
       for (const field of opInferFromClient) {
         const expr = clientFieldExpression(field);
         lines.push(`        if ${expr} is not None:`);
-        lines.push(`            params["${field}"] = ${expr}`);
+        lines.push(`            params[${pythonStringLiteral(field)}] = ${expr}`);
       }
     }
     // isinstance dispatch for parameter groups
@@ -777,7 +778,7 @@ function emitMethodBody(
         // Inject constant defaults into body
         if (Object.keys(opDefaults).length > 0) {
           for (const [key, value] of Object.entries(opDefaults)) {
-            lines.push(`        body["${key}"] = ${pythonLiteral(value)}`);
+            lines.push(`        body[${pythonStringLiteral(key)}] = ${pythonLiteral(value)}`);
           }
         }
         // Inject fields from client config into body
@@ -785,7 +786,7 @@ function emitMethodBody(
           for (const field of opInferFromClient) {
             const expr = clientFieldExpression(field);
             lines.push(`        if ${expr} is not None:`);
-            lines.push(`            body["${field}"] = ${expr}`);
+            lines.push(`            body[${pythonStringLiteral(field)}] = ${expr}`);
           }
         }
         // isinstance dispatch for parameter groups into body
@@ -823,7 +824,7 @@ function emitMethodBody(
       // Inject constant defaults into body
       if (Object.keys(opDefaults).length > 0) {
         for (const [key, value] of Object.entries(opDefaults)) {
-          lines.push(`        body["${key}"] = ${pythonLiteral(value)}`);
+          lines.push(`        body[${pythonStringLiteral(key)}] = ${pythonLiteral(value)}`);
         }
       }
       // Inject fields from client config into body
@@ -831,7 +832,7 @@ function emitMethodBody(
         for (const field of opInferFromClient) {
           const expr = clientFieldExpression(field);
           lines.push(`        if ${expr} is not None:`);
-          lines.push(`            body["${field}"] = ${expr}`);
+          lines.push(`            body[${pythonStringLiteral(field)}] = ${expr}`);
         }
       }
       // isinstance dispatch for parameter groups into body
@@ -927,7 +928,7 @@ function emitMethodBody(
         for (const param of visibleQueryParams) {
           const pn = fieldName(param.name);
           const value = serializeParameterValue(param.type, pn, param.required, (param as ParameterExt).explode);
-          lines.push(`            "${param.name}": ${value},`);
+          lines.push(`            ${pythonStringLiteral(param.name)}: ${value},`);
         }
         lines.push('        }.items() if v is not None}');
       } else if (visibleQueryParams.length > 0) {
@@ -935,7 +936,7 @@ function emitMethodBody(
         for (const param of visibleQueryParams) {
           const pn = fieldName(param.name);
           const value = serializeParameterValue(param.type, pn, param.required, (param as ParameterExt).explode);
-          lines.push(`            "${param.name}": ${value},`);
+          lines.push(`            ${pythonStringLiteral(param.name)}: ${value},`);
         }
         lines.push('        }');
       } else {
@@ -945,7 +946,7 @@ function emitMethodBody(
       // Inject constant defaults
       if (Object.keys(opDefaults).length > 0) {
         for (const [key, value] of Object.entries(opDefaults)) {
-          lines.push(`        params["${key}"] = ${pythonLiteral(value)}`);
+          lines.push(`        params[${pythonStringLiteral(key)}] = ${pythonLiteral(value)}`);
         }
       }
       // Inject fields from client config. Fields surfaced as optional
@@ -955,11 +956,11 @@ function emitMethodBody(
         for (const field of opInferFromClient) {
           const expr = clientFieldExpression(field);
           if (clientOverrides.has(field)) {
-            lines.push(`        if "${field}" not in params and ${expr} is not None:`);
+            lines.push(`        if ${pythonStringLiteral(field)} not in params and ${expr} is not None:`);
           } else {
             lines.push(`        if ${expr} is not None:`);
           }
-          lines.push(`            params["${field}"] = ${expr}`);
+          lines.push(`            params[${pythonStringLiteral(field)}] = ${expr}`);
         }
       }
       if (usesClientCredentialDefaults) {
@@ -1062,9 +1063,9 @@ function emitGroupDispatch(
           // Optional variant members are omitted from the wire format when
           // unset rather than sent as null.
           lines.push(`            ${indent}if ${groupParam}.${pyField} is not None:`);
-          lines.push(`                ${indent}${target}["${param.name}"] = ${value}`);
+          lines.push(`                ${indent}${target}[${pythonStringLiteral(param.name)}] = ${value}`);
         } else {
-          lines.push(`            ${indent}${target}["${param.name}"] = ${value}`);
+          lines.push(`            ${indent}${target}[${pythonStringLiteral(param.name)}] = ${value}`);
         }
       }
     }
@@ -1462,7 +1463,7 @@ function emitQueryParamsDict(
     lines.push('        params: Dict[str, Any] = {k: v for k, v in {');
     for (const param of queryParams) {
       lines.push(
-        `            "${param.name}": ${serializeParameterValue(param.type, fieldName(param.name), param.required, (param as ParameterExt).explode)},`,
+        `            ${pythonStringLiteral(param.name)}: ${serializeParameterValue(param.type, fieldName(param.name), param.required, (param as ParameterExt).explode)},`,
       );
     }
     lines.push('        }.items() if v is not None}');
@@ -1470,7 +1471,7 @@ function emitQueryParamsDict(
     lines.push('        params: Dict[str, Any] = {');
     for (const param of queryParams) {
       lines.push(
-        `            "${param.name}": ${serializeParameterValue(param.type, fieldName(param.name), param.required, (param as ParameterExt).explode)},`,
+        `            ${pythonStringLiteral(param.name)}: ${serializeParameterValue(param.type, fieldName(param.name), param.required, (param as ParameterExt).explode)},`,
       );
     }
     lines.push('        }');
@@ -1504,7 +1505,7 @@ function emitBodyDict(
     lines.push('        body: Dict[str, Any] = {k: v for k, v in {');
     for (const f of literalFields) {
       lines.push(
-        `            "${f.name}": ${serializeBodyFieldValue(f.type, bodyParamName(f, pathParamNames), f.required ?? false)},`,
+        `            ${pythonStringLiteral(f.name)}: ${serializeBodyFieldValue(f.type, bodyParamName(f, pathParamNames), f.required ?? false)},`,
       );
     }
     lines.push('        }.items() if v is not None}');
@@ -1512,7 +1513,7 @@ function emitBodyDict(
     lines.push('        body: Dict[str, Any] = {');
     for (const f of literalFields) {
       lines.push(
-        `            "${f.name}": ${serializeBodyFieldValue(f.type, bodyParamName(f, pathParamNames), f.required ?? false)},`,
+        `            ${pythonStringLiteral(f.name)}: ${serializeBodyFieldValue(f.type, bodyParamName(f, pathParamNames), f.required ?? false)},`,
       );
     }
     lines.push('        }');
@@ -1526,7 +1527,9 @@ function emitBodyDict(
     // type checker narrows `NotGiven` out of the union — required when the
     // value is transformed (e.g. `.to_dict()` on a nullable model/array field).
     lines.push(`        if not isinstance(${varName}, NotGiven):`);
-    lines.push(`            body["${f.name}"] = ${serializeBodyFieldValue(f.type, varName, f.required ?? false)}`);
+    lines.push(
+      `            body[${pythonStringLiteral(f.name)}] = ${serializeBodyFieldValue(f.type, varName, f.required ?? false)}`,
+    );
   }
 }
 

--- a/src/python/strings.ts
+++ b/src/python/strings.ts
@@ -1,0 +1,9 @@
+/** Render spec data as an ordinary Python string, never an f-string. */
+export function pythonStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+/** Escape triple-quoted docstring content while retaining readable line breaks. */
+export function pythonDocstring(value: string): string {
+  return value.replace(/[\\"\x00-\x1f\x7f]/g, (char) => (char === '\n' ? char : JSON.stringify(char).slice(1, -1)));
+}

--- a/src/python/type-map.ts
+++ b/src/python/type-map.ts
@@ -1,3 +1,4 @@
+import { pythonStringLiteral } from './strings.js';
 import type { TypeRef, PrimitiveType, UnionType } from '@workos/oagen';
 import { mapTypeRef as irMapTypeRef } from '@workos/oagen';
 import { className } from './naming.js';
@@ -22,7 +23,7 @@ export function mapTypeRef(ref: TypeRef): string {
     },
     literal: (r) =>
       typeof r.value === 'string'
-        ? `Literal["${r.value}"]`
+        ? `Literal[${pythonStringLiteral(r.value)}]`
         : r.value === null
           ? 'None'
           : `Literal[${toPythonLiteral(r.value)}]`,
@@ -57,7 +58,7 @@ export function mapTypeRefUnquoted(ref: TypeRef, knownEnums?: Set<string>, allow
     },
     literal: (r) =>
       typeof r.value === 'string'
-        ? `Literal["${r.value}"]`
+        ? `Literal[${pythonStringLiteral(r.value)}]`
         : r.value === null
           ? 'None'
           : `Literal[${toPythonLiteral(r.value)}]`,

--- a/src/python/wrappers.ts
+++ b/src/python/wrappers.ts
@@ -1,3 +1,4 @@
+import { pythonStringLiteral } from './strings.js';
 import type { EmitterContext, ResolvedOperation, ResolvedWrapper, Model } from '@workos/oagen';
 import { toSnakeCase } from '@workos/oagen';
 import { className, fieldName } from './naming.js';
@@ -95,7 +96,7 @@ function emitWrapperMethod(
 
   // Constant defaults
   for (const [key, value] of Object.entries(wrapper.defaults)) {
-    lines.push(`            "${key}": ${pythonLiteral(value)},`);
+    lines.push(`            ${pythonStringLiteral(key)}: ${pythonLiteral(value)},`);
   }
 
   // Exposed params (required ones go directly)
@@ -163,7 +164,7 @@ function emitWrapperMethod(
 
 /** Convert a value to a Python literal. */
 export function pythonLiteral(value: string | number | boolean): string {
-  if (typeof value === 'string') return `"${value.replace(/"/g, '\\"')}"`;
+  if (typeof value === 'string') return pythonStringLiteral(value);
   if (typeof value === 'boolean') return value ? 'True' : 'False';
   return String(value);
 }

--- a/test/spec-metadata-escaping.test.ts
+++ b/test/spec-metadata-escaping.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { stripTypeScriptTypes } from 'node:module';
+import type { ApiSpec, EmitterContext, Enum, GeneratedFile, Model, Service } from '@workos/oagen';
+import { defaultSdkBehavior } from '@workos/oagen';
+import { generateModels as pythonModels } from '../src/python/models.js';
+import { generateEnums as pythonEnums } from '../src/python/enums.js';
+import { generateResources as pythonResources } from '../src/python/resources.js';
+import { pythonLiteral } from '../src/python/wrappers.js';
+import { mapTypeRef as pythonType, mapTypeRefUnquoted as pythonUnquotedType } from '../src/python/type-map.js';
+import { generateEnums as nodeEnums } from '../src/node/enums.js';
+import { generateDiscriminatedFiles } from '../src/node/discriminated-models.js';
+import { generateResources as nodeResources } from '../src/node/resources.js';
+import { generateEnums as goEnums } from '../src/go/enums.js';
+import { generateModels as nodeModels } from '../src/node/models.js';
+import { mapTypeRef as nodeType, mapWireTypeRef as nodeWireType } from '../src/node/type-map.js';
+import { docComment } from '../src/node/utils.js';
+import { generateEnums as phpEnums } from '../src/php/enums.js';
+import { generateModels as phpModels } from '../src/php/models.js';
+import { phpDocComment } from '../src/php/utils.js';
+import { generateModels as goModels } from '../src/go/models.js';
+import { generateResources as goResources } from '../src/go/resources.js';
+import { goStructTag } from '../src/go/strings.js';
+import { generateEnums as dotnetEnums } from '../src/dotnet/enums.js';
+import { emitJsonPropertyAttributes } from '../src/dotnet/type-map.js';
+import { csLiteral, escapeCsAttributeString, escapeXml } from '../src/dotnet/naming.js';
+
+const emptySpec: ApiSpec = {
+  name: 'Test',
+  version: '1.0.0',
+  baseUrl: '',
+  services: [],
+  models: [],
+  enums: [],
+  sdk: defaultSdkBehavior(),
+};
+function context(spec: Partial<ApiSpec> = {}): EmitterContext {
+  return { namespace: 'workos', namespacePascal: 'WorkOS', spec: { ...emptySpec, ...spec } };
+}
+const text = (files: GeneratedFile[]) => files.map((file) => file.content).join('\n');
+const docPayload = 'Documentation."""\n    _injected = True\n    _doc = """internal\\';
+const literalPayload = 'x"; _injected = True; _ = "y\\\n\r\t\0';
+const blockPayload = 'end */ globalThis._injected = true; /* still docs';
+const enumSpec = (value: string, description?: string): Enum[] => [
+  {
+    name: 'Status',
+    values: [
+      { name: 'active', value: 'active' },
+      { name: 'evil', value, description },
+    ],
+  },
+];
+function service(description?: string): Service {
+  return {
+    name: 'Things',
+    operations: [
+      {
+        name: 'createThing',
+        httpMethod: 'post',
+        path: '/things',
+        pathParams: [],
+        queryParams: [{ name: 'query', type: { kind: 'primitive', type: 'string' }, required: false, description }],
+        headerParams: [],
+        requestBody: { kind: 'model', name: 'Thing' },
+        response: { kind: 'model', name: 'Thing' },
+        description,
+        errors: [],
+        injectIdempotencyKey: false,
+      },
+    ],
+  };
+}
+function model(name = literalPayload, description = docPayload): Model {
+  return {
+    name: 'Thing',
+    description,
+    fields: [
+      { name, domainName: 'value', required: true, type: { kind: 'literal', value: literalPayload }, description },
+      { name: 'optional', required: false, type: { kind: 'primitive', type: 'string' }, description },
+    ],
+  };
+}
+
+// Parse generated Python with the actual target parser. Never inherit SDK credentials.
+// /usr/bin avoids local version-manager shims; CI's python3 is the fallback.
+const python = process.platform === 'darwin' ? '/usr/bin/python3' : 'python3';
+function pythonAst(files: GeneratedFile[]): any[] {
+  const result = spawnSync(
+    python,
+    [
+      '-I',
+      '-c',
+      `
+import ast, json, sys
+result = []
+for file in json.load(sys.stdin):
+    tree = ast.parse(file['content'], filename=file['path'])
+    # An injected statement must not survive outside literal/comment content.
+    assert not any(isinstance(n, ast.Name) and n.id == '_injected' for n in ast.walk(tree))
+    result.append({
+        'constants': [n.value for n in ast.walk(tree) if isinstance(n, ast.Constant) and isinstance(n.value, str)],
+        'docs': [ast.get_docstring(n, clean=False) for n in ast.walk(tree) if isinstance(n, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))],
+    })
+print(json.dumps(result))
+`,
+    ],
+    { input: JSON.stringify(files), encoding: 'utf8', env: { PATH: process.env.PATH }, timeout: 10000 },
+  );
+  expect(result.error).toBeUndefined();
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+  return JSON.parse(result.stdout);
+}
+
+function evaluateTypeScript(source: string): Record<string, unknown> {
+  const output = stripTypeScriptTypes(source).replace(/^export /gm, '');
+  const sandbox = { _injected: false, result: {} };
+  runInNewContext(output + '\nresult = typeof Status === "undefined" ? {} : { Status };', sandbox, { timeout: 1000 });
+  expect(sandbox._injected).toBe(false);
+  return sandbox.result;
+}
+
+describe('VULN-2366: spec metadata remains data', () => {
+  it('Python model and field docstrings, wire keys, and literal defaults parse intact', () => {
+    const models = [model()];
+    const ast = pythonAst(pythonModels(models, context({ models })));
+    const constants = ast.flatMap((file) => file.constants);
+    expect(constants).toContain(docPayload);
+    expect(constants).toContain(literalPayload);
+    expect(ast.flatMap((file) => file.docs)).toContain(docPayload);
+    for (const render of [pythonType, pythonUnquotedType]) {
+      const type = render({ kind: 'literal', value: literalPayload });
+      expect(pythonAst([{ path: 'type.py', content: `value: ${type}` }])[0].constants).toContain(literalPayload);
+    }
+    expect(
+      pythonAst([{ path: 'default.py', content: `value = ${pythonLiteral(literalPayload)}` }])[0].constants,
+    ).toEqual([literalPayload]);
+  });
+
+  it('Python enum values and member docs remain literals', () => {
+    const enums = enumSpec(literalPayload, docPayload);
+    const constants = pythonAst(pythonEnums(enums, context({ enums }))).flatMap((file) => file.constants);
+    expect(constants.filter((value: string) => value === literalPayload).length).toBeGreaterThanOrEqual(2);
+    expect(constants).toContain(docPayload);
+  });
+
+  it('Python operation and parameter docs cannot close sync or async docstrings', () => {
+    const models = [model('value')];
+    const services = [service(docPayload)];
+    const docs = pythonAst(pythonResources(services, context({ models, services })))
+      .flatMap((file) => file.docs)
+      .filter(Boolean);
+    expect(docs.filter((doc: string) => doc.includes('_injected = True')).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('Python dispatcher and inline-union keys cannot inject expressions, including f-string braces', () => {
+    const key = 'kind"\\\n{_injected}';
+    const mapping = { [literalPayload]: 'Variant' };
+    const models: Model[] = [
+      { name: 'Variant', fields: [] },
+      { name: 'Dispatch', fields: [], description: docPayload, discriminator: { property: key, mapping } } as Model,
+      {
+        name: 'Container',
+        fields: [
+          {
+            name: literalPayload,
+            domainName: 'variant',
+            required: true,
+            type: {
+              kind: 'union',
+              variants: [{ kind: 'model', name: 'Variant' }],
+              discriminator: { property: key, mapping },
+            },
+          },
+        ],
+      },
+    ];
+    const constants = pythonAst(pythonModels(models, context({ models }))).flatMap((file) => file.constants);
+    expect(constants).toContain(key);
+    expect(constants).toContain(literalPayload);
+    expect(constants.some((value: string) => value.includes("Unknown discriminator '" + key))).toBe(true);
+    delete models[1].description;
+    pythonAst(pythonModels(models, context({ models })));
+  });
+
+  it('Node enum values and literal types preserve quotes, slashes, controls, and Unicode separators', () => {
+    const value = "x', injected: (globalThis._injected = true), y: 'z\\\n\r\t\0\u2028\u2029";
+    const enums = enumSpec(value, blockPayload);
+    const source = text(nodeEnums(enums, context({ enums })));
+    const exported = evaluateTypeScript(source);
+    expect(Object.values(exported.Status as object)).toContain(value);
+    for (const render of [nodeType, nodeWireType]) {
+      evaluateTypeScript(`export type Value = ${render({ kind: 'literal', value })};`);
+    }
+  });
+
+  it('Node and PHP block comments neutralize every closing delimiter', () => {
+    for (const render of [docComment, phpDocComment]) {
+      for (const payload of [blockPayload, `${blockPayload}\n${blockPayload}`]) {
+        const output = render(payload).join('\n');
+        expect(output.match(/\*\//g)).toHaveLength(1);
+        expect(output).toContain('*\u200b/');
+      }
+    }
+    const models = [model('value', blockPayload)];
+    const services = [service(blockPayload)];
+    const files = nodeModels(models, context({ models, services })).filter((file) =>
+      file.path.endsWith('.interface.ts'),
+    );
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      evaluateTypeScript(file.content);
+    }
+    const resources = text(nodeResources(services, context({ models, services })));
+    expect(resources).toContain('*\u200b/');
+    expect(resources).not.toContain(blockPayload);
+  });
+
+  it('Node discriminator metadata cannot escape interfaces or serializer expressions', () => {
+    const key = "kind'\\\n${globalThis._injected = true}";
+    const value = "value'\\\n";
+    const files = generateDiscriminatedFiles(
+      new Map([
+        [
+          'Thing',
+          {
+            modelDir: 'things',
+            depDirMap: new Map(),
+            shape: {
+              modelName: 'Thing',
+              baseFields: [],
+              discriminatorProperty: key,
+              discriminatorPropertyDomain: 'kind',
+              discriminatorDescription: blockPayload,
+              variants: [{ nameSuffix: 'Variant', discriminatorValue: value, fields: [] }],
+            },
+          },
+        ],
+      ]),
+      context(),
+    );
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      // Type-only imports disappear during stripping; the functions remain inert
+      // until explicitly called and must parse without evaluating metadata.
+      evaluateTypeScript(file.content);
+      expect(file.content).not.toContain(blockPayload);
+    }
+  });
+  it('Node extends baseline unions without reinterpreting escaped wire values', () => {
+    const enums = enumSpec("new'\\value");
+    const baseline = "'active' | 'a\\'b' | 'path\\\\name' | CustomStatus";
+    const ctx = context({ enums });
+    ctx.apiSurface = {
+      classes: {},
+      interfaces: {},
+      enums: {},
+      exports: {},
+      typeAliases: { Status: { value: baseline, sourceFile: 'src/common/interfaces/status.interface.ts' } },
+    } as unknown as EmitterContext['apiSurface'];
+    const source = text(nodeEnums(enums, ctx));
+    expect(source).toContain(baseline + ' | ');
+    evaluateTypeScript(source);
+  });
+
+  it('Go enum descriptions keep every line commented and enum values quoted', () => {
+    const value = 'x"\\\n';
+    const enums = enumSpec(value, 'description\n)\nfunc init() { panic("injected") }\n/*');
+    const source = text(goEnums(enums, context({ enums })));
+    expect(source).toContain(' = ' + JSON.stringify(value));
+    expect(source).not.toMatch(/^func init/m);
+    expect(source).toContain('// func init()');
+    if (spawnSync('gofmt', ['-h'], { timeout: 5000 }).error) return;
+    const parsed = spawnSync('gofmt', [], {
+      input: source,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH },
+      timeout: 10000,
+    });
+    expect(parsed.stderr).toBe('');
+    expect(parsed.status).toBe(0);
+  });
+
+  it('PHP enum and model values stay inside single-quoted strings', () => {
+    const value = "x';} $GLOBALS['_injected'] = true; //\\\n${still_data}";
+    const enums = enumSpec(value, blockPayload);
+    const models = [model(value, blockPayload)];
+    const generated = [...phpEnums(enums, context({ enums })), ...phpModels(models, context({ models }))];
+    for (const file of generated) {
+      expect(file.content).not.toContain("'x';}");
+    }
+    expect(text(generated)).toContain("'x\\';}");
+    if (spawnSync('php', ['--version'], { timeout: 5000 }).status !== 0) return;
+    const result = spawnSync('php', ['-n'], {
+      input: `<?php\n${generated.map((file) => file.content).join('\n')}\necho json_encode([Status::Evil->value, isset($GLOBALS['_injected'])]);`,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH },
+      timeout: 10000,
+    });
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([value, false]);
+  });
+
+  it('Go models and request structs escape both layers of tags', () => {
+    const key = 'wire`"\\\n}\nfunc init() { panic("injected") }\n//';
+    const models = [model(key, 'A thing.')];
+    const services = [service()];
+    const ctx = context({ models, services });
+    const source = text(goModels(models, ctx));
+    expect(source).toContain(goStructTag({ json: key }));
+    expect(text(goResources(services, ctx))).toContain(goStructTag({ json: key, url: '-' }));
+    expect(goStructTag({ json: 'id,omitempty' })).toBe('`json:"id,omitempty"`');
+    if (spawnSync('gofmt', ['-h'], { timeout: 5000 }).error) return;
+    const parsed = spawnSync('gofmt', [], {
+      input: source,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH },
+      timeout: 10000,
+    });
+    expect(parsed.stderr).toBe('');
+    expect(parsed.status).toBe(0);
+  });
+
+  it('Go tag values round-trip through reflect, including literal backticks', () => {
+    if (spawnSync('go', ['version'], { timeout: 5000 }).status !== 0) return;
+    const key = 'wire`"\\\n\t';
+    const dir = mkdtempSync(join(tmpdir(), 'oagen-tags-'));
+    try {
+      const file = join(dir, 'main.go');
+      writeFileSync(
+        file,
+        `package main\nimport ("reflect"; "encoding/json"; "os")\nfunc main() {\n type Value struct { Field string ${goStructTag({ json: key })} }\n json.NewEncoder(os.Stdout).Encode(reflect.TypeOf(Value{}).Field(0).Tag.Get("json"))\n}\n`,
+      );
+      const result = spawnSync('go', ['run', '-p=2', file], {
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH, HOME: process.env.HOME, GOCACHE: join(tmpdir(), 'oagen-go-test-cache') },
+        timeout: 60000,
+      });
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toBe(key);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 65000);
+
+  it('.NET enum attributes, wire names, and XML docs escape all lexical newlines', () => {
+    const value = 'x")]\r\n\u0085\u2028\u2029\\\0';
+    const enums = enumSpec(value, 'docs\n_injected = true;\r\u0085\u2028\u2029<&>');
+    const models: Model[] = [
+      { name: 'Thing', fields: [{ name: 'status', required: true, type: { kind: 'enum', name: 'Status' } }] },
+    ];
+    const content = text(dotnetEnums(enums, context({ enums, models })));
+    const literal = '"x\\\")]\\r\\n\\u0085\\u2028\\u2029\\\\\\u0000"';
+    expect(csLiteral(value)).toBe(literal);
+    expect(escapeCsAttributeString(value)).toBe(literal.slice(1, -1));
+    expect(content).toContain(`[EnumMember(Value = ${literal})]`);
+    expect(content).not.toMatch(/^_injected/m);
+    expect(escapeXml('\r\n\u0085\u2028\u2029')).toBe('&#13;&#10;&#133;&#8232;&#8233;');
+    for (const isRequiredEnum of [false, true]) {
+      const attributes = emitJsonPropertyAttributes(value, { explicitWireName: true, isRequiredEnum }).join('\n');
+      expect(attributes).toContain(`[STJS.JsonPropertyName(${literal})]`);
+      expect(attributes).toContain(`[JsonProperty(${literal}`);
+    }
+  });
+});

--- a/test/spec-metadata-escaping.test.ts
+++ b/test/spec-metadata-escaping.test.ts
@@ -23,6 +23,7 @@ import { generateEnums as phpEnums } from '../src/php/enums.js';
 import { generateModels as phpModels } from '../src/php/models.js';
 import { phpDocComment } from '../src/php/utils.js';
 import { generateModels as goModels } from '../src/go/models.js';
+import { generateWrapperMethods as goWrappers } from '../src/go/wrappers.js';
 import { generateResources as goResources } from '../src/go/resources.js';
 import { goStructTag } from '../src/go/strings.js';
 import { generateEnums as dotnetEnums } from '../src/dotnet/enums.js';
@@ -326,6 +327,40 @@ describe('VULN-2366: spec metadata remains data', () => {
     expect(parsed.status).toBe(0);
   });
 
+  it('Go wrapper defaults, exposed params, and inferred fields cannot break out of tags', () => {
+    const keys = ['default', 'required', 'optional', 'inferred'].map(
+      (prefix) => `${prefix}\`"\\\n}\nfunc init() { panic("injected") }\n//`,
+    );
+    const svc = service();
+    const resolved = {
+      operation: svc.operations[0],
+      service: svc,
+      wrappers: [
+        {
+          name: 'create_thing',
+          targetVariant: 'Thing',
+          defaults: { [keys[0]]: 'value' },
+          exposedParams: [keys[1], keys[2]],
+          optionalParams: [keys[2]],
+          inferFromClient: [keys[3]],
+        },
+      ],
+    } as unknown as Parameters<typeof goWrappers>[2];
+    const source = 'package workos\n' + goWrappers('ThingsService', 'Things', resolved, context()).join('\n');
+    expect(source).toContain(goStructTag({ json: keys[0] }));
+    expect(source.split(goStructTag({ json: keys[1] }))).toHaveLength(3);
+    expect(source.split(goStructTag({ json: keys[2] + ',omitempty' }))).toHaveLength(3);
+    expect(source).toContain(goStructTag({ json: keys[3] + ',omitempty' }));
+    if (spawnSync('gofmt', ['-h'], { timeout: 5000 }).error) return;
+    const parsed = spawnSync('gofmt', [], {
+      input: source,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH },
+      timeout: 10000,
+    });
+    expect(parsed.stderr).toBe('');
+    expect(parsed.status).toBe(0);
+  });
   it('Go tag values round-trip through reflect, including literal backticks', () => {
     if (spawnSync('go', ['version'], { timeout: 5000 }).status !== 0) return;
     const key = 'wire`"\\\n\t';


### PR DESCRIPTION
OpenAPI descriptions and wire values could terminate generated comments, docstrings, and string literals, allowing spec metadata to become executable SDK code before generated output was reviewed.

- Escape Python docstrings, enum and literal values, wire keys, and discriminator metadata throughout models, resources, and wrappers.
- Neutralize Node/PHP comment terminators and escape their enum, default, and discriminator values. Preserve existing Node union source when adding escaped values.
- Escape both layers of Go JSON/URL struct tags in models, resources, and wrappers, plus enum comments and metadata literals. Reuse C# literal escaping for enum/serialization attributes and discriminator converters, including control characters and Unicode line separators.
- Add 14 regressions covering harmless breakout payloads, native Python parsing, Node/PHP execution, and Go parsing and reflection round trips.

Validation: all 924 tests pass; typecheck, lint, formatting, Markdown formatting, and build pass. C# escaping is covered by generated-source assertions; native C# compilation was unavailable locally because no .NET SDK is installed.

Fixes [VULN-2366](https://linear.app/workos/issue/VULN-2366).
